### PR TITLE
Move question source to own table

### DIFF
--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -9,9 +9,27 @@ class Question extends Model
     protected $casts = [
         'flag' => 'boolean',
     ];
-    protected $fillable = ['question', 'difficulty', 'category_id','source'];
-    public function category() { return $this->belongsTo(Category::class); }
-    public function options() { return $this->hasMany(QuestionOption::class); }
-    public function answers() { return $this->hasMany(QuestionAnswer::class); }
+
+    protected $fillable = ['question', 'difficulty', 'category_id', 'source_id'];
+
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    public function source()
+    {
+        return $this->belongsTo(Source::class);
+    }
+
+    public function options()
+    {
+        return $this->hasMany(QuestionOption::class);
+    }
+
+    public function answers()
+    {
+        return $this->hasMany(QuestionAnswer::class);
+    }
 }
 

--- a/app/Models/Source.php
+++ b/app/Models/Source.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Source extends Model
+{
+    protected $fillable = ['name'];
+    public function questions()
+    {
+        return $this->hasMany(Question::class);
+    }
+}

--- a/database/migrations/2025_07_26_000001_create_sources_table.php
+++ b/database/migrations/2025_07_26_000001_create_sources_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sources', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+
+        Schema::table('questions', function (Blueprint $table) {
+            $table->foreignId('source_id')->nullable()->after('flag')->constrained('sources')->nullOnDelete();
+            $table->dropColumn('source');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->string('source')->nullable()->after('flag');
+            $table->dropConstrainedForeignId('source_id');
+        });
+
+        Schema::dropIfExists('sources');
+    }
+};

--- a/database/seeders/DoDoesIsAreSeeder.php
+++ b/database/seeders/DoDoesIsAreSeeder.php
@@ -6,12 +6,14 @@ use Illuminate\Database\Seeder;
 use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
+use App\Models\Source;
 
 class DoDoesIsAreSeeder extends Seeder
 {
     public function run()
     {
         $cat_present = 2; // Present Simple (заміни під свою структуру)
+        $sourceId = Source::firstOrCreate(['name' => 'Do Does Am Is Are'])->id;
         $options = ['do', 'does', 'am', 'is', 'are'];
         $questions = [
             ['What {a1} you like to eat for breakfast?',         'do'],
@@ -46,7 +48,7 @@ class DoDoesIsAreSeeder extends Seeder
                 'difficulty'  => 1,
                 'category_id' => $cat_present,
                 'flag'        => 0,
-                'source'      => 'Do Does Am Is Are',
+                'source_id'   => $sourceId,
             ]);
             QuestionAnswer::create([
                 'question_id' => $q->id,

--- a/database/seeders/FutureSimpleTest1Seeder.php
+++ b/database/seeders/FutureSimpleTest1Seeder.php
@@ -7,6 +7,7 @@ use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
 use App\Models\Category;
+use App\Models\Source;
 
 class FutureSimpleTest1Seeder extends Seeder
 {
@@ -19,7 +20,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => '{a1} a good plan?',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "Won't it be", 'verb_hint' => 'be'],
@@ -34,7 +35,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'Think what it {a1} to him.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will mean', 'verb_hint' => 'mean'],
@@ -49,7 +50,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'I {a1} to you again in the morning.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will speak', 'verb_hint' => 'speak'],
@@ -64,7 +65,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'I think you {a1} a child again.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will turn', 'verb_hint' => 'turn'],
@@ -79,7 +80,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'But I {a1} even with him.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will be', 'verb_hint' => 'be'],
@@ -94,7 +95,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'They {a1} to one another.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "won't listen", 'verb_hint' => 'listen'],
@@ -109,7 +110,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'I {a1}, if I live.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "won't fail", 'verb_hint' => 'fail'],
@@ -124,7 +125,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => '{a1} for them again?',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "Will they go and look", 'verb_hint' => 'go, look'],
@@ -139,7 +140,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'I {a1} this kind of letter.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "won't answer", 'verb_hint' => 'answer'],
@@ -154,7 +155,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'I {a1} her in other ways.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will help', 'verb_hint' => 'help'],
@@ -169,7 +170,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'Now we {a1} who he is.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will see', 'verb_hint' => 'see'],
@@ -184,7 +185,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'They {a1} you, but they know.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "won't tell", 'verb_hint' => 'tell'],
@@ -199,7 +200,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'But he {a1} my opinion first.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "won't ask", 'verb_hint' => 'ask'],
@@ -214,7 +215,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'I {a1} you some of mine.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will tell', 'verb_hint' => 'tell'],
@@ -229,7 +230,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'Now {a1} me that number?',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'Will you give', 'verb_hint' => 'give'],
@@ -244,7 +245,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'But I {a1} for that next time.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will come', 'verb_hint' => 'come'],
@@ -259,7 +260,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => '{a1} me have a line?',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'Will you let', 'verb_hint' => 'let'],
@@ -274,7 +275,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'He {a1} that he has lost a wife.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "won't know", 'verb_hint' => 'know'],
@@ -289,7 +290,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => '{a1} of us?',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "What will those people think", 'verb_hint' => 'think'],
@@ -304,7 +305,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question' => 'You {a1} it go far!',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => 'Future Simple - Test 1',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "won't find", 'verb_hint' => 'find'],
@@ -322,7 +323,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $d['category_id'],
                 'difficulty'  => $d['difficulty'],
-                'source'      => $d['source'],
+                'source_id'   => $d['source_id'],
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {

--- a/database/seeders/GrammarQuizPastSimpleSeeder.php
+++ b/database/seeders/GrammarQuizPastSimpleSeeder.php
@@ -7,19 +7,21 @@ use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
 use App\Models\Category;
+use App\Models\Source;
 
 class GrammarQuizPastSimpleSeeder extends Seeder
 {
     public function run()
     {
         $cat_past = Category::firstOrCreate(['name' => 'past'])->id;
+        $sourceId = Source::firstOrCreate(['name' => 'Grammar Quiz: Past Simple'])->id;
 
         $data = [
             [
                 'question' => 'My family and I {a1} in London when I was young.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'lived', 'verb_hint' => 'live'],
@@ -30,7 +32,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'We {a1} some sandwiches and fresh fruit to eat for lunch.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'bought', 'verb_hint' => 'buy'],
@@ -41,7 +43,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'They wanted to {a1} a movie but there were no more tickets.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'see', 'verb_hint' => 'see'],
@@ -52,7 +54,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'Did you have a good time? — Yes, I {a1}.',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'had', 'verb_hint' => 'have'],
@@ -63,7 +65,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'He didn’t {a1} me because I was behind the tree.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'see', 'verb_hint' => 'see'],
@@ -74,7 +76,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => '{a1} you a good student in school? — Yes, I was.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'Were', 'verb_hint' => 'be'],
@@ -85,7 +87,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'When did they {a1} back to their country?',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'fly', 'verb_hint' => 'fly'],
@@ -96,7 +98,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'They {a1} back to their country after a few weeks.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'flew', 'verb_hint' => 'fly'],
@@ -107,7 +109,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'Did you {a1} lots of interesting photos on your holiday?',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'take', 'verb_hint' => 'take'],
@@ -118,7 +120,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'We had a great time and we {a1} lots of fun and exciting things.',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'did', 'verb_hint' => 'do'],
@@ -129,7 +131,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'Why {a1} you finish your math homework last week?',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => "didn't", 'verb_hint' => 'do'],
@@ -140,7 +142,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'He {a1} see a dentist yesterday because he had a toothache.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'had to', 'verb_hint' => 'have to'],
@@ -151,7 +153,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'I wanted to {a1}, but I couldn’t. I had to stay and help my friend.',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'go', 'verb_hint' => 'go'],
@@ -162,7 +164,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => '{a1} they late or on time yesterday afternoon?',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'Were', 'verb_hint' => 'be'],
@@ -173,7 +175,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => 'She didn’t answer the phone because she {a1} at home.',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'wasn\'t', 'verb_hint' => 'be'],
@@ -184,7 +186,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question' => '{a1} they tired after the long trip? — Yes, they {a2}.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Grammar Quiz: Past Simple',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'Were', 'verb_hint' => 'be'],
@@ -199,7 +201,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $d['category_id'],
                 'difficulty'  => $d['difficulty'],
-                'source'      => $d['source'],
+                'source_id'   => $d['source_id'],
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {

--- a/database/seeders/GrammarTestAISeeder.php
+++ b/database/seeders/GrammarTestAISeeder.php
@@ -7,6 +7,7 @@ use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
 use App\Models\Category;
+use App\Models\Source;
 
 class GrammarTestAISeeder extends Seeder
 {
@@ -26,125 +27,140 @@ class GrammarTestAISeeder extends Seeder
             Category::firstOrCreate(['id' => $id], ['name' => $name]);
         }
 
+        $sourceNames = [
+            'AI: Present Simple',
+            'AI: Past Simple',
+            'AI: Present Continuous',
+            'AI: Present Perfect',
+            'AI: Future Simple',
+            'AI: First Conditional',
+            'AI: Mixed Tenses',
+            'AI: Conditionals Advanced',
+        ];
+        $sourceIds = [];
+        foreach ($sourceNames as $name) {
+            $sourceIds[$name] = Source::firstOrCreate(['name' => $name])->id;
+        }
+
         $aiQuestions = [
             // Складність 1–5
             [
                 'question' => 'He {a1} to school every day.',
-                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source' => 'AI: Present Simple',
+                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'goes', 'verb_hint' => 'go']],
                 'options' => ['go', 'goes', 'going', 'gone', 'went'],
             ],
             [
                 'question' => 'They {a1} football on Sundays.',
-                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source' => 'AI: Present Simple',
+                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'play', 'verb_hint' => 'play']],
                 'options' => ['play', 'plays', 'played', 'playing', 'have played'],
             ],
             [
                 'question' => 'We {a1} our homework yesterday.',
-                'difficulty' => 2, 'category_id' => 1, 'flag' => 1, 'source' => 'AI: Past Simple',
+                'difficulty' => 2, 'category_id' => 1, 'flag' => 1, 'source_id' => $sourceIds['AI: Past Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'did', 'verb_hint' => 'do']],
                 'options' => ['did', 'do', 'does', 'doing', 'done'],
             ],
             [
                 'question' => 'She {a1} a letter right now.',
-                'difficulty' => 2, 'category_id' => 3, 'flag' => 1, 'source' => 'AI: Present Continuous',
+                'difficulty' => 2, 'category_id' => 3, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Continuous'],
                 'answers' => [['marker' => 'a1', 'answer' => 'is writing', 'verb_hint' => 'write']],
                 'options' => ['writes', 'is writing', 'write', 'wrote', 'writing'],
             ],
             [
                 'question' => 'I {a1} a sandwich at the moment.',
-                'difficulty' => 3, 'category_id' => 3, 'flag' => 1, 'source' => 'AI: Present Continuous',
+                'difficulty' => 3, 'category_id' => 3, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Continuous'],
                 'answers' => [['marker' => 'a1', 'answer' => 'am eating', 'verb_hint' => 'eat']],
                 'options' => ['eat', 'eats', 'am eating', 'ate', 'eaten'],
             ],
             [
                 'question' => 'They {a1} to Paris last year.',
-                'difficulty' => 3, 'category_id' => 1, 'flag' => 1, 'source' => 'AI: Past Simple',
+                'difficulty' => 3, 'category_id' => 1, 'flag' => 1, 'source_id' => $sourceIds['AI: Past Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'went', 'verb_hint' => 'go']],
                 'options' => ['go', 'goes', 'going', 'gone', 'went'],
             ],
             [
                 'question' => 'He {a1} breakfast before school.',
-                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source' => 'AI: Present Simple',
+                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'has', 'verb_hint' => 'have']],
                 'options' => ['has', 'have', 'had', 'having', 'will have'],
             ],
             [
                 'question' => 'We {a1} in London for five years.',
-                'difficulty' => 4, 'category_id' => 5, 'flag' => 1, 'source' => 'AI: Present Perfect',
+                'difficulty' => 4, 'category_id' => 5, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Perfect'],
                 'answers' => [['marker' => 'a1', 'answer' => 'have lived', 'verb_hint' => 'live']],
                 'options' => ['live', 'lived', 'have lived', 'are living', 'has lived'],
             ],
             [
                 'question' => 'She {a1} her keys yesterday.',
-                'difficulty' => 2, 'category_id' => 1, 'flag' => 1, 'source' => 'AI: Past Simple',
+                'difficulty' => 2, 'category_id' => 1, 'flag' => 1, 'source_id' => $sourceIds['AI: Past Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'lost', 'verb_hint' => 'lose']],
                 'options' => ['lose', 'loses', 'losing', 'lost', 'has lost'],
             ],
             [
                 'question' => 'You {a1} tired today.',
-                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source' => 'AI: Present Simple',
+                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'look', 'verb_hint' => 'look']],
                 'options' => ['look', 'looks', 'looked', 'looking', 'has looked'],
             ],
             [
                 'question' => 'My mother {a1} very well.',
-                'difficulty' => 2, 'category_id' => 2, 'flag' => 1, 'source' => 'AI: Present Simple',
+                'difficulty' => 2, 'category_id' => 2, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'cooks', 'verb_hint' => 'cook']],
                 'options' => ['cook', 'cooks', 'cooked', 'cooking', 'has cooked'],
             ],
             [
                 'question' => 'They {a1} their friends every weekend.',
-                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source' => 'AI: Present Simple',
+                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'meet', 'verb_hint' => 'meet']],
                 'options' => ['meet', 'meets', 'met', 'meeting', 'has met'],
             ],
             [
                 'question' => 'My brother {a1} to music now.',
-                'difficulty' => 2, 'category_id' => 3, 'flag' => 1, 'source' => 'AI: Present Continuous',
+                'difficulty' => 2, 'category_id' => 3, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Continuous'],
                 'answers' => [['marker' => 'a1', 'answer' => 'is listening', 'verb_hint' => 'listen']],
                 'options' => ['listen', 'listens', 'listened', 'is listening', 'has listened'],
             ],
             [
                 'question' => 'We {a1} pizza for dinner yesterday.',
-                'difficulty' => 3, 'category_id' => 1, 'flag' => 1, 'source' => 'AI: Past Simple',
+                'difficulty' => 3, 'category_id' => 1, 'flag' => 1, 'source_id' => $sourceIds['AI: Past Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'ate', 'verb_hint' => 'eat']],
                 'options' => ['eat', 'eats', 'eating', 'ate', 'eaten'],
             ],
             [
                 'question' => 'She {a1} her homework every day.',
-                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source' => 'AI: Present Simple',
+                'difficulty' => 1, 'category_id' => 2, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'does', 'verb_hint' => 'do']],
                 'options' => ['do', 'does', 'doing', 'did', 'done'],
             ],
             [
                 'question' => 'He {a1} a new car last month.',
-                'difficulty' => 2, 'category_id' => 1, 'flag' => 1, 'source' => 'AI: Past Simple',
+                'difficulty' => 2, 'category_id' => 1, 'flag' => 1, 'source_id' => $sourceIds['AI: Past Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'bought', 'verb_hint' => 'buy']],
                 'options' => ['buy', 'buys', 'buying', 'bought', 'has bought'],
             ],
             [
                 'question' => 'She {a1} an interesting book these days.',
-                'difficulty' => 3, 'category_id' => 3, 'flag' => 1, 'source' => 'AI: Present Continuous',
+                'difficulty' => 3, 'category_id' => 3, 'flag' => 1, 'source_id' => $sourceIds['AI: Present Continuous'],
                 'answers' => [['marker' => 'a1', 'answer' => 'is reading', 'verb_hint' => 'read']],
                 'options' => ['reads', 'is reading', 'read', 'has read', 'reading'],
             ],
             [
                 'question' => 'I {a1} to the cinema last night.',
-                'difficulty' => 2, 'category_id' => 1, 'flag' => 1, 'source' => 'AI: Past Simple',
+                'difficulty' => 2, 'category_id' => 1, 'flag' => 1, 'source_id' => $sourceIds['AI: Past Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'went', 'verb_hint' => 'go']],
                 'options' => ['go', 'goes', 'going', 'gone', 'went'],
             ],
             [
                 'question' => 'My friends {a1} to visit us next week.',
-                'difficulty' => 3, 'category_id' => 4, 'flag' => 1, 'source' => 'AI: Future Simple',
+                'difficulty' => 3, 'category_id' => 4, 'flag' => 1, 'source_id' => $sourceIds['AI: Future Simple'],
                 'answers' => [['marker' => 'a1', 'answer' => 'will come', 'verb_hint' => 'come']],
                 'options' => ['come', 'comes', 'coming', 'will come', 'came'],
             ],
             [
                 'question' => 'She {a1} happy if she passes the exam.',
-                'difficulty' => 4, 'category_id' => 6, 'flag' => 1, 'source' => 'AI: First Conditional',
+                'difficulty' => 4, 'category_id' => 6, 'flag' => 1, 'source_id' => $sourceIds['AI: First Conditional'],
                 'answers' => [['marker' => 'a1', 'answer' => 'will be', 'verb_hint' => 'be']],
                 'options' => ['is', 'was', 'be', 'will be', 'being'],
             ],
@@ -169,7 +185,7 @@ class GrammarTestAISeeder extends Seeder
                 'difficulty' => $diff,
                 'category_id' => $cat,
                 'flag' => 1,
-                'source' => 'AI: Mixed Tenses',
+                'source_id' => $sourceIds['AI: Mixed Tenses'],
                 'answers' => [
                     ['marker' => 'a1', 'answer' => $v[1], 'verb_hint' => $v[0]],
                     ['marker' => 'a2', 'answer' => $v[3], 'verb_hint' => $v[0]],
@@ -184,7 +200,7 @@ class GrammarTestAISeeder extends Seeder
                 'difficulty' => 10,
                 'category_id' => 6,
                 'flag' => 1,
-                'source' => 'AI: Conditionals Advanced',
+                'source_id' => $sourceIds['AI: Conditionals Advanced'],
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'had', 'verb_hint' => 'have'],
                     ['marker' => 'a2', 'answer' => 'would finish', 'verb_hint' => 'finish'],
@@ -199,7 +215,7 @@ class GrammarTestAISeeder extends Seeder
                 'difficulty'  => $data['difficulty'],
                 'category_id' => $data['category_id'],
                 'flag'        => 1,
-                'source'      => $data['source'],
+                'source_id'   => $data['source_id'],
             ]);
             foreach ($data['answers'] as $ans) {
                 QuestionAnswer::create([

--- a/database/seeders/PastSimpleRegularSeeder.php
+++ b/database/seeders/PastSimpleRegularSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Seeder;
 use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
+use App\Models\Source;
 
 class PastSimpleRegularSeeder extends Seeder
 {
@@ -13,6 +14,7 @@ class PastSimpleRegularSeeder extends Seeder
     {
         // Категорія Past Simple (1)
         $cat_past = 1;
+        $sourceId = Source::firstOrCreate(['name' => 'Past Simple Regular Verbs'])->id;
 
         $questions = [
             [
@@ -163,7 +165,7 @@ class PastSimpleRegularSeeder extends Seeder
                 'difficulty'  => 2,
                 'category_id' => $cat_past,
                 'flag'        => 0,
-                'source'      => 'Past Simple Regular Verbs',
+                'source_id'   => $sourceId,
             ]);
             foreach ($data['answers'] as $ans) {
                 QuestionAnswer::create([

--- a/database/seeders/PastSimpleRegularVerbsFullSeeder.php
+++ b/database/seeders/PastSimpleRegularVerbsFullSeeder.php
@@ -6,12 +6,16 @@ use Illuminate\Database\Seeder;
 use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
+use App\Models\Source;
 
 class PastSimpleRegularVerbsFullSeeder extends Seeder
 {
     public function run()
     {
         $cat_past = 1;
+        $source1 = Source::firstOrCreate(['name' => 'Past Simple Regular Verbs - 1'])->id;
+        $source2 = Source::firstOrCreate(['name' => 'Past Simple Regular Verbs – Positive'])->id;
+        $source3 = Source::firstOrCreate(['name' => 'Past Simple Regular Verbs – Negative'])->id;
 
         // A) Write the past forms of the regular verbs below.
         $verbs = [
@@ -47,7 +51,7 @@ class PastSimpleRegularVerbsFullSeeder extends Seeder
                 'difficulty'  => 1,
                 'category_id' => $cat_past,
                 'flag'        => 0,
-                'source'      => 'Past Simple Regular Verbs - 1',
+                'source_id'   => $source1,
             ]);
             QuestionAnswer::create([
                 'question_id' => $q->id,
@@ -79,7 +83,7 @@ class PastSimpleRegularVerbsFullSeeder extends Seeder
                 'difficulty'  => 2,
                 'category_id' => $cat_past,
                 'flag'        => 1,
-                'source'      => 'Past Simple Regular Verbs – Positive',
+                'source_id'   => $source2,
             ]);
             QuestionAnswer::create([
                 'question_id' => $q->id,
@@ -106,7 +110,7 @@ class PastSimpleRegularVerbsFullSeeder extends Seeder
                 'difficulty'  => 2,
                 'category_id' => $cat_past,
                 'flag'        => 1,
-                'source'      => 'Past Simple Regular Verbs – Negative',
+                'source_id'   => $source3,
             ]);
             QuestionAnswer::create([
                 'question_id' => $q->id,

--- a/database/seeders/PresentPastRevisionSeeder.php
+++ b/database/seeders/PresentPastRevisionSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Seeder;
 use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
+use App\Models\Source;
 
 class PresentPastRevisionSeeder extends Seeder
 {
@@ -14,6 +15,7 @@ class PresentPastRevisionSeeder extends Seeder
         // Категорії: 1 — Past Simple, 2 — Present Simple
         $cat_past = 1;
         $cat_present = 2;
+        $sourceId = Source::firstOrCreate(['name' => 'Revision: Present or Past Simple'])->id;
 
         // 1. Underline the correct form (варіанти відповіді — зображено у формі select)
         $questions = [
@@ -22,63 +24,63 @@ class PresentPastRevisionSeeder extends Seeder
                 'category_id' => $cat_past,
                 'answers' => [['marker'=>'a1','answer'=>'helped','verb_hint'=>'help']],
                 'options' => ['helps', 'helped'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Ben {a1} hockey every day.',
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'plays','verb_hint'=>'play']],
                 'options' => ['plays', 'played'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'I {a1} TV yesterday.',
                 'category_id' => $cat_past,
                 'answers' => [['marker'=>'a1','answer'=>'watched','verb_hint'=>'watch']],
                 'options' => ['watch', 'watched'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'They {a1} milk every day.',
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'drink','verb_hint'=>'drink']],
                 'options' => ['drink', 'drank'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'I always {a1} my room.',
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'clean','verb_hint'=>'clean']],
                 'options' => ['clean', 'cleaned'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Andrew {a1} apples and bananas one hour ago.',
                 'category_id' => $cat_past,
                 'answers' => [['marker'=>'a1','answer'=>'ate','verb_hint'=>'eat']],
                 'options' => ['eats', 'ate'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Kate often {a1} her little sister.',
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'helps','verb_hint'=>'help']],
                 'options' => ['helps', 'helped'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'John {a1} a new mobile phone yesterday.',
                 'category_id' => $cat_past,
                 'answers' => [['marker'=>'a1','answer'=>'bought','verb_hint'=>'buy']],
                 'options' => ['buys', 'bought'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'We {a1} to the cinema every weekend.',
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'go','verb_hint'=>'go']],
                 'options' => ['go', 'went'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
         ];
 
@@ -89,63 +91,63 @@ class PresentPastRevisionSeeder extends Seeder
                 'category_id' => $cat_past,
                 'answers' => [['marker'=>'a1','answer'=>'caught','verb_hint'=>'catch']],
                 'options' => ['catches', 'caught'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Nora often {a1} the violin.',
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'plays','verb_hint'=>'play']],
                 'options' => ['plays', 'played'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Sam {a1} an SMS every day.',
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'sends','verb_hint'=>'send']],
                 'options' => ['sends', 'sent'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Nick {a1} an English test yesterday.',
                 'category_id' => $cat_past,
                 'answers' => [['marker'=>'a1','answer'=>'wrote','verb_hint'=>'write']],
                 'options' => ['writes', 'wrote'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'They always {a1} apples.',
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'buy','verb_hint'=>'buy']],
                 'options' => ['buy', 'bought'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'The boys {a1} 2 km two days ago.',
                 'category_id' => $cat_past,
                 'answers' => [['marker'=>'a1','answer'=>'ran','verb_hint'=>'run']],
                 'options' => ['run', 'ran'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Mona {a1} tea every day.',
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'drinks','verb_hint'=>'drink']],
                 'options' => ['drinks', 'drank'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'We often {a1} Nick.',
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'help','verb_hint'=>'help']],
                 'options' => ['help', 'helped'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Pam {a1} to the classical music yesterday.',
                 'category_id' => $cat_past,
                 'answers' => [['marker'=>'a1','answer'=>'listened','verb_hint'=>'listen']],
                 'options' => ['listens', 'listened'],
-                'source' => 'Revision: Present or Past Simple',
+                'source_id' => $sourceId,
             ],
         ]);
 
@@ -159,14 +161,14 @@ class PresentPastRevisionSeeder extends Seeder
                 'category_id' => $cat_present,
                 'answers' => [['marker'=>'a1','answer'=>'does not skate','verb_hint'=>'skate / negative']],
                 'options' => ['does not skate', 'did not skate'],
-                'source' => 'Revision: Present or Past Simple (negative)',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Pam {a1} yesterday.',
                 'category_id' => $cat_past,
                 'answers' => [['marker'=>'a1','answer'=>'did not jog','verb_hint'=>'jog / negative']],
                 'options' => ['does not jog', 'did not jog'],
-                'source' => 'Revision: Present or Past Simple (negative)',
+                'source_id' => $sourceId,
             ],
             // ... додай інші негативні та питання, якщо потрібно
         ]);
@@ -178,7 +180,7 @@ class PresentPastRevisionSeeder extends Seeder
                 'difficulty'  => 2,
                 'category_id' => $data['category_id'],
                 'flag'        => 0,
-                'source'      => $data['source'],
+                'source_id'   => $sourceId,
             ]);
             foreach ($data['answers'] as $ans) {
                 QuestionAnswer::create([

--- a/database/seeders/PresentSimpleExercisesSeeder.php
+++ b/database/seeders/PresentSimpleExercisesSeeder.php
@@ -7,12 +7,19 @@ use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
 use App\Models\Category;
+use App\Models\Source;
 
 class PresentSimpleExercisesSeeder extends Seeder
 {
     public function run()
     {
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
+        $source1 = Source::firstOrCreate([
+            'name' => 'Present Simple Exercises: Put the verbs in the correct form of the simple present.'
+        ])->id;
+        $source2 = Source::firstOrCreate([
+            'name' => 'Present Simple Exercises: Match the verbs in the box with the sentences and rewrite them in the correct form.'
+        ])->id;
 
         // SECTION 1
         $section1 = [
@@ -177,7 +184,7 @@ class PresentSimpleExercisesSeeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $cat_present,
                 'difficulty'  => 2,
-                'source'      => 'Present Simple Exercises: Put the verbs in the correct form of the simple present.',
+                'source_id'   => $source1,
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
@@ -201,7 +208,7 @@ class PresentSimpleExercisesSeeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $cat_present,
                 'difficulty'  => 2,
-                'source'      => 'Present Simple Exercises: Match the verbs in the box with the sentences and rewrite them in the correct form.',
+                'source_id'   => $source2,
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {

--- a/database/seeders/PresentSimpleSeeder.php
+++ b/database/seeders/PresentSimpleSeeder.php
@@ -5,18 +5,22 @@ use Illuminate\Database\Seeder;
 use App\Models\Question;
 use App\Models\QuestionOption;
 use App\Models\QuestionAnswer;
+use App\Models\Source;
 
 class PresentSimpleSeeder extends Seeder
 {
     public function run()
     {
         $categoryId = 2; // ID категорії для Present Simple
+        $sourceId = Source::firstOrCreate([
+            'name' => 'Present simple. Complete the sentences with the correct variant.'
+        ])->id;
 
         $data = [
             [
                 'question' => 'Bob always {a1} tea in the morning.',
                 'difficulty' => 1,
-                'source' => 'Present simple. Complete the sentences with the correct variant.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     [
@@ -30,7 +34,7 @@ class PresentSimpleSeeder extends Seeder
             [
                 'question' => 'We {a1} to the music every day.',
                 'difficulty' => 1,
-                'source' => 'Present simple. Complete the sentences with the correct variant.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     [
@@ -44,7 +48,7 @@ class PresentSimpleSeeder extends Seeder
             [
                 'question' => 'Mary usually {a1} TV in the evening.',
                 'difficulty' => 2,
-                'source' => 'Present simple. Complete the sentences with the correct variant.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     [
@@ -58,7 +62,7 @@ class PresentSimpleSeeder extends Seeder
             [
                 'question' => 'The girls often {a1} with the dolls.',
                 'difficulty' => 2,
-                'source' => 'Present simple. Complete the sentences with the correct variant.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     [
@@ -72,7 +76,7 @@ class PresentSimpleSeeder extends Seeder
             [
                 'question' => 'They {a1} their homework every day.',
                 'difficulty' => 1,
-                'source' => 'Present simple. Complete the sentences with the correct variant.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     [
@@ -86,7 +90,7 @@ class PresentSimpleSeeder extends Seeder
             [
                 'question' => 'I {a1} watch TV after school.',
                 'difficulty' => 2,
-                'source' => 'Present simple. Complete the sentences with the correct variant.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     [
@@ -100,7 +104,7 @@ class PresentSimpleSeeder extends Seeder
             [
                 'question' => 'My sister {a1} play tennis.',
                 'difficulty' => 3,
-                'source' => 'Present simple. Complete the sentences with the correct variant.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     [
@@ -114,7 +118,7 @@ class PresentSimpleSeeder extends Seeder
             [
                 'question' => 'Marta {a1} her dad’s car.',
                 'difficulty' => 2,
-                'source' => 'Present simple. Complete the sentences with the correct variant.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     [
@@ -128,7 +132,7 @@ class PresentSimpleSeeder extends Seeder
             [
                 'question' => 'The baby {a1} every night.',
                 'difficulty' => 2,
-                'source' => 'Present simple. Complete the sentences with the correct variant.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     [
@@ -142,7 +146,7 @@ class PresentSimpleSeeder extends Seeder
             [
                 'question' => 'The birds {a1} in the sky.',
                 'difficulty' => 1,
-                'source' => 'Present simple. Complete the sentences with the correct variant.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     [
@@ -160,7 +164,7 @@ class PresentSimpleSeeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $categoryId,
                 'difficulty'  => $d['difficulty'],
-                'source'      => $d['source'],
+                'source_id'   => $d['source_id'],
                 'flag'        => $d['flag'],
             ]);
 

--- a/database/seeders/QuizPresentSimpleSeeder.php
+++ b/database/seeders/QuizPresentSimpleSeeder.php
@@ -5,6 +5,7 @@ use Illuminate\Database\Seeder;
 use App\Models\Question;
 use App\Models\QuestionOption;
 use App\Models\QuestionAnswer;
+use App\Models\Source;
 
 class QuizPresentSimpleSeeder extends Seeder
 {
@@ -12,12 +13,13 @@ class QuizPresentSimpleSeeder extends Seeder
     {
         $categoryId = 2; // Present Simple
         $source = 'Quiz – present simple. Вибери правильний варіант.';
+        $sourceId = Source::firstOrCreate(['name' => $source])->id;
 
         $data = [
             [
                 'question' => 'Ann usually {a1} shopping on Friday.',
                 'difficulty' => 2,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'goes', 'verb_hint' => 'go'],
@@ -27,7 +29,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Tom always {a1} after school.',
                 'difficulty' => 1,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'plays', 'verb_hint' => 'play'],
@@ -37,7 +39,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'This girl sometimes {a1} her homework.',
                 'difficulty' => 3,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'doesn’t do', 'verb_hint' => 'do'],
@@ -47,7 +49,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Lisa and Mike {a1} to the same school.',
                 'difficulty' => 2,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'go', 'verb_hint' => 'go'],
@@ -57,7 +59,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Mary is a singer. She can {a1} beautiful songs.',
                 'difficulty' => 2,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'sing', 'verb_hint' => 'sing'],
@@ -67,7 +69,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Tom {a1} one book a week.',
                 'difficulty' => 1,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'reads', 'verb_hint' => 'read'],
@@ -77,7 +79,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'My rabbit always {a1} very fast.',
                 'difficulty' => 2,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'eats', 'verb_hint' => 'eat'],
@@ -87,7 +89,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'These girls can {a1} very well. They are dancers.',
                 'difficulty' => 2,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'dance', 'verb_hint' => 'dance'],
@@ -97,7 +99,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Martha {a1} four glasses of water a day.',
                 'difficulty' => 1,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'drinks', 'verb_hint' => 'drink'],
@@ -107,7 +109,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Tom and his friends sometimes {a1} football.',
                 'difficulty' => 1,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'play', 'verb_hint' => 'play'],
@@ -117,7 +119,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Ellie {a1} one letter a week to her granny.',
                 'difficulty' => 2,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'writes', 'verb_hint' => 'write'],
@@ -127,7 +129,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Peter {a1} to listen to music.',
                 'difficulty' => 1,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'likes', 'verb_hint' => 'like'],
@@ -137,7 +139,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Paul and his friend {a1} English everyday.',
                 'difficulty' => 2,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'learn', 'verb_hint' => 'learn'],
@@ -147,7 +149,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Jessika {a1} her new bike twice a week.',
                 'difficulty' => 1,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'rides', 'verb_hint' => 'ride'],
@@ -157,7 +159,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Michael {a1} got a blue parrot.',
                 'difficulty' => 2,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'has', 'verb_hint' => 'have'],
@@ -167,7 +169,7 @@ class QuizPresentSimpleSeeder extends Seeder
             [
                 'question' => 'Harry {a1} the violin once a week.',
                 'difficulty' => 2,
-                'source' => $source,
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'plays', 'verb_hint' => 'play'],
@@ -181,7 +183,7 @@ class QuizPresentSimpleSeeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $categoryId,
                 'difficulty'  => $d['difficulty'],
-                'source'      => $d['source'],
+                'source_id'   => $d['source_id'],
                 'flag'        => $d['flag'],
             ]);
 

--- a/database/seeders/RevisionTensesFullSeeder.php
+++ b/database/seeders/RevisionTensesFullSeeder.php
@@ -7,6 +7,7 @@ use App\Models\Question;
 use App\Models\QuestionOption;
 use App\Models\QuestionAnswer;
 use App\Models\Category;
+use App\Models\Source;
 
 class RevisionTensesFullSeeder extends Seeder
 {
@@ -16,13 +17,17 @@ class RevisionTensesFullSeeder extends Seeder
         $cat_past = Category::firstOrCreate(['name' => 'past'])->id;
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
         $cat_future = Category::firstOrCreate(['name' => 'Future'])->id;
+        $sourcePos = Source::firstOrCreate(['name' => 'Write positive sentences: Склади речення у правильному порядку.'])->id;
+        $sourceNeg = Source::firstOrCreate(['name' => 'Write negative sentences: Заперечні речення.'])->id;
+        $sourceGeneral = Source::firstOrCreate(['name' => 'Write general questions: Побудуй загальне питання.'])->id;
+        $sourceSpec = Source::firstOrCreate(['name' => 'Write questions to the underlined words: Побудуй спеціальне питання до підкреслених слів.'])->id;
 
         // 1. Write positive sentences
         $data[] = [
             'question' => 'I/tidy/my room/every day.',
             'difficulty' => 1,
             'category_id' => $cat_present,
-            'source' => 'Write positive sentences: Склади речення у правильному порядку.',
+            'source_id' => $sourcePos,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'I tidy my room every day.', 'verb_hint' => 'tidy']
@@ -33,7 +38,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Amy/play/the computer/yesterday.',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write positive sentences: Склади речення у правильному порядку.',
+            'source_id' => $sourcePos,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Amy played the computer yesterday.', 'verb_hint' => 'play']
@@ -44,7 +49,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Bob/send/the telegram/tomorrow.',
             'difficulty' => 3,
             'category_id' => $cat_future,
-            'source' => 'Write positive sentences: Склади речення у правильному порядку.',
+            'source_id' => $sourcePos,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Bob will send the telegram tomorrow.', 'verb_hint' => 'send']
@@ -55,7 +60,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Andrew/repair/his bike/two days ago.',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write positive sentences: Склади речення у правильному порядку.',
+            'source_id' => $sourcePos,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Andrew repaired his bike two days ago.', 'verb_hint' => 'repair']
@@ -66,7 +71,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'They/often/watch TV/in the morning.',
             'difficulty' => 1,
             'category_id' => $cat_present,
-            'source' => 'Write positive sentences: Склади речення у правильному порядку.',
+            'source_id' => $sourcePos,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'They often watch TV in the morning.', 'verb_hint' => 'watch']
@@ -77,7 +82,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Tim/probably/receive/a letter/next week.',
             'difficulty' => 3,
             'category_id' => $cat_future,
-            'source' => 'Write positive sentences: Склади речення у правильному порядку.',
+            'source_id' => $sourcePos,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Tim will probably receive a letter next week.', 'verb_hint' => 'receive']
@@ -88,7 +93,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Kate/help/me/with my Maths/last week.',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write positive sentences: Склади речення у правильному порядку.',
+            'source_id' => $sourcePos,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Kate helped me with my Maths last week.', 'verb_hint' => 'help']
@@ -99,7 +104,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Lucy/have/two cheeseburgers/for lunch.',
             'difficulty' => 1,
             'category_id' => $cat_present,
-            'source' => 'Write positive sentences: Склади речення у правильному порядку.',
+            'source_id' => $sourcePos,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Lucy has two cheeseburgers for lunch.', 'verb_hint' => 'have']
@@ -110,7 +115,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'I/usually/call/my friends/in the afternoon.',
             'difficulty' => 1,
             'category_id' => $cat_present,
-            'source' => 'Write positive sentences: Склади речення у правильному порядку.',
+            'source_id' => $sourcePos,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'I usually call my friends in the afternoon.', 'verb_hint' => 'call']
@@ -123,7 +128,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'We/clean/the room/yesterday.',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write negative sentences: Заперечні речення.',
+            'source_id' => $sourceNeg,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => "We didn't clean the room yesterday.", 'verb_hint' => 'clean']
@@ -134,7 +139,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Robots/do/all the housework/in the future.',
             'difficulty' => 3,
             'category_id' => $cat_future,
-            'source' => 'Write negative sentences: Заперечні речення.',
+            'source_id' => $sourceNeg,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => "Robots won't do all the housework in the future.", 'verb_hint' => 'do']
@@ -145,7 +150,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'My sister/usually/get up/at 8 o\'clock.',
             'difficulty' => 2,
             'category_id' => $cat_present,
-            'source' => 'Write negative sentences: Заперечні речення.',
+            'source_id' => $sourceNeg,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => "My sister doesn't usually get up at 8 o'clock.", 'verb_hint' => 'get']
@@ -156,7 +161,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Sue/often/do the shopping/on Fridays.',
             'difficulty' => 2,
             'category_id' => $cat_present,
-            'source' => 'Write negative sentences: Заперечні речення.',
+            'source_id' => $sourceNeg,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => "Sue doesn't often do the shopping on Fridays.", 'verb_hint' => 'do']
@@ -167,7 +172,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'They/make/a snowman/two days ago.',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write negative sentences: Заперечні речення.',
+            'source_id' => $sourceNeg,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => "They didn't make a snowman two days ago.", 'verb_hint' => 'make']
@@ -178,7 +183,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'We/move/to a new house/soon.',
             'difficulty' => 3,
             'category_id' => $cat_future,
-            'source' => 'Write negative sentences: Заперечні речення.',
+            'source_id' => $sourceNeg,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => "We won't move to a new house soon.", 'verb_hint' => 'move']
@@ -189,7 +194,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Nick/never/go/to school/by bus.',
             'difficulty' => 1,
             'category_id' => $cat_present,
-            'source' => 'Write negative sentences: Заперечні речення.',
+            'source_id' => $sourceNeg,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => "Nick never goes to school by bus.", 'verb_hint' => 'go']
@@ -200,7 +205,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Sally/send/two e-mails/yesterday.',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write negative sentences: Заперечні речення.',
+            'source_id' => $sourceNeg,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => "Sally didn't send two e-mails yesterday.", 'verb_hint' => 'send']
@@ -211,7 +216,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Tom/be/twenty/next year.',
             'difficulty' => 3,
             'category_id' => $cat_future,
-            'source' => 'Write negative sentences: Заперечні речення.',
+            'source_id' => $sourceNeg,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => "Tom won't be twenty next year.", 'verb_hint' => 'be']
@@ -224,7 +229,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'My working day/usually/at nine/begin?',
             'difficulty' => 3,
             'category_id' => $cat_present,
-            'source' => 'Write general questions: Побудуй загальне питання.',
+            'source_id' => $sourceGeneral,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Does my working day usually begin at nine?', 'verb_hint' => 'begin']
@@ -235,7 +240,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'They/live/last year/in a small flat?',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write general questions: Побудуй загальне питання.',
+            'source_id' => $sourceGeneral,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Did they live in a small flat last year?', 'verb_hint' => 'live']
@@ -246,7 +251,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Tim/a message/receive/yesterday?',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write general questions: Побудуй загальне питання.',
+            'source_id' => $sourceGeneral,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Did Tim receive a message yesterday?', 'verb_hint' => 'receive']
@@ -257,7 +262,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Sally/to the cinema/go/tomorrow?',
             'difficulty' => 3,
             'category_id' => $cat_future,
-            'source' => 'Write general questions: Побудуй загальне питання.',
+            'source_id' => $sourceGeneral,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Will Sally go to the cinema tomorrow?', 'verb_hint' => 'go']
@@ -268,7 +273,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'My brother/every day/play/the guitar?',
             'difficulty' => 2,
             'category_id' => $cat_present,
-            'source' => 'Write general questions: Побудуй загальне питання.',
+            'source_id' => $sourceGeneral,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Does my brother play the guitar every day?', 'verb_hint' => 'play']
@@ -279,7 +284,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Sam/that film/last week/see?',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write general questions: Побудуй загальне питання.',
+            'source_id' => $sourceGeneral,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Did Sam see that film last week?', 'verb_hint' => 'see']
@@ -290,7 +295,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Liz/to the exhibition/go/next week?',
             'difficulty' => 3,
             'category_id' => $cat_future,
-            'source' => 'Write general questions: Побудуй загальне питання.',
+            'source_id' => $sourceGeneral,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Will Liz go to the exhibition next week?', 'verb_hint' => 'go']
@@ -301,7 +306,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'I/forget/always/my keys/on the table?',
             'difficulty' => 2,
             'category_id' => $cat_present,
-            'source' => 'Write general questions: Побудуй загальне питання.',
+            'source_id' => $sourceGeneral,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Do I always forget my keys on the table?', 'verb_hint' => 'forget']
@@ -312,7 +317,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Mary/at school/dance/tomorrow?',
             'difficulty' => 2,
             'category_id' => $cat_future,
-            'source' => 'Write general questions: Побудуй загальне питання.',
+            'source_id' => $sourceGeneral,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Will Mary dance at school tomorrow?', 'verb_hint' => 'dance']
@@ -325,7 +330,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'She arrived at two o\'clock yesterday.',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write questions to the underlined words: Побудуй спеціальне питання до підкреслених слів.',
+            'source_id' => $sourceSpec,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'When did she arrive?', 'verb_hint' => 'arrive']
@@ -336,7 +341,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'I shall have chicken and some salad.',
             'difficulty' => 3,
             'category_id' => $cat_future,
-            'source' => 'Write questions to the underlined words: Побудуй спеціальне питання до підкреслених слів.',
+            'source_id' => $sourceSpec,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'What will you have?', 'verb_hint' => 'have']
@@ -347,7 +352,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Laura helps me with my English every day.',
             'difficulty' => 2,
             'category_id' => $cat_present,
-            'source' => 'Write questions to the underlined words: Побудуй спеціальне питання до підкреслених слів.',
+            'source_id' => $sourceSpec,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Who does Laura help with her English every day?', 'verb_hint' => 'help']
@@ -358,7 +363,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Timmy studied typing yesterday.',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write questions to the underlined words: Побудуй спеціальне питання до підкреслених слів.',
+            'source_id' => $sourceSpec,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'What did Timmy study yesterday?', 'verb_hint' => 'study']
@@ -369,7 +374,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Jane always draws nice pictures.',
             'difficulty' => 2,
             'category_id' => $cat_present,
-            'source' => 'Write questions to the underlined words: Побудуй спеціальне питання до підкреслених слів.',
+            'source_id' => $sourceSpec,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'What does Jane always draw?', 'verb_hint' => 'draw']
@@ -380,7 +385,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'They went to Italy last week.',
             'difficulty' => 2,
             'category_id' => $cat_past,
-            'source' => 'Write questions to the underlined words: Побудуй спеціальне питання до підкреслених слів.',
+            'source_id' => $sourceSpec,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Where did they go last week?', 'verb_hint' => 'go']
@@ -391,7 +396,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'Bob will see this comedy next week.',
             'difficulty' => 2,
             'category_id' => $cat_future,
-            'source' => 'Write questions to the underlined words: Побудуй спеціальне питання до підкреслених слів.',
+            'source_id' => $sourceSpec,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'What will Bob see next week?', 'verb_hint' => 'see']
@@ -402,7 +407,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'I often forget my things at home.',
             'difficulty' => 2,
             'category_id' => $cat_present,
-            'source' => 'Write questions to the underlined words: Побудуй спеціальне питання до підкреслених слів.',
+            'source_id' => $sourceSpec,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Where do you often forget your things?', 'verb_hint' => 'forget']
@@ -413,7 +418,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'The porter will bring your luggage.',
             'difficulty' => 3,
             'category_id' => $cat_future,
-            'source' => 'Write questions to the underlined words: Побудуй спеціальне питання до підкреслених слів.',
+            'source_id' => $sourceSpec,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'Who will bring your luggage?', 'verb_hint' => 'bring']
@@ -423,11 +428,12 @@ class RevisionTensesFullSeeder extends Seeder
 
         // 5. Fill in the correct form of the verbs
         $fillSource = 'Fill in the correct form of the verbs.';
+        $fillSourceId = Source::firstOrCreate(['name' => $fillSource])->id;
         $data[] = [
             'question' => 'I {a1} winter.',
             'difficulty' => 1,
             'category_id' => $cat_present,
-            'source' => $fillSource,
+            'source_id' => $fillSourceId,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'like', 'verb_hint' => 'like']
@@ -438,7 +444,7 @@ class RevisionTensesFullSeeder extends Seeder
             'question' => 'It {a1} a very beautiful season.',
             'difficulty' => 1,
             'category_id' => $cat_present,
-            'source' => $fillSource,
+            'source_id' => $fillSourceId,
             'flag' => 0,
             'answers' => [
                 ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be']
@@ -455,7 +461,7 @@ class RevisionTensesFullSeeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $d['category_id'],
                 'difficulty'  => $d['difficulty'],
-                'source'      => $d['source'],
+                'source_id'   => $d['source_id'],
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {

--- a/database/seeders/ShortAnswersSeeder.php
+++ b/database/seeders/ShortAnswersSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Seeder;
 use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\Category;
+use App\Models\Source;
 
 class ShortAnswersSeeder extends Seeder
 {
@@ -14,13 +15,14 @@ class ShortAnswersSeeder extends Seeder
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
         $cat_past = Category::firstOrCreate(['name' => 'past'])->id;
         $cat_future = Category::firstOrCreate(['name' => 'Future'])->id;
+        $sourceId = Source::firstOrCreate(['name' => 'Short answers. Answer the questions with short answers.'])->id;
 
         $data = [
             [
                 'question' => 'Can you speak French? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'I can.', 'verb_hint' => 'can'],
@@ -31,7 +33,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Are they eating cheese? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'They are.', 'verb_hint' => 'be'],
@@ -42,7 +44,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Could your sister swim last year? Yes, {a1} No, {a2}',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'She could.', 'verb_hint' => 'can'],
@@ -53,7 +55,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Do you go to school every day? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'I do.', 'verb_hint' => 'do'],
@@ -64,7 +66,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Are you happy? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'I am.', 'verb_hint' => 'be'],
@@ -75,7 +77,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Does a cat drink milk? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'It does.', 'verb_hint' => 'do'],
@@ -86,7 +88,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Was this table green? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'It was.', 'verb_hint' => 'be'],
@@ -97,7 +99,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Is Tom wearing a blue tie? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'He is.', 'verb_hint' => 'be'],
@@ -108,7 +110,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Have they got a new pet? Yes, {a1} No, {a2}',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'They have.', 'verb_hint' => 'have'],
@@ -119,7 +121,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Does your aunt work? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'She does.', 'verb_hint' => 'do'],
@@ -130,7 +132,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Did she live in Madrid? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'She did.', 'verb_hint' => 'do'],
@@ -141,7 +143,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Are your parents doctors? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'They are.', 'verb_hint' => 'be'],
@@ -152,7 +154,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Can a dolphin swim? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'It can.', 'verb_hint' => 'can'],
@@ -163,7 +165,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Was that dog eating bones? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'It was.', 'verb_hint' => 'be'],
@@ -174,7 +176,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Could you open the window? Yes, {a1} No, {a2}',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'I could.', 'verb_hint' => 'can'],
@@ -185,7 +187,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Has he got a small car? Yes, {a1} No, {a2}',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'He has.', 'verb_hint' => 'have'],
@@ -196,7 +198,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Do you like Coke? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'I do.', 'verb_hint' => 'do'],
@@ -207,7 +209,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Can Anna play the piano? Yes, {a1} No, {a2}',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'She can.', 'verb_hint' => 'can'],
@@ -218,7 +220,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Are we writing an email? Yes, {a1} No, {a2}',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'We are.', 'verb_hint' => 'be'],
@@ -229,7 +231,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Do you want to go to the cinema? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'I do.', 'verb_hint' => 'do'],
@@ -240,7 +242,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Did Peter study at university? Yes, {a1} No, {a2}',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'He did.', 'verb_hint' => 'do'],
@@ -251,7 +253,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Was she hungry? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'She was.', 'verb_hint' => 'be'],
@@ -262,7 +264,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Does George like onions? Yes, {a1} No, {a2}',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'He does.', 'verb_hint' => 'do'],
@@ -273,7 +275,7 @@ class ShortAnswersSeeder extends Seeder
                 'question' => 'Was Linda watching the news? Yes, {a1} No, {a2}',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => 'Short answers. Answer the questions with short answers.',
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'She was.', 'verb_hint' => 'be'],
@@ -287,7 +289,7 @@ class ShortAnswersSeeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $d['category_id'],
                 'difficulty'  => $d['difficulty'],
-                'source'      => $d['source'],
+                'source_id'   => $d['source_id'],
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {

--- a/database/seeders/SimplePresentPastSeeder.php
+++ b/database/seeders/SimplePresentPastSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Seeder;
 use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
+use App\Models\Source;
 
 class SimplePresentPastSeeder extends Seeder
 {
@@ -14,6 +15,7 @@ class SimplePresentPastSeeder extends Seeder
         // Категорія (створи/знайди): 2 = Present, 1 = Past
         $categoryPresent = 2;
         $categoryPast = 1;
+        $sourceId = Source::firstOrCreate(['name' => 'Simple Present x Simple Past'])->id;
 
         $questions = [
             [
@@ -23,7 +25,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'walk', 'verb_hint' => 'walk'],
                 ],
                 'options' => ['walk', 'walks', 'walked', 'walking'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Mark {a1} computers for three years before he graduated.',
@@ -32,7 +34,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'studied', 'verb_hint' => 'study'],
                 ],
                 'options' => ['study', 'studies', 'studied', 'studying'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'They {a1} late for the party.',
@@ -41,7 +43,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'did not arrive', 'verb_hint' => 'arrive / neg'],
                 ],
                 'options' => ['arrived', 'did not arrive', 'arrives', 'arriving'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'My parents {a1} in that church.',
@@ -50,7 +52,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'married', 'verb_hint' => 'marry'],
                 ],
                 'options' => ['marry', 'married', 'marries', 'marrying'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Sorry! My classes {a1} 15 minutes late.',
@@ -59,7 +61,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'end', 'verb_hint' => 'end'],
                 ],
                 'options' => ['end', 'ended', 'ends', 'ending'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'July {a1} for us.',
@@ -68,7 +70,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'does not wait', 'verb_hint' => 'wait / neg'],
                 ],
                 'options' => ['waits', 'wait', 'does not wait', 'waited'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'You {a1} dogs. You have many.',
@@ -77,7 +79,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'like', 'verb_hint' => 'like'],
                 ],
                 'options' => ['like', 'likes', 'liked', 'liking'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'I {a1} that book yesterday for the test.',
@@ -86,7 +88,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'needed', 'verb_hint' => 'need'],
                 ],
                 'options' => ['need', 'needed', 'needs', 'needing'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'She {a1} my new dress last night.',
@@ -95,7 +97,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'used', 'verb_hint' => 'use'],
                 ],
                 'options' => ['use', 'used', 'uses', 'using'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'The teacher {a1} the students after class. Now, he can\'t.',
@@ -104,7 +106,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'helped', 'verb_hint' => 'help'],
                 ],
                 'options' => ['help', 'helped', 'helps', 'helping'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'It {a1} heavily last night.',
@@ -113,7 +115,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'rained', 'verb_hint' => 'rain'],
                 ],
                 'options' => ['rains', 'rain', 'rained', 'raining'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'The police {a1} to the thief earlier.',
@@ -122,7 +124,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'talked', 'verb_hint' => 'talk'],
                 ],
                 'options' => ['talk', 'talked', 'talks', 'talking'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'He {a1} the suitcase for me. It was too heavy.',
@@ -131,7 +133,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'carried', 'verb_hint' => 'carry'],
                 ],
                 'options' => ['carry', 'carried', 'carries', 'carrying'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'The stores {a1} earlier today.',
@@ -140,7 +142,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'closed', 'verb_hint' => 'close'],
                 ],
                 'options' => ['close', 'closed', 'closes', 'closing'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'The kids {a1} their homework.',
@@ -149,7 +151,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'do not finish', 'verb_hint' => 'finish / neg'],
                 ],
                 'options' => ['finish', 'finishes', 'finished', 'do not finish'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'I {a1} some milk on the floor.',
@@ -158,7 +160,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'dropped', 'verb_hint' => 'drop'],
                 ],
                 'options' => ['drop', 'dropped', 'drops', 'dropping'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'My kids {a1} video games every day, only on Sundays.',
@@ -167,7 +169,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'do not play', 'verb_hint' => 'play / neg'],
                 ],
                 'options' => ['play', 'plays', 'played', 'do not play'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Sarah {a1} the box for him. It was difficult.',
@@ -176,7 +178,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'opened', 'verb_hint' => 'open'],
                 ],
                 'options' => ['open', 'opened', 'opens', 'opening'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Patrick {a1} money to buy a house.',
@@ -185,7 +187,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'saved', 'verb_hint' => 'save'],
                 ],
                 'options' => ['save', 'saved', 'saves', 'saving'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'My mother {a1} dinner when she arrives from work.',
@@ -194,7 +196,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'cooks', 'verb_hint' => 'cook'],
                 ],
                 'options' => ['cook', 'cooks', 'cooked', 'cooking'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Last night I {a1} a noise in the garage.',
@@ -203,7 +205,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'heard', 'verb_hint' => 'hear'],
                 ],
                 'options' => ['hear', 'hears', 'heard', 'hearing'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'I {a1} at night. I get home tired.',
@@ -212,7 +214,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'do not cook', 'verb_hint' => 'cook / neg'],
                 ],
                 'options' => ['cook', 'cooks', 'do not cook', 'cooked'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'Renata {a1} to the gym yesterday morning.',
@@ -221,7 +223,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'went', 'verb_hint' => 'go'],
                 ],
                 'options' => ['go', 'goes', 'went', 'going'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'The city {a1} crowded. Our event is a success.',
@@ -230,7 +232,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
                 ],
                 'options' => ['is', 'are', 'was', 'were'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
             [
                 'question' => 'We {a1} help the man. We were afraid.',
@@ -239,7 +241,7 @@ class SimplePresentPastSeeder extends Seeder
                     ['marker' => 'a1', 'answer' => 'did not help', 'verb_hint' => 'help / neg'],
                 ],
                 'options' => ['help', 'helped', 'did not help', 'helps'],
-                'source' => 'Simple Present x Simple Past',
+                'source_id' => $sourceId,
             ],
         ];
 
@@ -249,7 +251,7 @@ class SimplePresentPastSeeder extends Seeder
                 'difficulty'  => 2, // Або оціни самостійно, тут для всіх 2
                 'category_id' => $data['category_id'],
                 'flag'        => 0,
-                'source'      => $data['source'],
+                'source_id'   => $data['source_id'],
             ]);
             foreach ($data['answers'] as $ans) {
                 QuestionAnswer::create([

--- a/database/seeders/ThisThatTheseThoseExercise2Seeder.php
+++ b/database/seeders/ThisThatTheseThoseExercise2Seeder.php
@@ -7,6 +7,7 @@ use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
 use App\Models\Category;
+use App\Models\Source;
 
 class ThisThatTheseThoseExercise2Seeder extends Seeder
 {
@@ -14,6 +15,7 @@ class ThisThatTheseThoseExercise2Seeder extends Seeder
     {
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
         $source = 'Choose this, that, these, those to complete the following sentences.';
+        $sourceId = Source::firstOrCreate(['name' => $source])->id;
 
         $data = [
             [
@@ -73,7 +75,7 @@ class ThisThatTheseThoseExercise2Seeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $cat_present,
                 'difficulty'  => 1,
-                'source'      => $source,
+                'source_id'   => $sourceId,
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {

--- a/database/seeders/ThisThatTheseThoseExercise3Seeder.php
+++ b/database/seeders/ThisThatTheseThoseExercise3Seeder.php
@@ -7,6 +7,7 @@ use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
 use App\Models\Category;
+use App\Models\Source;
 
 class ThisThatTheseThoseExercise3Seeder extends Seeder
 {
@@ -14,6 +15,7 @@ class ThisThatTheseThoseExercise3Seeder extends Seeder
     {
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
         $source = 'Transform singular sentences into plural sentences and plural sentences into singular sentences using this, that, these, those and other missing words.';
+        $sourceId = Source::firstOrCreate(['name' => $source])->id;
 
         $data = [
             [
@@ -73,7 +75,7 @@ class ThisThatTheseThoseExercise3Seeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $cat_present,
                 'difficulty'  => 2,
-                'source'      => $source,
+                'source_id'   => $sourceId,
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {

--- a/database/seeders/ThisThatTheseThoseSeeder.php
+++ b/database/seeders/ThisThatTheseThoseSeeder.php
@@ -7,6 +7,7 @@ use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
 use App\Models\Category;
+use App\Models\Source;
 
 class ThisThatTheseThoseSeeder extends Seeder
 {
@@ -14,6 +15,7 @@ class ThisThatTheseThoseSeeder extends Seeder
     {
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
         $source = 'Complete the sentences with this, that, these, those';
+        $sourceId = Source::firstOrCreate(['name' => $source])->id;
 
         $data = [
             [
@@ -73,7 +75,7 @@ class ThisThatTheseThoseSeeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $cat_present,
                 'difficulty'  => 1,
-                'source'      => $source,
+                'source_id'   => $sourceId,
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {

--- a/database/seeders/ToBeTenseSeeder.php
+++ b/database/seeders/ToBeTenseSeeder.php
@@ -6,6 +6,7 @@ use App\Models\Question;
 use App\Models\QuestionOption;
 use App\Models\QuestionAnswer;
 use App\Models\Category;
+use App\Models\Source;
 
 class ToBeTenseSeeder extends Seeder
 {
@@ -15,13 +16,14 @@ class ToBeTenseSeeder extends Seeder
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
         $cat_past = Category::firstOrCreate(['name' => 'past'])->id;
         $cat_future = Category::firstOrCreate(['name' => 'Future'])->id;
+        $sourceId = Source::firstOrCreate(["name" => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms."])->id;
 
         $data = [
             [
                 'question' => 'Jordan and Alan {a1} basketball players. They {a2} tall.',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'are', 'verb_hint' => 'be'],
@@ -33,7 +35,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'The pupils {a1} in the class now.',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'are', 'verb_hint' => 'be'],
@@ -44,7 +46,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'There {a1} an interesting picture on the wall.',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
@@ -55,7 +57,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'I {a1} a sportsman when I grow up.',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will be', 'verb_hint' => 'be'],
@@ -66,7 +68,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Julian {a1} five last year.',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'was', 'verb_hint' => 'be'],
@@ -77,7 +79,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Dr. Jeremy {a1} a famous surgeon.',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
@@ -88,7 +90,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Yesterday we {a1} at the zoo.',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'were', 'verb_hint' => 'be'],
@@ -99,7 +101,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Our class {a1} in Moscow next month.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will be', 'verb_hint' => 'be'],
@@ -110,7 +112,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'When my uncle {a1} young, he {a2} a singer.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'was', 'verb_hint' => 'be'],
@@ -122,7 +124,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'My friend {a1} at home now.',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
@@ -133,7 +135,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'She {a1} 18 in two days. She {a2} happy.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will be', 'verb_hint' => 'be'],
@@ -145,7 +147,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Where {a1} Lucy? She {a2} in the bathroom.',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
@@ -157,7 +159,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Will you {a1} at school tomorrow?',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'be', 'verb_hint' => 'be'],
@@ -168,7 +170,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Where {a1} you now? - I {a2} at the cinema.',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'are', 'verb_hint' => 'be'],
@@ -180,7 +182,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Henry {a1} ill three weeks ago.',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'was', 'verb_hint' => 'be'],
@@ -191,7 +193,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'The teacher {a1} in the classroom.',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
@@ -202,7 +204,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Where {a1} they yesterday? - They {a2} in the restaurant.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'were', 'verb_hint' => 'be'],
@@ -214,7 +216,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'I {a1} Mr. White. Nice to meet you!',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'am', 'verb_hint' => 'be'],
@@ -225,7 +227,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'This {a1} your apple. Take it!',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
@@ -236,7 +238,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'There {a1} many books on the shelf.',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'are', 'verb_hint' => 'be'],
@@ -247,7 +249,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Where {a1} they from? - They {a2} from Wales.',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'are', 'verb_hint' => 'be'],
@@ -259,7 +261,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Who {a1} you? - I {a2} Nick Green.',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'are', 'verb_hint' => 'be'],
@@ -271,7 +273,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'What {a1} you? - I {a2} a bus-driver.',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'are', 'verb_hint' => 'be'],
@@ -283,7 +285,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => '{a1} there any honey in the jar? - Yes, it {a2}.',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
@@ -295,7 +297,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Why {a1} your brother here?',
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
@@ -306,7 +308,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => "Don't phone him. He {a1} out.",
                 'difficulty' => 2,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
@@ -317,7 +319,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'What {a1} your favourite book?',
                 'difficulty' => 1,
                 'category_id' => $cat_present,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
@@ -328,7 +330,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'My parents {a1} in Hawaii last month.',
                 'difficulty' => 2,
                 'category_id' => $cat_past,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'were', 'verb_hint' => 'be'],
@@ -339,7 +341,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'The boss {a1} here in a minute.',
                 'difficulty' => 2,
                 'category_id' => $cat_future,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'will be', 'verb_hint' => 'be'],
@@ -350,7 +352,7 @@ class ToBeTenseSeeder extends Seeder
                 'question' => 'Rosie {a1} at hairdresser\'s last week.',
                 'difficulty' => 1,
                 'category_id' => $cat_past,
-                'source' => "To Be. Fill in the gaps with the verb 'to be' in Present, Past, Future forms.",
+                'source_id' => $sourceId,
                 'flag' => 0,
                 'answers' => [
                     ['marker' => 'a1', 'answer' => 'was', 'verb_hint' => 'be'],
@@ -364,7 +366,7 @@ class ToBeTenseSeeder extends Seeder
                 'question'    => $d['question'],
                 'category_id' => $d['category_id'],
                 'difficulty'  => $d['difficulty'],
-                'source'      => $d['source'],
+                'source_id'   => $d['source_id'],
                 'flag'        => $d['flag'],
             ]);
 


### PR DESCRIPTION
## Summary
- create `sources` table and reference it from `questions`
- add `Source` model and relation from `Question`
- update seeders to use `source_id`

## Testing
- `composer install`
- `APP_KEY=base64:UHf6Ed2TtpuJWo0iKSX87SC8e3tEVlWqU5gzPgBFhow= ./vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688519538b04832aa6835ec45fa5022c