### PR TITLE
Ensure unique question answers

### DIFF
--- a/database/migrations/2025_07_27_000001_add_unique_index_to_question_answers.php
+++ b/database/migrations/2025_07_27_000001_add_unique_index_to_question_answers.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('question_answers', function (Blueprint $table) {
+            $table->unique(['question_id', 'marker', 'answer'], 'question_marker_answer_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('question_answers', function (Blueprint $table) {
+            $table->dropUnique('question_marker_answer_unique');
+        });
+    }
+};

--- a/database/seeders/DoDoesIsAreSeeder.php
+++ b/database/seeders/DoDoesIsAreSeeder.php
@@ -50,7 +50,7 @@ class DoDoesIsAreSeeder extends Seeder
                 'flag'        => 0,
                 'source_id'   => $sourceId,
             ]);
-            QuestionAnswer::create([
+            QuestionAnswer::firstOrCreate([
                 'question_id' => $q->id,
                 'marker'      => 'a1',
                 'answer'      => $data[1],

--- a/database/seeders/FutureSimpleTest1Seeder.php
+++ b/database/seeders/FutureSimpleTest1Seeder.php
@@ -328,7 +328,7 @@ class FutureSimpleTest1Seeder extends Seeder
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/GrammarQuizPastSimpleSeeder.php
+++ b/database/seeders/GrammarQuizPastSimpleSeeder.php
@@ -205,7 +205,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/GrammarTestAISeeder.php
+++ b/database/seeders/GrammarTestAISeeder.php
@@ -218,7 +218,7 @@ class GrammarTestAISeeder extends Seeder
                 'source_id'   => $data['source_id'],
             ]);
             foreach ($data['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/GrammarTestSeeder.php
+++ b/database/seeders/GrammarTestSeeder.php
@@ -270,7 +270,7 @@ class GrammarTestSeeder extends Seeder
                 ]);
             }
             foreach ($q['answers'] as $marker => $answerData) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $question->id,
                     'marker' => $marker,
                     'answer' => $answerData['answer'],

--- a/database/seeders/PastSimpleRegularSeeder.php
+++ b/database/seeders/PastSimpleRegularSeeder.php
@@ -168,7 +168,7 @@ class PastSimpleRegularSeeder extends Seeder
                 'source_id'   => $sourceId,
             ]);
             foreach ($data['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/PastSimpleRegularVerbsFullSeeder.php
+++ b/database/seeders/PastSimpleRegularVerbsFullSeeder.php
@@ -53,7 +53,7 @@ class PastSimpleRegularVerbsFullSeeder extends Seeder
                 'flag'        => 0,
                 'source_id'   => $source1,
             ]);
-            QuestionAnswer::create([
+            QuestionAnswer::firstOrCreate([
                 'question_id' => $q->id,
                 'marker'      => 'a1',
                 'answer'      => $past,
@@ -85,7 +85,7 @@ class PastSimpleRegularVerbsFullSeeder extends Seeder
                 'flag'        => 1,
                 'source_id'   => $source2,
             ]);
-            QuestionAnswer::create([
+            QuestionAnswer::firstOrCreate([
                 'question_id' => $q->id,
                 'marker'      => 'a1',
                 'answer'      => $pos,
@@ -112,7 +112,7 @@ class PastSimpleRegularVerbsFullSeeder extends Seeder
                 'flag'        => 1,
                 'source_id'   => $source3,
             ]);
-            QuestionAnswer::create([
+            QuestionAnswer::firstOrCreate([
                 'question_id' => $q->id,
                 'marker'      => 'a1',
                 'answer'      => $neg,

--- a/database/seeders/PresentPastRevisionSeeder.php
+++ b/database/seeders/PresentPastRevisionSeeder.php
@@ -183,7 +183,7 @@ class PresentPastRevisionSeeder extends Seeder
                 'source_id'   => $sourceId,
             ]);
             foreach ($data['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/PresentSimpleExercisesSeeder.php
+++ b/database/seeders/PresentSimpleExercisesSeeder.php
@@ -188,7 +188,7 @@ class PresentSimpleExercisesSeeder extends Seeder
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],
@@ -212,7 +212,7 @@ class PresentSimpleExercisesSeeder extends Seeder
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/PresentSimpleSeeder.php
+++ b/database/seeders/PresentSimpleSeeder.php
@@ -169,7 +169,7 @@ class PresentSimpleSeeder extends Seeder
             ]);
 
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/QuizPresentSimpleSeeder.php
+++ b/database/seeders/QuizPresentSimpleSeeder.php
@@ -188,7 +188,7 @@ class QuizPresentSimpleSeeder extends Seeder
             ]);
 
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/RevisionTensesFullSeeder.php
+++ b/database/seeders/RevisionTensesFullSeeder.php
@@ -465,7 +465,7 @@ class RevisionTensesFullSeeder extends Seeder
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/ShortAnswersSeeder.php
+++ b/database/seeders/ShortAnswersSeeder.php
@@ -293,7 +293,7 @@ class ShortAnswersSeeder extends Seeder
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/SimplePresentPastSeeder.php
+++ b/database/seeders/SimplePresentPastSeeder.php
@@ -254,7 +254,7 @@ class SimplePresentPastSeeder extends Seeder
                 'source_id'   => $data['source_id'],
             ]);
             foreach ($data['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/ThisThatTheseThoseExercise2Seeder.php
+++ b/database/seeders/ThisThatTheseThoseExercise2Seeder.php
@@ -79,7 +79,7 @@ class ThisThatTheseThoseExercise2Seeder extends Seeder
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/ThisThatTheseThoseExercise3Seeder.php
+++ b/database/seeders/ThisThatTheseThoseExercise3Seeder.php
@@ -79,7 +79,7 @@ class ThisThatTheseThoseExercise3Seeder extends Seeder
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/ThisThatTheseThoseSeeder.php
+++ b/database/seeders/ThisThatTheseThoseSeeder.php
@@ -79,7 +79,7 @@ class ThisThatTheseThoseSeeder extends Seeder
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
-                QuestionAnswer::create([
+                QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],

--- a/database/seeders/ToBeTenseSeeder.php
+++ b/database/seeders/ToBeTenseSeeder.php
@@ -371,7 +371,7 @@ class ToBeTenseSeeder extends Seeder
             ]);
 
             foreach ($d['answers'] as $ans) {
-                \App\Models\QuestionAnswer::create([
+                \App\Models\QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'answer'      => $ans['answer'],


### PR DESCRIPTION
## Summary
- prevent duplicate answers by using `firstOrCreate`
- add unique index on `question_answers`

## Testing
- `vendor/bin/phpunit --testsuite Feature --stop-on-failure` *(fails: No application encryption key specified)*

------
https://chatgpt.com/codex/tasks/task_e_688532246830832a9e9350d6f22cd78d