### PR TITLE
Refactor question options table

### DIFF
--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -24,7 +24,7 @@ class Question extends Model
 
     public function options()
     {
-        return $this->hasMany(QuestionOption::class);
+        return $this->belongsToMany(QuestionOption::class, 'question_option_question', 'question_id', 'option_id');
     }
 
     public function answers()

--- a/app/Models/QuestionOption.php
+++ b/app/Models/QuestionOption.php
@@ -6,10 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class QuestionOption extends Model
 {
-    protected $fillable = ['question_id', 'option'];
-    public function question()
+    protected $fillable = ['option'];
+    public function questions()
     {
-        return $this->belongsTo(Question::class);
+        return $this->belongsToMany(Question::class, 'question_option_question', 'option_id', 'question_id');
     }
 
     public function answers()

--- a/database/migrations/2025_07_29_000001_create_question_option_question_table.php
+++ b/database/migrations/2025_07_29_000001_create_question_option_question_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('question_option_question', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('question_id')->constrained('questions')->cascadeOnDelete();
+            $table->foreignId('option_id')->constrained('question_options')->cascadeOnDelete();
+            $table->unique(['question_id','option_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('question_option_question');
+    }
+};

--- a/database/migrations/2025_07_29_000002_alter_question_options_table.php
+++ b/database/migrations/2025_07_29_000002_alter_question_options_table.php
@@ -1,0 +1,31 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('question_options', function (Blueprint $table) {
+            if (Schema::hasColumn('question_options', 'question_id')) {
+                $table->dropForeign(['question_id']);
+                $table->dropColumn('question_id');
+            }
+            if (!Schema::hasColumn('question_options', 'option')) {
+                $table->string('option');
+            }
+            $table->unique('option');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('question_options', function (Blueprint $table) {
+            $table->dropUnique(['option']);
+            if (!Schema::hasColumn('question_options', 'question_id')) {
+                $table->foreignId('question_id')->after('id')->constrained('questions')->cascadeOnDelete();
+            }
+        });
+    }
+};

--- a/database/seeders/FutureSimpleTest1Seeder.php
+++ b/database/seeders/FutureSimpleTest1Seeder.php
@@ -12,6 +12,13 @@ use App\Models\Source;
 
 class FutureSimpleTest1Seeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         $cat_future = Category::firstOrCreate(['name' => 'Future'])->id;
@@ -329,20 +336,14 @@ class FutureSimpleTest1Seeder extends Seeder
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -352,10 +353,7 @@ class FutureSimpleTest1Seeder extends Seeder
             }
             if (!empty($d['options'])) {
                 foreach ($d['options'] as $opt) {
-                    QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $opt,
-                    ]);
+                    $this->attachOption($q, $opt);
                 }
             }
         }

--- a/database/seeders/GrammarQuizPastSimpleSeeder.php
+++ b/database/seeders/GrammarQuizPastSimpleSeeder.php
@@ -12,6 +12,13 @@ use App\Models\Source;
 
 class GrammarQuizPastSimpleSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         $cat_past = Category::firstOrCreate(['name' => 'past'])->id;
@@ -206,20 +213,14 @@ class GrammarQuizPastSimpleSeeder extends Seeder
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -229,10 +230,7 @@ class GrammarQuizPastSimpleSeeder extends Seeder
             }
             if (!empty($d['options'])) {
                 foreach ($d['options'] as $opt) {
-                    QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $opt,
-                    ]);
+                    $this->attachOption($q, $opt);
                 }
             }
         }

--- a/database/seeders/GrammarTestAISeeder.php
+++ b/database/seeders/GrammarTestAISeeder.php
@@ -12,6 +12,13 @@ use App\Models\Source;
 
 class GrammarTestAISeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
 
@@ -219,20 +226,14 @@ class GrammarTestAISeeder extends Seeder
                 'source_id'   => $data['source_id'],
             ]);
             foreach ($data['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -241,10 +242,7 @@ class GrammarTestAISeeder extends Seeder
                 }
             }
             foreach ($data['options'] as $opt) {
-                QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $opt,
-                ]);
+                $this->attachOption($q, $opt);
             }
         }
     }

--- a/database/seeders/GrammarTestSeeder.php
+++ b/database/seeders/GrammarTestSeeder.php
@@ -11,6 +11,13 @@ use App\Models\VerbHint;
 
 class GrammarTestSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run(): void
     {
         $cats = [
@@ -265,26 +272,17 @@ class GrammarTestSeeder extends Seeder
                 'category_id' => $cats[$q['category']]->id,
             ]);
             foreach ($q['options'] as $option) {
-                QuestionOption::firstOrCreate([
-                    'question_id' => $question->id,
-                    'option' => $option,
-                ]);
+                $this->attachOption($question, $option);
             }
             foreach ($q['answers'] as $marker => $answerData) {
-                $opt = QuestionOption::firstOrCreate([
-                    'question_id' => $question->id,
-                    'option' => $answerData['answer'],
-                ]);
+                $opt = $this->attachOption($question, $answerData['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $question->id,
                     'marker' => $marker,
                     'option_id' => $opt->id,
                 ]);
                 if (!empty($answerData['verb_hint'])) {
-                    $hintOpt = QuestionOption::firstOrCreate([
-                        'question_id' => $question->id,
-                        'option' => $answerData['verb_hint'],
-                    ]);
+                    $hintOpt = $this->attachOption($question, $answerData['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $question->id,
                         'marker' => $marker,

--- a/database/seeders/PastSimpleRegularSeeder.php
+++ b/database/seeders/PastSimpleRegularSeeder.php
@@ -11,6 +11,13 @@ use App\Models\Source;
 
 class PastSimpleRegularSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         // Категорія Past Simple (1)
@@ -169,20 +176,14 @@ class PastSimpleRegularSeeder extends Seeder
                 'source_id'   => $sourceId,
             ]);
             foreach ($data['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -191,10 +192,7 @@ class PastSimpleRegularSeeder extends Seeder
                 }
             }
             foreach ($data['options'] as $opt) {
-                QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $opt,
-                ]);
+                $this->attachOption($q, $opt);
             }
         }
     }

--- a/database/seeders/PastSimpleRegularVerbsFullSeeder.php
+++ b/database/seeders/PastSimpleRegularVerbsFullSeeder.php
@@ -11,6 +11,13 @@ use App\Models\Source;
 
 class PastSimpleRegularVerbsFullSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         $cat_past = 1;
@@ -54,29 +61,20 @@ class PastSimpleRegularVerbsFullSeeder extends Seeder
                 'flag'        => 0,
                 'source_id'   => $source1,
             ]);
-            $opt = QuestionOption::firstOrCreate([
-                'question_id' => $q->id,
-                'option'      => $past,
-            ]);
+            $opt = $this->attachOption($q, $past);
             QuestionAnswer::firstOrCreate([
                 'question_id' => $q->id,
                 'marker'      => 'a1',
                 'option_id'   => $opt->id,
             ]);
-            $hintOpt = QuestionOption::firstOrCreate([
-                'question_id' => $q->id,
-                'option'      => $inf,
-            ]);
+            $hintOpt = $this->attachOption($q, $inf);
             VerbHint::firstOrCreate([
                 'question_id' => $q->id,
                 'marker'      => 'a1',
                 'option_id'   => $hintOpt->id,
             ]);
             foreach([$past, $inf] as $optStr) {
-                QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $optStr,
-                ]);
+                $this->attachOption($q, $optStr);
             }
         }
         /*    
@@ -98,19 +96,13 @@ class PastSimpleRegularVerbsFullSeeder extends Seeder
                 'flag'        => 1,
                 'source_id'   => $source2,
             ]);
-            $opt = QuestionOption::firstOrCreate([
-                'question_id' => $q->id,
-                'option'      => $pos,
-            ]);
+            $opt = $this->attachOption($q, $pos);
             QuestionAnswer::firstOrCreate([
                 'question_id' => $q->id,
                 'marker'      => 'a1',
                 'option_id'   => $opt->id,
             ]);
-            $hintOpt = QuestionOption::firstOrCreate([
-                'question_id' => $q->id,
-                'option'      => 'make positive',
-            ]);
+            $hintOpt = $this->attachOption($q, 'make positive');
             VerbHint::firstOrCreate([
                 'question_id' => $q->id,
                 'marker'      => 'a1',
@@ -137,19 +129,13 @@ class PastSimpleRegularVerbsFullSeeder extends Seeder
                 'flag'        => 1,
                 'source_id'   => $source3,
             ]);
-            $opt = QuestionOption::firstOrCreate([
-                'question_id' => $q->id,
-                'option'      => $neg,
-            ]);
+            $opt = $this->attachOption($q, $neg);
             QuestionAnswer::firstOrCreate([
                 'question_id' => $q->id,
                 'marker'      => 'a1',
                 'option_id'   => $opt->id,
             ]);
-            $hintOpt = QuestionOption::firstOrCreate([
-                'question_id' => $q->id,
-                'option'      => 'make negative',
-            ]);
+            $hintOpt = $this->attachOption($q, 'make negative');
             VerbHint::firstOrCreate([
                 'question_id' => $q->id,
                 'marker'      => 'a1',

--- a/database/seeders/PresentPastRevisionSeeder.php
+++ b/database/seeders/PresentPastRevisionSeeder.php
@@ -11,6 +11,13 @@ use App\Models\Source;
 
 class PresentPastRevisionSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         // Категорії: 1 — Past Simple, 2 — Present Simple
@@ -184,20 +191,14 @@ class PresentPastRevisionSeeder extends Seeder
                 'source_id'   => $sourceId,
             ]);
             foreach ($data['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -207,10 +208,7 @@ class PresentPastRevisionSeeder extends Seeder
             }
             if (!empty($data['options'])) {
                 foreach ($data['options'] as $opt) {
-                    QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $opt,
-                    ]);
+                    $this->attachOption($q, $opt);
                 }
             }
         }

--- a/database/seeders/PresentSimpleExercisesSeeder.php
+++ b/database/seeders/PresentSimpleExercisesSeeder.php
@@ -12,6 +12,13 @@ use App\Models\Source;
 
 class PresentSimpleExercisesSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
@@ -189,20 +196,14 @@ class PresentSimpleExercisesSeeder extends Seeder
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -211,10 +212,7 @@ class PresentSimpleExercisesSeeder extends Seeder
                 }
             }
             foreach ($d['options'] as $opt) {
-                QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $opt,
-                ]);
+                $this->attachOption($q, $opt);
             }
         }
 
@@ -227,20 +225,14 @@ class PresentSimpleExercisesSeeder extends Seeder
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -249,10 +241,7 @@ class PresentSimpleExercisesSeeder extends Seeder
                 }
             }
             foreach ($d['options'] as $opt) {
-                QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $opt,
-                ]);
+                $this->attachOption($q, $opt);
             }
         }
     }

--- a/database/seeders/PresentSimpleSeeder.php
+++ b/database/seeders/PresentSimpleSeeder.php
@@ -10,6 +10,13 @@ use App\Models\Source;
 
 class PresentSimpleSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         $categoryId = 2; // ID категорії для Present Simple
@@ -170,10 +177,7 @@ class PresentSimpleSeeder extends Seeder
             ]);
 
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
@@ -181,10 +185,7 @@ class PresentSimpleSeeder extends Seeder
                 ]);
 
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -195,10 +196,7 @@ class PresentSimpleSeeder extends Seeder
 
             if (!empty($d['options'])) {
                 foreach ($d['options'] as $opt) {
-                    QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $opt,
-                    ]);
+                    $this->attachOption($q, $opt);
                 }
             }
         }

--- a/database/seeders/QuizPresentSimpleSeeder.php
+++ b/database/seeders/QuizPresentSimpleSeeder.php
@@ -10,6 +10,13 @@ use App\Models\Source;
 
 class QuizPresentSimpleSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         $categoryId = 2; // Present Simple
@@ -189,20 +196,14 @@ class QuizPresentSimpleSeeder extends Seeder
             ]);
 
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -213,10 +214,7 @@ class QuizPresentSimpleSeeder extends Seeder
 
             if (!empty($d['options'])) {
                 foreach ($d['options'] as $opt) {
-                    QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $opt,
-                    ]);
+                    $this->attachOption($q, $opt);
                 }
             }
         }

--- a/database/seeders/RevisionTensesFullSeeder.php
+++ b/database/seeders/RevisionTensesFullSeeder.php
@@ -12,6 +12,13 @@ use App\Models\Source;
 
 class RevisionTensesFullSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         // Категорії
@@ -466,20 +473,14 @@ class RevisionTensesFullSeeder extends Seeder
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -489,10 +490,7 @@ class RevisionTensesFullSeeder extends Seeder
             }
             if (!empty($d['options'])) {
                 foreach ($d['options'] as $opt) {
-                    QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $opt,
-                    ]);
+                    $this->attachOption($q, $opt);
                 }
             }
         }

--- a/database/seeders/ShortAnswersSeeder.php
+++ b/database/seeders/ShortAnswersSeeder.php
@@ -12,6 +12,13 @@ use App\Models\Source;
 
 class ShortAnswersSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
@@ -295,20 +302,14 @@ class ShortAnswersSeeder extends Seeder
                 'flag'        => $d['flag'],
             ]);
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],

--- a/database/seeders/SimplePresentPastSeeder.php
+++ b/database/seeders/SimplePresentPastSeeder.php
@@ -11,6 +11,13 @@ use App\Models\Source;
 
 class SimplePresentPastSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         // Категорія (створи/знайди): 2 = Present, 1 = Past
@@ -255,20 +262,14 @@ class SimplePresentPastSeeder extends Seeder
                 'source_id'   => $data['source_id'],
             ]);
             foreach ($data['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -277,10 +278,7 @@ class SimplePresentPastSeeder extends Seeder
                 }
             }
             foreach ($data['options'] as $opt) {
-                QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $opt,
-                ]);
+                $this->attachOption($q, $opt);
             }
         }
     }

--- a/database/seeders/ThisThatTheseThoseExercise2Seeder.php
+++ b/database/seeders/ThisThatTheseThoseExercise2Seeder.php
@@ -12,6 +12,13 @@ use App\Models\Source;
 
 class ThisThatTheseThoseExercise2Seeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
@@ -80,10 +87,7 @@ class ThisThatTheseThoseExercise2Seeder extends Seeder
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
@@ -91,10 +95,7 @@ class ThisThatTheseThoseExercise2Seeder extends Seeder
                 ]);
             }
             foreach ($d['options'] as $opt) {
-                QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $opt,
-                ]);
+                $this->attachOption($q, $opt);
             }
         }
     }

--- a/database/seeders/ThisThatTheseThoseExercise3Seeder.php
+++ b/database/seeders/ThisThatTheseThoseExercise3Seeder.php
@@ -12,6 +12,13 @@ use App\Models\Source;
 
 class ThisThatTheseThoseExercise3Seeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
@@ -80,10 +87,7 @@ class ThisThatTheseThoseExercise3Seeder extends Seeder
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
@@ -91,10 +95,7 @@ class ThisThatTheseThoseExercise3Seeder extends Seeder
                 ]);
             }
             foreach ($d['options'] as $opt) {
-                QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $opt,
-                ]);
+                $this->attachOption($q, $opt);
             }
         }
     }

--- a/database/seeders/ThisThatTheseThoseSeeder.php
+++ b/database/seeders/ThisThatTheseThoseSeeder.php
@@ -12,6 +12,13 @@ use App\Models\Source;
 
 class ThisThatTheseThoseSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         $cat_present = Category::firstOrCreate(['name' => 'present'])->id;
@@ -80,20 +87,14 @@ class ThisThatTheseThoseSeeder extends Seeder
                 'flag'        => 0,
             ]);
             foreach ($d['answers'] as $ans) {
-                $option = QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -102,10 +103,7 @@ class ThisThatTheseThoseSeeder extends Seeder
                 }
             }
             foreach ($d['options'] as $opt) {
-                QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $opt,
-                ]);
+                $this->attachOption($q, $opt);
             }
         }
     }

--- a/database/seeders/ToBeTenseSeeder.php
+++ b/database/seeders/ToBeTenseSeeder.php
@@ -11,6 +11,13 @@ use App\Models\Source;
 
 class ToBeTenseSeeder extends Seeder
 {
+    private function attachOption(Question $question, string $value)
+    {
+        $option = QuestionOption::firstOrCreate(['option' => $value]);
+        $question->options()->syncWithoutDetaching($option->id);
+        return $option;
+    }
+
     public function run()
     {
         // Категорії
@@ -372,20 +379,14 @@ class ToBeTenseSeeder extends Seeder
             ]);
 
             foreach ($d['answers'] as $ans) {
-                $option = \App\Models\QuestionOption::firstOrCreate([
-                    'question_id' => $q->id,
-                    'option'      => $ans['answer'],
-                ]);
+                $option = $this->attachOption($q, $ans['answer']);
                 \App\Models\QuestionAnswer::firstOrCreate([
                     'question_id' => $q->id,
                     'marker'      => $ans['marker'],
                     'option_id'   => $option->id,
                 ]);
                 if (!empty($ans['verb_hint'])) {
-                    $hintOption = \App\Models\QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $ans['verb_hint'],
-                    ]);
+                    $hintOption = $this->attachOption($q, $ans['verb_hint']);
                     \App\Models\VerbHint::firstOrCreate([
                         'question_id' => $q->id,
                         'marker'      => $ans['marker'],
@@ -396,10 +397,7 @@ class ToBeTenseSeeder extends Seeder
 
             if (!empty($d['options'])) {
                 foreach ($d['options'] as $opt) {
-                    \App\Models\QuestionOption::firstOrCreate([
-                        'question_id' => $q->id,
-                        'option'      => $opt,
-                    ]);
+                    $this->attachOption($q, $opt);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- normalize question_options and use pivot table
- update models for belongsToMany relationship
- revise seeders to work with new structure
- add migrations for pivot and unique options

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688603003ac0832aa90c24f6e02fb43d