### PR TITLE
Add question numbers and tag links

### DIFF
--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -45,7 +45,7 @@ class GrammarTestController extends Controller
     public function showSavedTest($slug)
     {
         $test = \App\Models\Test::where('slug', $slug)->firstOrFail();
-        $questions = \App\Models\Question::with(['category', 'answers.option', 'options', 'verbHints.option'])
+        $questions = \App\Models\Question::with(['category', 'answers.option', 'options', 'verbHints.option', 'tags'])
             ->whereIn('id', $test->questions)
             ->get();
             $manualInput = !empty($test->filters['manual_input']);

--- a/resources/views/grammar-test.blade.php
+++ b/resources/views/grammar-test.blade.php
@@ -163,7 +163,7 @@
                 <div class="bg-white shadow rounded-2xl p-4 mb-4">
                     <div class="mb-2 flex items-center justify-between">
                         <span class="text-base font-bold">
-                            Категорія:
+                            {{ $loop->iteration }}. Категорія:
                             <span class="uppercase px-2 py-1 rounded text-xs 
                                 {{ $q->category->name === 'past' ? 'bg-red-100 text-red-700' : ($q->category->name === 'present' ? 'bg-blue-100 text-blue-700' : 'bg-green-100 text-green-700') }}">
                                 {{ ucfirst($q->category->name) }}
@@ -179,7 +179,7 @@
                         @if($q->tags->count())
                             <span class="ml-2 text-xs text-gray-600">
                                 @foreach($q->tags as $tag)
-                                    {{ $tag->name }}@if(!$loop->last),@endif
+                                    <a href="{{ route('saved-tests.cards', ['tag' => $tag->name]) }}" class="hover:underline">{{ $tag->name }}</a>@if(!$loop->last),@endif
                                 @endforeach
                             </span>
                         @endif

--- a/resources/views/saved-test.blade.php
+++ b/resources/views/saved-test.blade.php
@@ -19,6 +19,16 @@
         @foreach($questions as $q)
             <input type="hidden" name="questions[{{ $q->id }}]" value="1">
             <div class="bg-white shadow rounded-2xl p-4 mb-4">
+                <div class="mb-2 flex items-center justify-between">
+                    <span class="font-bold text-base">{{ $loop->iteration }}.</span>
+                    @if($q->tags->count())
+                        <span class="ml-2 text-xs text-gray-600">
+                            @foreach($q->tags as $tag)
+                                <a href="{{ route('saved-tests.cards', ['tag' => $tag->name]) }}" class="hover:underline">{{ $tag->name }}</a>@if(!$loop->last),@endif
+                            @endforeach
+                        </span>
+                    @endif
+                </div>
                 <div class="flex flex-wrap gap-2">
                     @php
                         $questionText = $q->question;


### PR DESCRIPTION
## Summary
- number questions on the grammar test page
- show clickable tags per question on grammar and saved test views
- eager load tags for saved tests

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688694e5a628832a8dd221bc8f3481f3