### PR TITLE
Implement tag categories and group filter

### DIFF
--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -56,6 +56,10 @@ class GrammarTestController extends Controller
             'questions' => $questions,
             'manualInput' => $manualInput,
             'autocompleteInput' => $autocompleteInput,
+            'breadcrumbs' => [
+                ['label' => 'Tests Catalog', 'url' => route('saved-tests.cards')],
+                ['label' => $test->name],
+            ],
         ]);
     }
 
@@ -80,7 +84,11 @@ class GrammarTestController extends Controller
             'categories', 'minDifficulty', 'maxDifficulty', 'maxQuestions',
             'selectedCategories', 'difficultyFrom', 'difficultyTo', 'numQuestions',
             'manualInput', 'autocompleteInput', 'checkOneInput', 'questions'
-        ));
+        ) + [
+            'breadcrumbs' => [
+                ['label' => 'Grammar Test'],
+            ],
+        ]);
     }
 
     public function generate(Request $request)
@@ -178,7 +186,11 @@ class GrammarTestController extends Controller
             'includeAi', 'onlyAi', 'questions',
             'sources', 'selectedSources', 'autoTestName',
             'allTags', 'selectedTags'
-        ));
+        ) + [
+            'breadcrumbs' => [
+                ['label' => 'Grammar Test'],
+            ],
+        ]);
     }
     
     public function destroy(\App\Models\Test $test)
@@ -250,6 +262,9 @@ class GrammarTestController extends Controller
             'maxQuestions' => $maxQuestions,
             'allTags' => $allTags,
             'selectedTags' => $selectedTags,
+            'breadcrumbs' => [
+                ['label' => 'Grammar Test'],
+            ],
         ]);
     }
 
@@ -281,13 +296,24 @@ class GrammarTestController extends Controller
             ];
         }
 
-        return view('grammar-test-result', compact('results'));
+        return view('grammar-test-result', [
+            'results' => $results,
+            'breadcrumbs' => [
+                ['label' => 'Grammar Test', 'url' => route('grammar-test')],
+                ['label' => 'Result'],
+            ],
+        ]);
     }
 
     public function list()
     {
         $tests = \App\Models\Test::latest()->paginate(20); // пагінація, якщо тестів багато
-        return view('saved-tests', compact('tests'));
+        return view('saved-tests', [
+            'tests' => $tests,
+            'breadcrumbs' => [
+                ['label' => 'Saved Tests'],
+            ],
+        ]);
     }
 
     public function catalog(Request $request)
@@ -323,6 +349,9 @@ class GrammarTestController extends Controller
             'tests' => $tests,
             'tags' => $availableTags,
             'selectedTags' => $selectedTags,
+            'breadcrumbs' => [
+                ['label' => 'Tests Catalog'],
+            ],
         ]);
     }
     

--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -305,7 +305,10 @@ class GrammarTestController extends Controller
             $test->tag_names = $tagNames->unique()->values();
         }
 
-        $availableTags = $tests->flatMap(fn($t) => $t->tag_names)->unique()->values();
+        $availableTagNames = $tests->flatMap(fn($t) => $t->tag_names)->unique()->values();
+        $availableTags = \App\Models\Tag::with('category')
+            ->whereIn('name', $availableTagNames)
+            ->get();
 
         if ($selectedTag) {
             $tests = $tests->filter(fn($t) => $t->tag_names->contains($selectedTag))->values();

--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -292,7 +292,10 @@ class GrammarTestController extends Controller
 
     public function catalog(Request $request)
     {
-        $selectedTag = $request->input('tag');
+        $selectedTags = $request->input('tags', []);
+        if (empty($selectedTags) && $request->filled('tag')) {
+            $selectedTags = [$request->input('tag')];
+        }
 
         $tests = \App\Models\Test::latest()->get();
 
@@ -310,14 +313,16 @@ class GrammarTestController extends Controller
             ->whereIn('name', $availableTagNames)
             ->get();
 
-        if ($selectedTag) {
-            $tests = $tests->filter(fn($t) => $t->tag_names->contains($selectedTag))->values();
+        if ($selectedTags) {
+            $tests = $tests->filter(function ($t) use ($selectedTags) {
+                return collect($selectedTags)->every(fn($tag) => $t->tag_names->contains($tag));
+            })->values();
         }
 
         return view('saved-tests-cards', [
             'tests' => $tests,
             'tags' => $availableTags,
-            'selectedTag' => $selectedTag,
+            'selectedTags' => $selectedTags,
         ]);
     }
     

--- a/app/Http/Controllers/WordsTestController.php
+++ b/app/Http/Controllers/WordsTestController.php
@@ -62,6 +62,9 @@ class WordsTestController extends Controller
                 'totalCount' => $totalCount,
                 'selectedTags' => $selectedTags,
                 'allTags' => Tag::whereHas('words')->get(),
+                'breadcrumbs' => [
+                    ['label' => 'Words Test'],
+                ],
             ]);
         }
 
@@ -101,6 +104,9 @@ class WordsTestController extends Controller
             'totalCount' => $totalCount,
             'selectedTags' => $selectedTags,
             'allTags' => Tag::whereHas('words')->get(),
+            'breadcrumbs' => [
+                ['label' => 'Words Test'],
+            ],
         ]);
     }
 

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Tag extends Model
 {
-    protected $fillable = ['name'];
+    protected $fillable = ['name', 'tag_category_id'];
 
     public function words()
     {
@@ -16,5 +16,10 @@ class Tag extends Model
     public function questions()
     {
         return $this->belongsToMany(Question::class);
+    }
+
+    public function category()
+    {
+        return $this->belongsTo(TagCategory::class, 'tag_category_id');
     }
 }

--- a/app/Models/TagCategory.php
+++ b/app/Models/TagCategory.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TagCategory extends Model
+{
+    protected $fillable = ['name'];
+
+    public function tags()
+    {
+        return $this->hasMany(Tag::class);
+    }
+}

--- a/database/migrations/2025_08_01_000001_create_tag_categories_table.php
+++ b/database/migrations/2025_08_01_000001_create_tag_categories_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('tag_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tag_categories');
+    }
+};

--- a/database/migrations/2025_08_01_000002_add_tag_category_id_to_tags_table.php
+++ b/database/migrations/2025_08_01_000002_add_tag_category_id_to_tags_table.php
@@ -1,0 +1,23 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->foreignId('tag_category_id')
+                ->nullable()
+                ->after('name')
+                ->constrained('tag_categories');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('tag_category_id');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -25,6 +25,7 @@ class DatabaseSeeder extends Seeder
         }
 
         $this->call([
+            TagCategorySeeder::class,
             TenseTagsSeeder::class,
             DoDoesIsAreSeeder::class,
             FutureSimpleTest1Seeder::class,

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -48,6 +48,7 @@ class DatabaseSeeder extends Seeder
             WordsWithTranslationsSeeder::class,
             PronounWordsSeeder::class,
             QuestionTenseAssignmentSeeder::class,
+            TestsSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PronounWordsSeeder.php
+++ b/database/seeders/PronounWordsSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Tag;
+use App\Models\TagCategory;
 use App\Models\Translate;
 use App\Models\Word;
 use Illuminate\Database\Seeder;
@@ -61,10 +62,11 @@ class PronounWordsSeeder extends Seeder
         ];
 
         DB::transaction(function () use ($pronouns) {
-            $pronounTag = Tag::firstOrCreate(['name' => 'pronouns']);
+            $category = TagCategory::firstOrCreate(['name' => 'Words']);
+            $pronounTag = Tag::firstOrCreate(['name' => 'pronouns'], ['tag_category_id' => $category->id]);
 
             foreach ($pronouns as $group => $items) {
-                $groupTag = Tag::firstOrCreate(['name' => $group]);
+                $groupTag = Tag::firstOrCreate(['name' => $group], ['tag_category_id' => $category->id]);
 
                 foreach ($items as $item) {
                     $word = Word::firstOrCreate(['word' => $item['en']]);

--- a/database/seeders/QuestionTenseAssignmentSeeder.php
+++ b/database/seeders/QuestionTenseAssignmentSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use App\Models\Question;
 use App\Models\Tag;
+use App\Models\TagCategory;
 
 class QuestionTenseAssignmentSeeder extends Seeder
 {
@@ -51,7 +52,8 @@ class QuestionTenseAssignmentSeeder extends Seeder
                 $tagName = 'Present Simple';
             }
 
-            $tag = Tag::firstOrCreate(['name' => $tagName]);
+            $category = TagCategory::firstOrCreate(['name' => 'Tenses']);
+            $tag = Tag::firstOrCreate(['name' => $tagName], ['tag_category_id' => $category->id]);
             $q->tags()->syncWithoutDetaching([$tag->id]);
         }
     }

--- a/database/seeders/TagCategorySeeder.php
+++ b/database/seeders/TagCategorySeeder.php
@@ -1,0 +1,15 @@
+<?php
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\TagCategory;
+
+class TagCategorySeeder extends Seeder
+{
+    public function run(): void
+    {
+        foreach (['Tenses', 'Words'] as $name) {
+            TagCategory::firstOrCreate(['name' => $name]);
+        }
+    }
+}

--- a/database/seeders/TenseTagsSeeder.php
+++ b/database/seeders/TenseTagsSeeder.php
@@ -3,6 +3,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\Tag;
+use App\Models\TagCategory;
 
 class TenseTagsSeeder extends Seeder
 {
@@ -23,8 +24,14 @@ class TenseTagsSeeder extends Seeder
             'Future Perfect Continuous',
         ];
 
+        $category = TagCategory::firstOrCreate(['name' => 'Tenses']);
+
         foreach ($tenses as $name) {
-            Tag::firstOrCreate(['name' => $name]);
+            Tag::firstOrCreate([
+                'name' => $name
+            ], [
+                'tag_category_id' => $category->id
+            ]);
         }
     }
 }

--- a/database/seeders/TestsSeeder.php
+++ b/database/seeders/TestsSeeder.php
@@ -1,0 +1,17 @@
+<?php
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+
+class TestsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $path = storage_path('tests.sql');
+        if (File::exists($path)) {
+            DB::unprepared(File::get($path));
+        }
+    }
+}

--- a/database/seeders/WordsWithTranslationsSeeder.php
+++ b/database/seeders/WordsWithTranslationsSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Tag;
+use App\Models\TagCategory;
 use App\Models\Translate;
 use App\Models\Word;
 use Illuminate\Database\Seeder;
@@ -18,7 +19,10 @@ class WordsWithTranslationsSeeder extends Seeder
 
         DB::beginTransaction();
         try {
-            $popularTag = Tag::firstOrCreate(['name' => '1000_most_popular']);
+            $category = TagCategory::firstOrCreate(['name' => 'Words']);
+            $popularTag = Tag::firstOrCreate(['name' => '1000_most_popular'], [
+                'tag_category_id' => $category->id,
+            ]);
             foreach ($rows as $row) {
                 $en = trim($row[0]);
                 $uk = trim($row[1]);

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -78,6 +78,23 @@
     </script>
     <!-- Контент -->
     <main class="flex-1 container mx-auto px-4">
+        @isset($breadcrumbs)
+            <nav class="text-sm text-gray-500 mb-4" aria-label="Breadcrumb">
+                <ol class="list-reset flex">
+                    <li><a href="{{ route('home') }}" class="text-blue-600 hover:underline">Home</a></li>
+                    @foreach($breadcrumbs as $crumb)
+                        <li class="mx-2">/</li>
+                        <li>
+                            @if(isset($crumb['url']))
+                                <a href="{{ $crumb['url'] }}" class="text-blue-600 hover:underline">{{ $crumb['label'] }}</a>
+                            @else
+                                <span>{{ $crumb['label'] }}</span>
+                            @endif
+                        </li>
+                    @endforeach
+                </ol>
+            </nav>
+        @endisset
         @yield('content')
     </main>
 

--- a/resources/views/saved-tests-cards.blade.php
+++ b/resources/views/saved-tests-cards.blade.php
@@ -6,15 +6,18 @@
 <div class="flex gap-6">
     <aside class="w-48 shrink-0">
         <h2 class="text-lg font-bold mb-2">Теги</h2>
-        <ul class="space-y-1 text-sm">
-            @foreach($tags as $tag)
-                <li>
-                    <a href="{{ route('saved-tests.cards', ['tag' => $tag]) }}" class="{{ $selectedTag === $tag ? 'text-blue-700 font-semibold' : 'text-blue-600 hover:underline' }}">
-                        {{ $tag }}
-                    </a>
-                </li>
-            @endforeach
-        </ul>
+        @foreach($tags->groupBy(fn($t) => optional($t->category)->name ?? 'Other') as $catName => $group)
+            <div class="mb-1 font-semibold">{{ $catName }}</div>
+            <ul class="space-y-1 text-sm mb-2">
+                @foreach($group as $tag)
+                    <li>
+                        <a href="{{ route('saved-tests.cards', ['tag' => $tag->name]) }}" class="{{ $selectedTag === $tag->name ? 'text-blue-700 font-semibold' : 'text-blue-600 hover:underline' }}">
+                            {{ $tag->name }}
+                        </a>
+                    </li>
+                @endforeach
+            </ul>
+        @endforeach
         @if($selectedTag)
             <div class="mt-2">
                 <a href="{{ route('saved-tests.cards') }}" class="text-xs text-gray-500 hover:underline">Скинути фільтр</a>

--- a/resources/views/saved-tests-cards.blade.php
+++ b/resources/views/saved-tests-cards.blade.php
@@ -19,6 +19,7 @@
                                 id="tag-{{ $tag->id }}"
                                 class="hidden peer"
                                 {{ in_array($tag->name, $selectedTags) ? 'checked' : '' }}
+                                onchange="this.form.submit()"
                             >
                             <label for="tag-{{ $tag->id }}" class="px-3 py-1 rounded border cursor-pointer text-sm bg-gray-200 peer-checked:bg-blue-600 peer-checked:text-white">
                                 {{ $tag->name }}
@@ -27,12 +28,11 @@
                     @endforeach
                 </div>
             @endforeach
-            <div class="flex gap-2 mt-2">
-                <button type="submit" class="bg-green-600 text-white px-3 py-1 rounded text-sm hover:bg-green-700">Застосувати</button>
-                @if(count($selectedTags))
+            @if(count($selectedTags))
+                <div class="mt-2">
                     <a href="{{ route('saved-tests.cards') }}" class="bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700">Скинути</a>
-                @endif
-            </div>
+                </div>
+            @endif
         </form>
     </aside>
     <div class="flex-1">

--- a/resources/views/saved-tests-cards.blade.php
+++ b/resources/views/saved-tests-cards.blade.php
@@ -6,23 +6,34 @@
 <div class="flex gap-6">
     <aside class="w-48 shrink-0">
         <h2 class="text-lg font-bold mb-2">Теги</h2>
-        @foreach($tags->groupBy(fn($t) => optional($t->category)->name ?? 'Other') as $catName => $group)
-            <div class="mb-1 font-semibold">{{ $catName }}</div>
-            <ul class="space-y-1 text-sm mb-2">
-                @foreach($group as $tag)
-                    <li>
-                        <a href="{{ route('saved-tests.cards', ['tag' => $tag->name]) }}" class="{{ $selectedTag === $tag->name ? 'text-blue-700 font-semibold' : 'text-blue-600 hover:underline' }}">
-                            {{ $tag->name }}
-                        </a>
-                    </li>
-                @endforeach
-            </ul>
-        @endforeach
-        @if($selectedTag)
-            <div class="mt-2">
-                <a href="{{ route('saved-tests.cards') }}" class="text-xs text-gray-500 hover:underline">Скинути фільтр</a>
+        <form method="GET" action="{{ route('saved-tests.cards') }}">
+            @foreach($tags->groupBy(fn($t) => optional($t->category)->name ?? 'Other') as $catName => $group)
+                <div class="mb-1 font-semibold">{{ $catName }}</div>
+                <div class="flex flex-wrap gap-2 mb-2">
+                    @foreach($group as $tag)
+                        <div>
+                            <input
+                                type="checkbox"
+                                name="tags[]"
+                                value="{{ $tag->name }}"
+                                id="tag-{{ $tag->id }}"
+                                class="hidden peer"
+                                {{ in_array($tag->name, $selectedTags) ? 'checked' : '' }}
+                            >
+                            <label for="tag-{{ $tag->id }}" class="px-3 py-1 rounded border cursor-pointer text-sm bg-gray-200 peer-checked:bg-blue-600 peer-checked:text-white">
+                                {{ $tag->name }}
+                            </label>
+                        </div>
+                    @endforeach
+                </div>
+            @endforeach
+            <div class="flex gap-2 mt-2">
+                <button type="submit" class="bg-green-600 text-white px-3 py-1 rounded text-sm hover:bg-green-700">Застосувати</button>
+                @if(count($selectedTags))
+                    <a href="{{ route('saved-tests.cards') }}" class="bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700">Скинути</a>
+                @endif
             </div>
-        @endif
+        </form>
     </aside>
     <div class="flex-1">
         @if($tests->count())

--- a/tests/Feature/PronounsTestTest.php
+++ b/tests/Feature/PronounsTestTest.php
@@ -15,6 +15,8 @@ class PronounsTestTest extends TestCase
         Artisan::call('migrate', ['--path' => 'database/migrations/2025_07_31_000001_update_translates_unique_index.php']);
         Artisan::call('migrate', ['--path' => 'database/migrations/2025_07_30_000001_create_tags_table.php']);
         Artisan::call('migrate', ['--path' => 'database/migrations/2025_07_30_000002_create_tag_word_table.php']);
+        Artisan::call('migrate', ['--path' => 'database/migrations/2025_08_01_000001_create_tag_categories_table.php']);
+        Artisan::call('migrate', ['--path' => 'database/migrations/2025_08_01_000002_add_tag_category_id_to_tags_table.php']);
 
         $this->seed(\Database\Seeders\PronounWordsSeeder::class);
 


### PR DESCRIPTION
## Summary
- introduce tag category model and migrations
- seed default categories for tags
- link tags with categories in seeders
- group test catalog tags by category
- adapt tests to new migrations

## Testing
- `composer install --no-interaction --no-progress --no-scripts`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68874a8d646c832a997662d67ce97ace