### PR TITLE
Add question review flow

### DIFF
--- a/app/Http/Controllers/QuestionReviewController.php
+++ b/app/Http/Controllers/QuestionReviewController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Question;
+use App\Models\Tag;
+use App\Models\QuestionReviewResult;
+
+class QuestionReviewController extends Controller
+{
+    public function index()
+    {
+        $reviewed = session('reviewed_questions', []);
+
+        $question = Question::with(['options', 'answers', 'tags'])
+            ->whereNotIn('id', $reviewed)
+            ->inRandomOrder()
+            ->first();
+
+        if (! $question) {
+            return view('question-review-complete');
+        }
+
+        $allTags = Tag::orderBy('name')->get();
+
+        return view('question-review', [
+            'question' => $question,
+            'allTags' => $allTags,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'question_id' => 'required|exists:questions,id',
+        ]);
+
+        $question = Question::with('tags', 'answers')->findOrFail($request->input('question_id'));
+
+        $answers = [];
+        foreach ($question->answers as $ans) {
+            $default = $ans->option->option ?? $ans->answer;
+            $answers[$ans->marker] = $request->input('answers.'.$ans->marker, $default);
+        }
+
+        $tags = $request->input('tags', []);
+        $question->tags()->sync($tags);
+
+        QuestionReviewResult::create([
+            'question_id' => $question->id,
+            'answers' => $answers,
+            'tags' => $tags,
+        ]);
+
+        $reviewed = session('reviewed_questions', []);
+        $reviewed[] = $question->id;
+        session(['reviewed_questions' => $reviewed]);
+
+        return redirect()->route('question-review.index');
+    }
+}

--- a/app/Models/QuestionReviewResult.php
+++ b/app/Models/QuestionReviewResult.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class QuestionReviewResult extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'question_id',
+        'answers',
+        'tags',
+    ];
+
+    protected $casts = [
+        'answers' => 'array',
+        'tags' => 'array',
+    ];
+}

--- a/database/migrations/2025_07_28_112705_create_question_review_results_table.php
+++ b/database/migrations/2025_07_28_112705_create_question_review_results_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('question_review_results', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('question_id')->constrained('questions')->cascadeOnDelete();
+            $table->json('answers');
+            $table->json('tags')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('question_review_results');
+    }
+};

--- a/resources/views/question-review-complete.blade.php
+++ b/resources/views/question-review-complete.blade.php
@@ -1,0 +1,10 @@
+@extends('layouts.app')
+
+@section('title', 'Review Complete')
+
+@section('content')
+<div class="max-w-3xl mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">Всі питання переглянуто</h1>
+    <a href="{{ route('question-review.index') }}" class="text-blue-600 underline">Почати спочатку</a>
+</div>
+@endsection

--- a/resources/views/question-review.blade.php
+++ b/resources/views/question-review.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.app')
+
+@section('title', 'Question Review')
+
+@section('content')
+<div class="max-w-3xl mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">Перевірка питань</h1>
+    <form method="POST" action="{{ route('question-review.store') }}" class="space-y-4">
+        @csrf
+        <input type="hidden" name="question_id" value="{{ $question->id }}">
+        <div class="bg-white shadow rounded-2xl p-4">
+            @php
+                $text = $question->question;
+                preg_match_all('/\{a(\d+)\}/', $text, $m);
+                $repl = [];
+                foreach($m[0] as $i => $marker){
+                    $num = $m[1][$i];
+                    $key = 'a'.$num;
+                    $answer = $question->answers->where('marker', $key)->first();
+                    $current = $answer?->option?->option ?? $answer?->answer;
+                    $select = '<select name="answers['.$key.']" class="border rounded px-2 py-1">';
+                    foreach($question->options as $opt){
+                        $sel = $opt->option === $current ? 'selected' : '';
+                        $select .= '<option value="'.$opt->option.'" '.$sel.'>'.$opt->option.'</option>';
+                    }
+                    $select .= '</select>';
+                    $repl[$marker] = $select;
+                }
+                echo strtr(e($text), $repl);
+            @endphp
+        </div>
+        <div class="bg-white shadow rounded-2xl p-4">
+            <div class="font-semibold mb-2">Теги:</div>
+            <div class="flex flex-wrap gap-2">
+                @foreach($allTags as $tag)
+                    <label class="inline-flex items-center">
+                        <input type="checkbox" name="tags[]" value="{{ $tag->id }}" class="mr-1" {{ $question->tags->contains($tag->id) ? 'checked' : '' }}>
+                        <span>{{ $tag->name }}</span>
+                    </label>
+                @endforeach
+            </div>
+        </div>
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Next</button>
+    </form>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,3 +52,7 @@ Route::get('/test/{slug}', [GrammarTestController::class, 'showSavedTest'])->nam
 Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
 Route::delete('/tests/{test}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
 Route::get('/tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('saved-tests.cards');
+
+use App\Http\Controllers\QuestionReviewController;
+Route::get('/question-review', [QuestionReviewController::class, 'index'])->name('question-review.index');
+Route::post('/question-review', [QuestionReviewController::class, 'store'])->name('question-review.store');

--- a/tests/Feature/QuestionReviewTest.php
+++ b/tests/Feature/QuestionReviewTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+use App\Models\{Category, Question, QuestionOption, QuestionAnswer, Tag};
+
+class QuestionReviewTest extends TestCase
+{
+    /** @test */
+    public function question_review_flow(): void
+    {
+        $migrations = [
+            '2025_07_20_143201_create_categories_table.php',
+            '2025_07_20_143210_create_quastion_table.php',
+            '2025_07_20_143230_create_quastion_options_table.php',
+            '2025_07_20_143243_create_quastion_answers_table.php',
+            '2025_07_20_164021_add_verb_hint_to_question_answers.php',
+            '2025_07_20_180521_add_flag_to_question_table.php',
+            '2025_07_20_193626_add_source_to_qustion_table.php',
+            '2025_07_27_000001_add_unique_index_to_question_answers.php',
+            '2025_07_28_000002_create_verb_hints_table.php',
+            '2025_07_29_000001_create_question_option_question_table.php',
+            '2025_07_30_000001_create_tags_table.php',
+            '2025_07_30_000003_create_question_tag_table.php',
+            '2025_07_28_112705_create_question_review_results_table.php',
+        ];
+        foreach ($migrations as $file) {
+            Artisan::call('migrate', ['--path' => 'database/migrations/' . $file]);
+        }
+
+        \Illuminate\Support\Facades\Schema::table('question_option_question', function ($table) {
+            $table->tinyInteger('flag')->nullable()->after('option_id');
+        });
+
+        $category = Category::create(['name' => 'test']);
+        $question = Question::create([
+            'question' => 'Choose {a1}',
+            'difficulty' => 1,
+            'category_id' => $category->id,
+        ]);
+        $opt1 = new QuestionOption(['option' => 'yes']);
+        $opt1->question_id = $question->id;
+        $opt1->save();
+        $opt2 = new QuestionOption(['option' => 'no']);
+        $opt2->question_id = $question->id;
+        $opt2->save();
+        $question->options()->attach($opt1->id);
+        $question->options()->attach($opt2->id);
+        $qa = new QuestionAnswer(['marker' => 'a1']);
+        $qa->question_id = $question->id;
+        $qa->answer = 'yes';
+        $qa->save();
+        $tag = Tag::create(['name' => 'tag1']);
+        $question->tags()->attach($tag->id);
+
+        $response = $this->get('/question-review');
+        $response->assertStatus(200);
+
+        $response = $this->post('/question-review', [
+            'question_id' => $question->id,
+            'answers' => ['a1' => 'yes'],
+            'tags' => [$tag->id],
+        ]);
+        $response->assertRedirect('/question-review');
+
+        $this->assertDatabaseHas('question_review_results', [
+            'question_id' => $question->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add QuestionReviewController and model for storing results
- create migration for question_review_results table
- create simple review views to iterate through questions
- register routes
- add feature test for question review

## Testing
- `./vendor/bin/phpunit --testsuite Feature`

------
https://chatgpt.com/codex/tasks/task_e_68875e264480832a999221301c44fc8c