### PR TITLE
Add tests seeder and tag categories

### DIFF
--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -10,6 +10,7 @@ use App\Models\QuestionAnswer;
 use App\Models\Source;
 use Illuminate\Support\Str;
 use App\Models\Test;
+use App\Models\Tag;
 
 class GrammarTestController extends Controller
 {
@@ -312,13 +313,17 @@ class GrammarTestController extends Controller
 
         $availableTags = $tests->flatMap(fn($t) => $t->tag_names)->unique()->values();
 
+        $tagModels = Tag::whereIn('name', $availableTags)->get();
+        $tagsByCategory = $tagModels->groupBy(fn($t) => $t->category ?? 'Other')
+            ->map(fn($group) => $group->pluck('name')->sort()->values());
+
         if ($selectedTag) {
             $tests = $tests->filter(fn($t) => $t->tag_names->contains($selectedTag))->values();
         }
 
         return view('saved-tests-cards', [
             'tests' => $tests,
-            'tags' => $availableTags,
+            'tags' => $tagsByCategory,
             'selectedTag' => $selectedTag,
         ]);
     }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Tag extends Model
 {
-    protected $fillable = ['name'];
+    protected $fillable = ['name', 'category'];
 
     public function words()
     {

--- a/database/migrations/2025_08_01_000001_add_category_to_tags_table.php
+++ b/database/migrations/2025_08_01_000001_add_category_to_tags_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->string('category')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->dropColumn('category');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -46,6 +46,7 @@ class DatabaseSeeder extends Seeder
             ToBeTenseSeeder::class,
             WordsWithTranslationsSeeder::class,
             PronounWordsSeeder::class,
+            TestsSqlSeeder::class,
             QuestionTenseAssignmentSeeder::class,
         ]);
     }

--- a/database/seeders/TenseTagsSeeder.php
+++ b/database/seeders/TenseTagsSeeder.php
@@ -24,7 +24,10 @@ class TenseTagsSeeder extends Seeder
         ];
 
         foreach ($tenses as $name) {
-            Tag::firstOrCreate(['name' => $name]);
+            Tag::firstOrCreate(
+                ['name' => $name],
+                ['category' => 'Tenses']
+            );
         }
     }
 }

--- a/database/seeders/TestsSqlSeeder.php
+++ b/database/seeders/TestsSqlSeeder.php
@@ -1,0 +1,32 @@
+<?php
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class TestsSqlSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $path = storage_path('tests.sql');
+        if (!file_exists($path)) {
+            return;
+        }
+
+        $lines = file($path);
+        $collect = false;
+        $sql = '';
+        foreach ($lines as $line) {
+            if (str_contains($line, 'INSERT INTO `tests`')) {
+                $collect = true;
+            }
+            if ($collect) {
+                $sql .= $line;
+            }
+        }
+
+        if ($sql) {
+            DB::unprepared($sql);
+        }
+    }
+}

--- a/resources/views/saved-tests-cards.blade.php
+++ b/resources/views/saved-tests-cards.blade.php
@@ -5,16 +5,18 @@
 @section('content')
 <div class="flex gap-6">
     <aside class="w-48 shrink-0">
-        <h2 class="text-lg font-bold mb-2">Теги</h2>
-        <ul class="space-y-1 text-sm">
-            @foreach($tags as $tag)
-                <li>
-                    <a href="{{ route('saved-tests.cards', ['tag' => $tag]) }}" class="{{ $selectedTag === $tag ? 'text-blue-700 font-semibold' : 'text-blue-600 hover:underline' }}">
-                        {{ $tag }}
-                    </a>
-                </li>
-            @endforeach
-        </ul>
+        @foreach($tags as $category => $tagNames)
+            <h3 class="text-lg font-bold mb-2">{{ $category }}</h3>
+            <ul class="space-y-1 text-sm mb-4">
+                @foreach($tagNames as $tag)
+                    <li>
+                        <a href="{{ route('saved-tests.cards', ['tag' => $tag]) }}" class="{{ $selectedTag === $tag ? 'text-blue-700 font-semibold' : 'text-blue-600 hover:underline' }}">
+                            {{ $tag }}
+                        </a>
+                    </li>
+                @endforeach
+            </ul>
+        @endforeach
         @if($selectedTag)
             <div class="mt-2">
                 <a href="{{ route('saved-tests.cards') }}" class="text-xs text-gray-500 hover:underline">Скинути фільтр</a>


### PR DESCRIPTION
## Summary
- seed tests from `storage/tests.sql`
- add a `category` column to tags
- group tags by category (Tenses) in test catalog sidebar

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6887e4be77c4832aa98e0a0074406cb5