### PR TITLE
Add ChatGPT response caching with language settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ APP_URL=http://localhost
 
 # Your OpenAI API key
 CHAT_GPT_API_KEY=sk-your-api-key
+CHAT_GPT_LANGUAGE=uk

--- a/app/Models/ChatGPTExplanation.php
+++ b/app/Models/ChatGPTExplanation.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ChatGPTExplanation extends Model
+{
+    protected $fillable = [
+        'question',
+        'wrong_answer',
+        'correct_answer',
+        'language',
+        'explanation',
+    ];
+}

--- a/app/Services/ChatGPTService.php
+++ b/app/Services/ChatGPTService.php
@@ -3,20 +3,32 @@
 namespace App\Services;
 
 use Exception;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use App\Models\ChatGPTExplanation;
 
 class ChatGPTService
 {
-    public function explainWrongAnswer(string $question, string $wrongAnswer, string $correctAnswer): string
+    public function explainWrongAnswer(string $question, string $wrongAnswer, string $correctAnswer, ?string $lang = null): string
     {
         $key = config('services.chatgpt.key');
         if (empty($key)) {
             Log::warning('ChatGPT API key not configured');
-           return '';
-       }
+            return '';
+        }
 
-        $prompt = "Question: {$question}\nWrong answer: {$wrongAnswer}\nCorrect answer: {$correctAnswer}\nExplain in 1-2 sentences why the wrong answer is incorrect.";
+        $lang = $lang ?? config('services.chatgpt.language', 'uk');
+
+        $cached = ChatGPTExplanation::where('question', $question)
+            ->where('wrong_answer', $wrongAnswer)
+            ->where('correct_answer', $correctAnswer)
+            ->where('language', $lang)
+            ->first();
+
+        if ($cached) {
+            return $cached->explanation;
+        }
+
+        $prompt = "Question: {$question}\nWrong answer: {$wrongAnswer}\nCorrect answer: {$correctAnswer}\nExplain in 1-2 sentences in {$lang} why the wrong answer is incorrect.";
 
         try {
 
@@ -30,9 +42,17 @@ class ChatGPTService
                 ],
             ]);
 
+            $text = trim($result->choices[0]->message->content);
 
-           
-            return trim($result->choices[0]->message->content);
+            ChatGPTExplanation::create([
+                'question' => $question,
+                'wrong_answer' => $wrongAnswer,
+                'correct_answer' => $correctAnswer,
+                'language' => $lang,
+                'explanation' => $text,
+            ]);
+
+            return $text;
        
 
             //Log::warning('ChatGPT explanation failed: ' . $response->status() . ' ' . $response->body());

--- a/config/services.php
+++ b/config/services.php
@@ -33,6 +33,7 @@ return [
 
     'chatgpt' => [
         'key' => env('CHAT_GPT_API_KEY'),
+        'language' => env('CHAT_GPT_LANGUAGE', 'uk'),
     ],
 
 ];

--- a/database/migrations/2025_08_02_000001_create_chatgpt_explanations_table.php
+++ b/database/migrations/2025_08_02_000001_create_chatgpt_explanations_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('chatgpt_explanations', function (Blueprint $table) {
+            $table->id();
+            $table->text('question');
+            $table->text('wrong_answer');
+            $table->text('correct_answer');
+            $table->string('language')->default('uk');
+            $table->text('explanation');
+            $table->timestamps();
+            $table->unique(['question', 'wrong_answer', 'correct_answer', 'language'], 'chatgpt_explanations_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('chatgpt_explanations');
+    }
+};

--- a/resources/views/grammar-test-result.blade.php
+++ b/resources/views/grammar-test-result.blade.php
@@ -25,7 +25,7 @@
                             if (strtolower($answer) !== strtolower($right)) {
                                 $show .= ' <span class="text-xs text-gray-500">(правильна: '.$right.')</span>';
                                 if ($explanation) {
-                                    $show .= '<div class="text-xs text-gray-700 mt-1">'.e($explanation).'</div>';
+                                    $show .= '<div class="text-xs italic text-blue-800 bg-blue-50 rounded px-2 py-1 mt-1">'.e($explanation).'</div>';
                                 }
                             }
                             $replacements['{a'.$num.'}'] = $show;


### PR DESCRIPTION
## Summary
- cache ChatGPT explanations in the new `chatgpt_explanations` table
- add `ChatGPTExplanation` model and configuration for default language
- support language selection and caching in `ChatGPTService`
- style displayed explanations in test results
- document `CHAT_GPT_LANGUAGE` in `.env.example`

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6887ece34c48832a82d6e59f4000cbb6