### PR TITLE
Improve ChatGPT text styling

### DIFF
--- a/resources/views/grammar-test-result.blade.php
+++ b/resources/views/grammar-test-result.blade.php
@@ -25,7 +25,10 @@
                             if (strtolower($answer) !== strtolower($right)) {
                                 $show .= ' <span class="text-xs text-gray-500">(правильна: '.$right.')</span>';
                                 if ($explanation) {
-                                    $show .= '<div class="text-xs italic text-blue-800 bg-blue-50 rounded px-2 py-1 mt-1">'.e($explanation).'</div>';
+                                    $paragraphs = preg_split("/\r?\n/", trim($explanation));
+                                    $paragraphs = array_filter($paragraphs);
+                                    $formatted = array_map(fn($p) => '<p class="mb-1 font-semibold">'.e($p).'</p>', $paragraphs);
+                                    $show .= '<div class="text-xs text-blue-800 bg-blue-50 rounded px-2 py-1 mt-1 space-y-1">'.implode('', $formatted).'</div>';
                                 }
                             }
                             $replacements['{a'.$num.'}'] = $show;


### PR DESCRIPTION
## Summary
- enhance grammar test results page
- show ChatGPT explanations in bold paragraphs for readability

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6887f165fca8832a8260551d2d33163f