### PR TITLE
Add breadcrumbs and better tag filters

### DIFF
--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -298,7 +298,7 @@ class GrammarTestController extends Controller
 
     public function catalog(Request $request)
     {
-        $selectedTag = $request->input('tag');
+        $selectedTags = (array) $request->input('tags', []);
 
         $tests = \App\Models\Test::latest()->get();
 
@@ -317,14 +317,21 @@ class GrammarTestController extends Controller
         $tagsByCategory = $tagModels->groupBy(fn($t) => $t->category ?? 'Other')
             ->map(fn($group) => $group->pluck('name')->sort()->values());
 
-        if ($selectedTag) {
-            $tests = $tests->filter(fn($t) => $t->tag_names->contains($selectedTag))->values();
+        if (!empty($selectedTags)) {
+            $tests = $tests->filter(function ($t) use ($selectedTags) {
+                return collect($selectedTags)
+                    ->every(fn($tag) => $t->tag_names->contains($tag));
+            })->values();
         }
 
         return view('saved-tests-cards', [
             'tests' => $tests,
             'tags' => $tagsByCategory,
-            'selectedTag' => $selectedTag,
+            'selectedTags' => $selectedTags,
+            'breadcrumbs' => [
+                ['label' => 'Home', 'url' => route('home')],
+                ['label' => 'Tests Catalog'],
+            ],
         ]);
     }
     

--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,0 +1,14 @@
+<nav class="text-sm text-gray-600 mb-4" aria-label="Breadcrumb">
+    <ol class="list-reset flex items-center">
+        @foreach($items as $item)
+            <li class="flex items-center">
+                @if(!$loop->last)
+                    <a href="{{ $item['url'] ?? '#' }}" class="text-blue-600 hover:underline">{{ $item['label'] }}</a>
+                    <span class="mx-2">/</span>
+                @else
+                    <span class="text-gray-700">{{ $item['label'] }}</span>
+                @endif
+            </li>
+        @endforeach
+    </ol>
+</nav>

--- a/resources/views/grammar-test-result.blade.php
+++ b/resources/views/grammar-test-result.blade.php
@@ -25,7 +25,10 @@
                             if (strtolower($answer) !== strtolower($right)) {
                                 $show .= ' <span class="text-xs text-gray-500">(правильна: '.$right.')</span>';
                                 if ($explanation) {
-                                    $show .= '<div class="text-xs italic text-blue-800 bg-blue-50 rounded px-2 py-1 mt-1">'.e($explanation).'</div>';
+                                    $paragraphs = preg_split("/\r?\n/", trim($explanation));
+                                    $paragraphs = array_filter($paragraphs);
+                                    $formatted = array_map(fn($p) => '<p class="mb-1 font-semibold">'.e($p).'</p>', $paragraphs);
+                                    $show .= '<div class="text-xs text-blue-800 bg-blue-50 rounded px-2 py-1 mt-1 space-y-1">'.implode('', $formatted).'</div>';
                                 }
                             }
                             $replacements['{a'.$num.'}'] = $show;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -79,6 +79,15 @@
     </script>
     <!-- Контент -->
     <main class="flex-1 container mx-auto px-4">
+        @php $pageTitle = trim($__env->yieldContent('title')); @endphp
+        @if(isset($breadcrumbs))
+            @include('components.breadcrumbs', ['items' => $breadcrumbs])
+        @elseif(request()->path() !== '/' && !empty($pageTitle))
+            @include('components.breadcrumbs', ['items' => [
+                ['label' => 'Home', 'url' => route('home')],
+                ['label' => $pageTitle]
+            ]])
+        @endif
         @yield('content')
     </main>
 

--- a/resources/views/saved-tests-cards.blade.php
+++ b/resources/views/saved-tests-cards.blade.php
@@ -5,19 +5,21 @@
 @section('content')
 <div class="flex gap-6">
     <aside class="w-48 shrink-0">
-        @foreach($tags as $category => $tagNames)
-            <h3 class="text-lg font-bold mb-2">{{ $category }}</h3>
-            <ul class="space-y-1 text-sm mb-4">
-                @foreach($tagNames as $tag)
-                    <li>
-                        <a href="{{ route('saved-tests.cards', ['tag' => $tag]) }}" class="{{ $selectedTag === $tag ? 'text-blue-700 font-semibold' : 'text-blue-600 hover:underline' }}">
-                            {{ $tag }}
-                        </a>
-                    </li>
-                @endforeach
-            </ul>
-        @endforeach
-        @if($selectedTag)
+        <form id="tag-filter" action="{{ route('saved-tests.cards') }}" method="GET">
+            @foreach($tags as $category => $tagNames)
+                <h3 class="text-lg font-bold mb-2">{{ $category }}</h3>
+                <div class="flex flex-wrap gap-2 mb-4">
+                    @foreach($tagNames as $tag)
+                        @php $id = 'tag-' . md5($tag); @endphp
+                        <div>
+                            <input type="checkbox" name="tags[]" value="{{ $tag }}" id="{{ $id }}" class="hidden peer" {{ in_array($tag, $selectedTags ?? []) ? 'checked' : '' }}>
+                            <label for="{{ $id }}" class="px-3 py-1 rounded border cursor-pointer text-sm bg-gray-200 peer-checked:bg-blue-600 peer-checked:text-white">{{ $tag }}</label>
+                        </div>
+                    @endforeach
+                </div>
+            @endforeach
+        </form>
+        @if(!empty($selectedTags))
             <div class="mt-2">
                 <a href="{{ route('saved-tests.cards') }}" class="text-xs text-gray-500 hover:underline">Скинути фільтр</a>
             </div>
@@ -45,6 +47,11 @@
         @else
             <div class="text-gray-600">Ще немає збережених тестів.</div>
         @endif
-    </div>
 </div>
+</div>
+<script>
+    document.querySelectorAll('#tag-filter input[type=checkbox]').forEach(el => {
+        el.addEventListener('change', () => document.getElementById('tag-filter').submit());
+    });
+</script>
 @endsection


### PR DESCRIPTION
## Summary
- add a reusable breadcrumbs component and include in layout
- let /tests/cards filter by multiple tags via instant button clicks
- automatically display breadcrumbs based on the page title
- show chatGPT explanations as bold paragraphs
- require tests to have all selected tags when filtering

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6887f165fca8832a8260551d2d33163f