### PR TITLE
Add sentence translation test

### DIFF
--- a/app/Http/Controllers/SentenceTranslationTestController.php
+++ b/app/Http/Controllers/SentenceTranslationTestController.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Sentence;
+use App\Services\ChatGPTService;
+
+class SentenceTranslationTestController extends Controller
+{
+    public function index(Request $request)
+    {
+        if ($request->boolean('reset')) {
+            session()->forget([
+                'translation_stats',
+                'translation_queue',
+                'translation_total',
+                'current_sentence_id',
+                'current_attempts',
+            ]);
+        }
+
+        $stats = session('translation_stats', [
+            'correct' => 0,
+            'wrong' => 0,
+            'total' => 0,
+        ]);
+        $percentage = $stats['total'] > 0 ? round(($stats['correct'] / $stats['total']) * 100, 2) : 0;
+
+        $queue = session('translation_queue');
+        $totalCount = session('translation_total', 0);
+
+        if (!$queue) {
+            $queue = Sentence::pluck('id')->shuffle()->toArray();
+            $totalCount = count($queue);
+            session(['translation_queue' => $queue, 'translation_total' => $totalCount]);
+        }
+
+        $currentId = session('current_sentence_id');
+        if (!$currentId) {
+            if (empty($queue)) {
+                return view('translate.complete', [
+                    'stats' => $stats,
+                    'percentage' => $percentage,
+                    'totalCount' => $totalCount,
+                ]);
+            }
+            $currentId = array_shift($queue);
+            session(['translation_queue' => $queue, 'current_sentence_id' => $currentId, 'current_attempts' => 0]);
+        }
+
+        $sentence = Sentence::find($currentId);
+        $attempts = session('current_attempts', 0);
+        $feedback = session('translation_feedback');
+
+        return view('translate.test', [
+            'sentence' => $sentence,
+            'stats' => $stats,
+            'percentage' => $percentage,
+            'totalCount' => $totalCount,
+            'attempts' => $attempts,
+            'feedback' => $feedback,
+        ]);
+    }
+
+    public function check(Request $request, ChatGPTService $gpt)
+    {
+        $request->validate([
+            'sentence_id' => 'required|exists:sentences,id',
+            'answer' => 'required|string',
+        ]);
+
+        $sentence = Sentence::findOrFail($request->input('sentence_id'));
+
+        $attempts = session('current_attempts', 0);
+        $stats = session('translation_stats', [
+            'correct' => 0,
+            'wrong' => 0,
+            'total' => 0,
+        ]);
+
+        $result = $gpt->checkTranslation($sentence->text_uk, $sentence->text_en, $request->input('answer'));
+
+        if ($result['is_correct']) {
+            $stats['correct']++; $stats['total']++;
+            session([
+                'translation_stats' => $stats,
+                'current_sentence_id' => null,
+                'current_attempts' => 0,
+            ]);
+            session()->flash('translation_feedback', [
+                'isCorrect' => true,
+                'userAnswer' => $request->input('answer'),
+                'correct' => $sentence->text_en,
+                'explanation' => '',
+            ]);
+        } else {
+            if ($attempts >= 1) {
+                $stats['wrong']++; $stats['total']++;
+                session([
+                    'translation_stats' => $stats,
+                    'current_sentence_id' => null,
+                    'current_attempts' => 0,
+                ]);
+                session()->flash('translation_feedback', [
+                    'isCorrect' => false,
+                    'userAnswer' => $request->input('answer'),
+                    'correct' => $sentence->text_en,
+                    'explanation' => $result['explanation'] ?? '',
+                ]);
+            } else {
+                session(['current_attempts' => $attempts + 1]);
+                session()->flash('translation_feedback', [
+                    'isCorrect' => false,
+                    'userAnswer' => $request->input('answer'),
+                    'correct' => $sentence->text_en,
+                    'explanation' => $result['explanation'] ?? '',
+                ]);
+            }
+        }
+
+        return redirect()->route('translate.test');
+    }
+
+    public function reset()
+    {
+        session()->forget([
+            'translation_stats',
+            'translation_queue',
+            'translation_total',
+            'current_sentence_id',
+            'current_attempts',
+        ]);
+
+        return redirect()->route('translate.test');
+    }
+}

--- a/app/Models/Sentence.php
+++ b/app/Models/Sentence.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Sentence extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'uuid',
+        'text_uk',
+        'text_en',
+    ];
+}

--- a/app/Services/ChatGPTService.php
+++ b/app/Services/ChatGPTService.php
@@ -62,4 +62,44 @@ class ChatGPTService
 
         return '';
     }
+
+    public function checkTranslation(string $original, string $correct, string $user, ?string $lang = null): array
+    {
+        $key = config('services.chatgpt.key');
+        if (empty($key)) {
+            Log::warning('ChatGPT API key not configured');
+            return ['is_correct' => false, 'explanation' => ''];
+        }
+
+        $lang = $lang ?? config('services.chatgpt.language', 'uk');
+
+        $prompt = "You are a language teacher.\n".
+            "Original: {$original}\n".
+            "Reference translation: {$correct}\n".
+            "Student translation: {$user}\n".
+            "Respond in JSON with keys 'correct' (true or false) and 'explanation' in {$lang}.";
+
+        try {
+            $client = \OpenAI::client($key);
+            $result = $client->chat()->create([
+                'model' => 'gpt-4o',
+                'messages' => [
+                    ['role' => 'user', 'content' => $prompt],
+                ],
+            ]);
+
+            $content = trim($result->choices[0]->message->content);
+            $data = json_decode($content, true);
+            if (is_array($data) && isset($data['correct'])) {
+                return [
+                    'is_correct' => (bool) $data['correct'],
+                    'explanation' => $data['explanation'] ?? '',
+                ];
+            }
+        } catch (Exception $e) {
+            Log::warning('ChatGPT translation check failed: ' . $e->getMessage());
+        }
+
+        return ['is_correct' => false, 'explanation' => ''];
+    }
 }

--- a/database/migrations/2025_07_29_093218_create_sentences_table.php
+++ b/database/migrations/2025_07_29_093218_create_sentences_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sentences', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('uuid')->unique();
+            $table->text('text_uk');
+            $table->text('text_en');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sentences');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -46,6 +46,7 @@ class DatabaseSeeder extends Seeder
             ToBeTenseSeeder::class,
             WordsWithTranslationsSeeder::class,
             PronounWordsSeeder::class,
+            SentenceTranslationSeeder::class,
             TestsSqlSeeder::class,
             QuestionTenseAssignmentSeeder::class,
         ]);

--- a/database/seeders/SentenceTranslationSeeder.php
+++ b/database/seeders/SentenceTranslationSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Sentence;
+use Illuminate\Support\Str;
+
+class SentenceTranslationSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $sentences = [
+            ['uk' => 'З ким вона розмовляла вчора ?', 'en' => 'Who was she talking to yesterday?'],
+            ['uk' => 'Про що ця книга?', 'en' => 'What is this book about?'],
+            ['uk' => 'Де він працює?', 'en' => 'Where does he work?'],
+            ['uk' => 'Як вона добирається додому ?', 'en' => 'How does she get home?'],
+            ['uk' => 'Коли він прокидається?', 'en' => 'When does he wake up?'],
+            ['uk' => 'З ким вона зустрічалася вчора?', 'en' => 'Who did she meet yesterday?'],
+            ['uk' => 'О котрій годині починається фільм', 'en' => 'What time does the movie start?'],
+            ['uk' => 'Коли він буде на роботі?', 'en' => 'When will he be at work?'],
+            ['uk' => 'З ким вона розмовляла вчора?', 'en' => 'Who was she talking to yesterday?'],
+            ['uk' => 'Де вони працюють?', 'en' => 'Where do they work?'],
+            ['uk' => 'О котрій годині він закінчує роботу?', 'en' => 'What time does he finish work?'],
+            ['uk' => 'Що вона робить кожен день?', 'en' => 'What does she do every day?'],
+            ['uk' => 'З ким він зустрічався вчора?', 'en' => 'Who did he meet yesterday?'],
+            ['uk' => 'Про що вони розмовляли минулого вечора?', 'en' => 'What were they talking about last night?'],
+            ['uk' => 'Де його книжка?', 'en' => 'Where is his book?'],
+            ['uk' => 'Якого кольору її машина?', 'en' => 'What color is her car?'],
+            ['uk' => 'Він живе в іншій країні.', 'en' => 'He lives in another country.'],
+            ['uk' => 'Вони не прибирають кожного дня.', 'en' => "They don't clean every day."],
+            ['uk' => 'Мій брат не дзвонив вчора.', 'en' => "My brother didn't call yesterday."],
+            ['uk' => 'Вона слухала музику минулого вечора.', 'en' => 'She was listening to music last night.'],
+        ];
+
+        foreach ($sentences as $i => $row) {
+            Sentence::create([
+                'uuid' => Str::slug(class_basename(self::class)) . '-' . ($i + 1),
+                'text_uk' => $row['uk'],
+                'text_en' => $row['en'],
+            ]);
+        }
+    }
+}

--- a/resources/views/translate/complete.blade.php
+++ b/resources/views/translate/complete.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+
+@section('title', 'Translation Test Finished')
+
+@section('content')
+    <div class="max-w-xl mx-auto mt-8 p-8 bg-white rounded-xl shadow">
+        <h2 class="text-2xl font-bold mb-4 text-blue-700">Translation Test Finished</h2>
+        <div class="mb-4 flex gap-4 text-gray-600 text-base">
+            <div>Total: <b>{{ $stats['total'] }} / {{ $totalCount }}</b></div>
+            <div>Correct: <b class="text-green-700">{{ $stats['correct'] }}</b></div>
+            <div>Wrong: <b class="text-red-700">{{ $stats['wrong'] }}</b></div>
+            <div>Percent: <b>{{ $percentage }}%</b></div>
+        </div>
+        <form method="POST" action="{{ route('translate.test.reset') }}">
+            @csrf
+            <button type="submit" class="bg-blue-600 text-white px-6 py-2 rounded-xl font-semibold hover:bg-blue-700 transition">
+                Restart Test
+            </button>
+        </form>
+    </div>
+@endsection
+

--- a/resources/views/translate/test.blade.php
+++ b/resources/views/translate/test.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app')
+
+@section('title', 'Sentence Translation Test')
+
+@section('content')
+    <div class="mx-auto mt-8 p-8 bg-white rounded-xl shadow w-[800px]">
+        <h2 class="text-2xl font-bold mb-4 text-blue-700">Sentence Translation Test</h2>
+
+        <div class="mb-4 flex gap-4 text-gray-600 text-base">
+            <div>Total: <b>{{ $stats['total'] }} / {{ $totalCount }}</b></div>
+            <div>Correct: <b class="text-green-700">{{ $stats['correct'] }}</b></div>
+            <div>Wrong: <b class="text-red-700">{{ $stats['wrong'] }}</b></div>
+            <div>Percent: <b>{{ $percentage }}%</b></div>
+        </div>
+        <form method="POST" action="{{ route('translate.test.reset') }}" class="mb-4">
+            @csrf
+            <button type="submit" class="bg-gray-200 px-4 py-1 rounded hover:bg-gray-300 transition text-sm">Reset</button>
+        </form>
+
+        @if(isset($feedback))
+            <div class="mb-4">
+                @if($feedback['isCorrect'])
+                    <div class="bg-green-100 text-green-800 px-4 py-2 rounded mb-2">
+                        Correct! <b>{{ $feedback['correct'] }}</b>
+                    </div>
+                @else
+                    <div class="bg-red-100 text-red-800 px-4 py-2 rounded mb-2">
+                        {{ $feedback['explanation'] }}<br>
+                        Your answer: <b>{{ $feedback['userAnswer'] }}</b><br>
+                        Correct: <b>{{ $feedback['correct'] }}</b>
+                    </div>
+                @endif
+            </div>
+        @endif
+
+        <form method="POST" action="{{ route('translate.test.check') }}" class="mt-4">
+            @csrf
+            <input type="hidden" name="sentence_id" value="{{ $sentence->id }}">
+            <div class="mb-6 text-xl font-semibold">{{ $sentence->text_uk }}</div>
+            <input type="text" name="answer" class="border rounded w-full p-2 mb-4" autofocus required>
+            <button type="submit" class="bg-blue-600 text-white px-6 py-2 rounded-xl font-semibold hover:bg-blue-700 transition">
+                {{ $attempts > 0 ? 'Submit' : 'Check' }}
+            </button>
+        </form>
+    </div>
+@endsection
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::get('/', [HomeController::class, 'index'])->name('home');
 Route::get('/train/{topic?}', [TrainController::class, 'index'])->name('train');
 
 use App\Http\Controllers\WordsTestController;
+use App\Http\Controllers\SentenceTranslationTestController;
 
 Route::get('/words/test', [WordsTestController::class, 'index'])->name('words.test');
 Route::post('/words/test/check', [WordsTestController::class, 'check'])->name('words.test.check');
@@ -40,6 +41,10 @@ Route::post('/words/test/reset', function () {
 
     return redirect()->route('words.test');
 })->name('words.test.reset');
+
+Route::get('/translate/test', [SentenceTranslationTestController::class, 'index'])->name('translate.test');
+Route::post('/translate/test/check', [SentenceTranslationTestController::class, 'check'])->name('translate.test.check');
+Route::post('/translate/test/reset', [SentenceTranslationTestController::class, 'reset'])->name('translate.test.reset');
 
 Route::get('/grammar-test', [GrammarTestController::class, 'index'])->name('grammar-test');
 Route::post('/grammar-test', [GrammarTestController::class, 'generate'])->name('grammar-test.generate');


### PR DESCRIPTION
## Summary
- add migrations and model for sentences
- seed translation sentences
- implement ChatGPT translation checking
- create new controller and views for translation tests
- wire up routes

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_688893ab5ee8832ab439c7ae007e730d