### PR TITLE
Add seeder to generate words from all sentences

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -49,6 +49,7 @@ class DatabaseSeeder extends Seeder
             SentenceTranslationSeeder::class,
             TestsSqlSeeder::class,
             QuestionTenseAssignmentSeeder::class,
+            WordsFromSentencesSeeder::class,
         ]);
     }
 }

--- a/database/seeders/WordsFromSentencesSeeder.php
+++ b/database/seeders/WordsFromSentencesSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\{Question, Sentence, Word};
+
+class WordsFromSentencesSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $texts = array_merge(
+            Question::pluck('question')->toArray(),
+            Sentence::pluck('text_en')->toArray()
+        );
+
+        foreach ($texts as $text) {
+            $clean = strtolower(preg_replace('/\{[^}]+\}/', '', $text));
+            preg_match_all("/[a-zA-Z']+/",$clean, $matches);
+            foreach ($matches[0] as $word) {
+                Word::firstOrCreate(['word' => $word]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- populate `words` table with unique words from seeded questions and sentences
- call new seeder at the end of `DatabaseSeeder`

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6888b91ab4f4832abd52dde52fe6da1f