### PR TITLE
Add modal tags for HaveGot exercises

### DIFF
--- a/database/seeders/HaveGotExercise2Seeder.php
+++ b/database/seeders/HaveGotExercise2Seeder.php
@@ -19,9 +19,7 @@ class HaveGotExercise2Seeder extends Seeder
         ])->id;
 
         $themeTag = Tag::firstOrCreate(['name' => 'have_has_got_exercise_2']);
-        $haveTag = Tag::firstOrCreate(['name' => 'Have'], ['category' => 'modal']);
-        $hasTag = Tag::firstOrCreate(['name' => 'Has'], ['category' => 'modal']);
-        $gotTag = Tag::firstOrCreate(['name' => 'Got'], ['category' => 'modal']);
+        $modalTag = Tag::firstOrCreate(['name' => 'Have Has Got'], ['category' => 'modal']);
 
         $data = [
             [
@@ -84,17 +82,7 @@ class HaveGotExercise2Seeder extends Seeder
             $max = 36 - strlen((string) $index) - 1;
             $uuid = substr($slug, 0, $max).'-'.$index;
 
-            $answersText = strtolower(implode(' ', array_column($d['answers'], 'answer')));
-            $tagIds = [$themeTag->id];
-            if (str_contains($answersText, 'have')) {
-                $tagIds[] = $haveTag->id;
-            }
-            if (str_contains($answersText, 'has')) {
-                $tagIds[] = $hasTag->id;
-            }
-            if (str_contains($answersText, 'got')) {
-                $tagIds[] = $gotTag->id;
-            }
+            $tagIds = [$themeTag->id, $modalTag->id];
 
             $items[] = [
                 'uuid' => $uuid,

--- a/database/seeders/HaveGotExercise2Seeder.php
+++ b/database/seeders/HaveGotExercise2Seeder.php
@@ -15,10 +15,13 @@ class HaveGotExercise2Seeder extends Seeder
     {
         $categoryId = Category::firstOrCreate(['name' => 'present'])->id;
         $sourceId = Source::firstOrCreate([
-            'name' => "Write affirmative (+) and negative (-) sentences using have/has got."
+            'name' => 'Write affirmative (+) and negative (-) sentences using have/has got.',
         ])->id;
 
         $themeTag = Tag::firstOrCreate(['name' => 'have_has_got_exercise_2']);
+        $haveTag = Tag::firstOrCreate(['name' => 'Have'], ['category' => 'modal']);
+        $hasTag = Tag::firstOrCreate(['name' => 'Has'], ['category' => 'modal']);
+        $gotTag = Tag::firstOrCreate(['name' => 'Got'], ['category' => 'modal']);
 
         $data = [
             [
@@ -73,24 +76,36 @@ class HaveGotExercise2Seeder extends Seeder
             ],
         ];
 
-        $service = new QuestionSeedingService();
+        $service = new QuestionSeedingService;
         $items = [];
         foreach ($data as $i => $d) {
             $index = $i + 1;
-            $slug  = Str::slug(class_basename(self::class));
-            $max   = 36 - strlen((string) $index) - 1;
-            $uuid  = substr($slug, 0, $max) . '-' . $index;
+            $slug = Str::slug(class_basename(self::class));
+            $max = 36 - strlen((string) $index) - 1;
+            $uuid = substr($slug, 0, $max).'-'.$index;
+
+            $answersText = strtolower(implode(' ', array_column($d['answers'], 'answer')));
+            $tagIds = [$themeTag->id];
+            if (str_contains($answersText, 'have')) {
+                $tagIds[] = $haveTag->id;
+            }
+            if (str_contains($answersText, 'has')) {
+                $tagIds[] = $hasTag->id;
+            }
+            if (str_contains($answersText, 'got')) {
+                $tagIds[] = $gotTag->id;
+            }
 
             $items[] = [
-                'uuid'        => $uuid,
-                'question'    => $d['question'],
+                'uuid' => $uuid,
+                'question' => $d['question'],
                 'category_id' => $categoryId,
-                'difficulty'  => 2,
-                'source_id'   => $sourceId,
-                'flag'        => 0,
-                'tag_ids'     => [$themeTag->id],
-                'answers'     => $d['answers'],
-                'options'     => $d['options'],
+                'difficulty' => 2,
+                'source_id' => $sourceId,
+                'flag' => 0,
+                'tag_ids' => $tagIds,
+                'answers' => $d['answers'],
+                'options' => $d['options'],
             ];
         }
 

--- a/database/seeders/HaveGotExercise3Seeder.php
+++ b/database/seeders/HaveGotExercise3Seeder.php
@@ -19,9 +19,7 @@ class HaveGotExercise3Seeder extends Seeder
         ])->id;
 
         $themeTag = Tag::firstOrCreate(['name' => 'have_has_got_exercise_3']);
-        $haveTag = Tag::firstOrCreate(['name' => 'Have'], ['category' => 'modal']);
-        $hasTag = Tag::firstOrCreate(['name' => 'Has'], ['category' => 'modal']);
-        $gotTag = Tag::firstOrCreate(['name' => 'Got'], ['category' => 'modal']);
+        $modalTag = Tag::firstOrCreate(['name' => 'Have Has Got'], ['category' => 'modal']);
 
         $data = [
             [
@@ -84,17 +82,7 @@ class HaveGotExercise3Seeder extends Seeder
             $max = 36 - strlen((string) $index) - 1;
             $uuid = substr($slug, 0, $max).'-'.$index;
 
-            $answersText = strtolower(implode(' ', array_column($d['answers'], 'answer')));
-            $tagIds = [$themeTag->id];
-            if (str_contains($answersText, 'have')) {
-                $tagIds[] = $haveTag->id;
-            }
-            if (str_contains($answersText, 'has')) {
-                $tagIds[] = $hasTag->id;
-            }
-            if (str_contains($answersText, 'got')) {
-                $tagIds[] = $gotTag->id;
-            }
+            $tagIds = [$themeTag->id, $modalTag->id];
 
             $items[] = [
                 'uuid' => $uuid,

--- a/database/seeders/HaveGotExercise3Seeder.php
+++ b/database/seeders/HaveGotExercise3Seeder.php
@@ -15,10 +15,13 @@ class HaveGotExercise3Seeder extends Seeder
     {
         $categoryId = Category::firstOrCreate(['name' => 'present'])->id;
         $sourceId = Source::firstOrCreate([
-            'name' => 'Complete the questions and short answers with have/has got.'
+            'name' => 'Complete the questions and short answers with have/has got.',
         ])->id;
 
         $themeTag = Tag::firstOrCreate(['name' => 'have_has_got_exercise_3']);
+        $haveTag = Tag::firstOrCreate(['name' => 'Have'], ['category' => 'modal']);
+        $hasTag = Tag::firstOrCreate(['name' => 'Has'], ['category' => 'modal']);
+        $gotTag = Tag::firstOrCreate(['name' => 'Got'], ['category' => 'modal']);
 
         $data = [
             [
@@ -73,24 +76,36 @@ class HaveGotExercise3Seeder extends Seeder
             ],
         ];
 
-        $service = new QuestionSeedingService();
+        $service = new QuestionSeedingService;
         $items = [];
         foreach ($data as $i => $d) {
             $index = $i + 1;
-            $slug  = Str::slug(class_basename(self::class));
-            $max   = 36 - strlen((string) $index) - 1;
-            $uuid  = substr($slug, 0, $max) . '-' . $index;
+            $slug = Str::slug(class_basename(self::class));
+            $max = 36 - strlen((string) $index) - 1;
+            $uuid = substr($slug, 0, $max).'-'.$index;
+
+            $answersText = strtolower(implode(' ', array_column($d['answers'], 'answer')));
+            $tagIds = [$themeTag->id];
+            if (str_contains($answersText, 'have')) {
+                $tagIds[] = $haveTag->id;
+            }
+            if (str_contains($answersText, 'has')) {
+                $tagIds[] = $hasTag->id;
+            }
+            if (str_contains($answersText, 'got')) {
+                $tagIds[] = $gotTag->id;
+            }
 
             $items[] = [
-                'uuid'        => $uuid,
-                'question'    => $d['question'],
+                'uuid' => $uuid,
+                'question' => $d['question'],
                 'category_id' => $categoryId,
-                'difficulty'  => 2,
-                'source_id'   => $sourceId,
-                'flag'        => 0,
-                'tag_ids'     => [$themeTag->id],
-                'answers'     => $d['answers'],
-                'options'     => $d['options'],
+                'difficulty' => 2,
+                'source_id' => $sourceId,
+                'flag' => 0,
+                'tag_ids' => $tagIds,
+                'answers' => $d['answers'],
+                'options' => $d['options'],
             ];
         }
 

--- a/database/seeders/HaveGotHasGotSeeder.php
+++ b/database/seeders/HaveGotHasGotSeeder.php
@@ -19,9 +19,7 @@ class HaveGotHasGotSeeder extends Seeder
         ])->id;
 
         $themeTag = Tag::firstOrCreate(['name' => 'have_has_got']);
-        $haveTag = Tag::firstOrCreate(['name' => 'Have'], ['category' => 'modal']);
-        $hasTag = Tag::firstOrCreate(['name' => 'Has'], ['category' => 'modal']);
-        $gotTag = Tag::firstOrCreate(['name' => 'Got'], ['category' => 'modal']);
+        $modalTag = Tag::firstOrCreate(['name' => 'Have Has Got'], ['category' => 'modal']);
 
         $data = [
             [
@@ -84,17 +82,7 @@ class HaveGotHasGotSeeder extends Seeder
             $max = 36 - strlen((string) $index) - 1;
             $uuid = substr($slug, 0, $max).'-'.$index;
 
-            $answersText = strtolower(implode(' ', array_column($d['answers'], 'answer')));
-            $tagIds = [$themeTag->id];
-            if (str_contains($answersText, 'have')) {
-                $tagIds[] = $haveTag->id;
-            }
-            if (str_contains($answersText, 'has')) {
-                $tagIds[] = $hasTag->id;
-            }
-            if (str_contains($answersText, 'got')) {
-                $tagIds[] = $gotTag->id;
-            }
+            $tagIds = [$themeTag->id, $modalTag->id];
 
             $items[] = [
                 'uuid' => $uuid,

--- a/database/seeders/HaveGotHasGotSeeder.php
+++ b/database/seeders/HaveGotHasGotSeeder.php
@@ -15,10 +15,13 @@ class HaveGotHasGotSeeder extends Seeder
     {
         $categoryId = Category::firstOrCreate(['name' => 'present'])->id;
         $sourceId = Source::firstOrCreate([
-            'name' => 'Complete the sentences with have got or has got.'
+            'name' => 'Complete the sentences with have got or has got.',
         ])->id;
 
         $themeTag = Tag::firstOrCreate(['name' => 'have_has_got']);
+        $haveTag = Tag::firstOrCreate(['name' => 'Have'], ['category' => 'modal']);
+        $hasTag = Tag::firstOrCreate(['name' => 'Has'], ['category' => 'modal']);
+        $gotTag = Tag::firstOrCreate(['name' => 'Got'], ['category' => 'modal']);
 
         $data = [
             [
@@ -73,24 +76,36 @@ class HaveGotHasGotSeeder extends Seeder
             ],
         ];
 
-        $service = new QuestionSeedingService();
+        $service = new QuestionSeedingService;
         $items = [];
         foreach ($data as $i => $d) {
             $index = $i + 1;
-            $slug  = Str::slug(class_basename(self::class));
-            $max   = 36 - strlen((string) $index) - 1;
-            $uuid  = substr($slug, 0, $max) . '-' . $index;
+            $slug = Str::slug(class_basename(self::class));
+            $max = 36 - strlen((string) $index) - 1;
+            $uuid = substr($slug, 0, $max).'-'.$index;
+
+            $answersText = strtolower(implode(' ', array_column($d['answers'], 'answer')));
+            $tagIds = [$themeTag->id];
+            if (str_contains($answersText, 'have')) {
+                $tagIds[] = $haveTag->id;
+            }
+            if (str_contains($answersText, 'has')) {
+                $tagIds[] = $hasTag->id;
+            }
+            if (str_contains($answersText, 'got')) {
+                $tagIds[] = $gotTag->id;
+            }
 
             $items[] = [
-                'uuid'        => $uuid,
-                'question'    => $d['question'],
+                'uuid' => $uuid,
+                'question' => $d['question'],
                 'category_id' => $categoryId,
-                'difficulty'  => 1,
-                'source_id'   => $sourceId,
-                'flag'        => 0,
-                'tag_ids'     => [$themeTag->id],
-                'answers'     => $d['answers'],
-                'options'     => $d['options'],
+                'difficulty' => 1,
+                'source_id' => $sourceId,
+                'flag' => 0,
+                'tag_ids' => $tagIds,
+                'answers' => $d['answers'],
+                'options' => $d['options'],
             ];
         }
 


### PR DESCRIPTION
## Summary
- add `Have`, `Has`, `Got` tags to Have Got exercise seeders
- assign tags dynamically based on answers

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688a0b930e00832a9ecc9ce711e25b43