### PR TITLE
Add seeders for ChatGPT data

### DIFF
--- a/database/seeders/ChatGPTExplanationsSeeder.php
+++ b/database/seeders/ChatGPTExplanationsSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ChatGPTExplanationsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $path = storage_path('chatgpt_explanations.sql');
+        if (!file_exists($path)) {
+            return;
+        }
+
+        $lines = file($path);
+        $collect = false;
+        $sql = '';
+        foreach ($lines as $line) {
+            if (str_contains($line, 'INSERT INTO `chatgpt_explanations`')) {
+                $collect = true;
+            }
+            if ($collect) {
+                $sql .= $line;
+            }
+        }
+
+        if ($sql) {
+            DB::unprepared($sql);
+        }
+    }
+}

--- a/database/seeders/ChatGPTTranslationChecksSeeder.php
+++ b/database/seeders/ChatGPTTranslationChecksSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ChatGPTTranslationChecksSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $path = storage_path('chatgpt_translation_checks.sql');
+        if (!file_exists($path)) {
+            return;
+        }
+
+        $lines = file($path);
+        $collect = false;
+        $sql = '';
+        foreach ($lines as $line) {
+            if (str_contains($line, 'INSERT INTO `chatgpt_translation_checks`')) {
+                $collect = true;
+            }
+            if ($collect) {
+                $sql .= $line;
+            }
+        }
+
+        if ($sql) {
+            DB::unprepared($sql);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -59,6 +59,8 @@ class DatabaseSeeder extends Seeder
             TestsSqlSeeder::class,
             QuestionTenseAssignmentSeeder::class,
             WordsFromSentencesSeeder::class,
+            ChatGPTExplanationsSeeder::class,
+            ChatGPTTranslationChecksSeeder::class,
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- add ChatGPTExplanationsSeeder and ChatGPTTranslationChecksSeeder for importing data from SQL files
- register the new seeders in DatabaseSeeder

## Testing
- `composer install --no-interaction`
- `composer dump-autoload -o`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688a19db2e44832a8495ea92bb05ef45