### PR TITLE
Add seeder for Present Simple vs Continuous

### DIFF
--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Test extends Model
 {
-    protected $fillable = ['name', 'slug', 'filters', 'questions'];
+    protected $fillable = ['name', 'slug', 'filters', 'questions', 'description'];
     protected $casts = [
         'filters' => 'array',
         'questions' => 'array',

--- a/app/Services/ChatGPTService.php
+++ b/app/Services/ChatGPTService.php
@@ -150,7 +150,9 @@ class ChatGPTService
     }
 
     /**
-     * Generate a short description of what to do in a test based on its questions.
+     * Generate a detailed description of what to do in a test based on its questions.
+     * The description should include a short explanation of the grammar rule that
+     * is tested so students know how to form the correct answers.
      */
     public function generateTestDescription(array $questions, ?string $lang = null): string
     {
@@ -162,7 +164,9 @@ class ChatGPTService
 
         $lang = $lang ?? config('services.chatgpt.language', 'uk');
 
-        $prompt = "Сформулюй короткий опис українською, що потрібно зробити у цьому тесті. Ось питання тесту:\n";
+        $prompt = "Сформулюй детальний опис українською того, що потрібно зробити у цьому тесті." .
+            " Додай коротке пояснення правила або формули, за якою утворюються правильні відповіді." .
+            " Ось питання тесту:\n";
         foreach ($questions as $i => $q) {
             $prompt .= ($i + 1) . ". {$q}\n";
         }

--- a/database/migrations/2025_08_04_000002_add_description_to_tests_table.php
+++ b/database/migrations/2025_08_04_000002_add_description_to_tests_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('tests', function (Blueprint $table) {
+            $table->text('description')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('tests', function (Blueprint $table) {
+            $table->dropColumn('description');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -63,6 +63,7 @@ class DatabaseSeeder extends Seeder
             ChatGPTExplanationsSeeder::class,
             ChatGPTTranslationChecksSeeder::class,
             PresentContinuousStorySeeder::class,
+            PresentSimpleOrContinuousSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PresentSimpleOrContinuousSeeder.php
+++ b/database/seeders/PresentSimpleOrContinuousSeeder.php
@@ -1,0 +1,172 @@
+<?php
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Services\QuestionSeedingService;
+use App\Models\{Category, Source, Tag};
+use Illuminate\Support\Str;
+
+class PresentSimpleOrContinuousSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $catId = Category::firstOrCreate(['name' => 'present'])->id;
+        $sourceId = Source::firstOrCreate([
+            'name' => 'Present Simple or Present Continuous'
+        ])->id;
+
+        $simpleTag = Tag::firstOrCreate(['name' => 'Present Simple'], ['category' => 'Tenses']);
+        $contTag   = Tag::firstOrCreate(['name' => 'Present Continuous'], ['category' => 'Tenses']);
+        $themeTag  = Tag::firstOrCreate(['name' => 'present_simple_or_continuous']);
+
+        $data = [
+            [
+                'question' => 'Listen! Somebody {a1} the violin.',
+                'answers'  => [['marker' => 'a1', 'answer' => 'is playing', 'verb_hint' => 'play']],
+                'options'  => ['is playing', 'plays', 'play'],
+            ],
+            [
+                'question' => 'How often {a1} you {a2} to the cinema?',
+                'answers'  => [
+                    'a1' => ['answer' => 'do', 'verb_hint' => 'do'],
+                    'a2' => ['answer' => 'go', 'verb_hint' => 'go'],
+                ],
+                'options'  => ['do', 'are', 'go', 'going'],
+            ],
+            [
+                'question' => 'Why {a1} you {a2} at me now?',
+                'answers'  => [
+                    'a1' => ['answer' => 'are', 'verb_hint' => 'be'],
+                    'a2' => ['answer' => 'shouting', 'verb_hint' => 'shout'],
+                ],
+                'options'  => ['are', 'do', 'shout', 'shouting'],
+            ],
+            [
+                'question' => 'Shh! The baby {a1} asleep.',
+                'answers'  => [['marker' => 'a1', 'answer' => 'is falling', 'verb_hint' => 'fall']],
+                'options'  => ['is falling', 'falls', 'fall'],
+            ],
+            [
+                'question' => '{a1} you {a2} who I am?',
+                'answers'  => [
+                    'a1' => ['answer' => 'Do', 'verb_hint' => 'do'],
+                    'a2' => ['answer' => 'know', 'verb_hint' => 'know'],
+                ],
+                'options'  => ['Do', 'Are', 'know', 'knowing'],
+            ],
+            [
+                'question' => 'How much coffee {a1} you {a2}?',
+                'answers'  => [
+                    'a1' => ['answer' => 'do', 'verb_hint' => 'do'],
+                    'a2' => ['answer' => 'drink', 'verb_hint' => 'drink'],
+                ],
+                'options'  => ['do', 'are', 'drink', 'drinking'],
+            ],
+            [
+                'question' => 'Look! The boys {a1} football.',
+                'answers'  => [['marker' => 'a1', 'answer' => 'are playing', 'verb_hint' => 'play']],
+                'options'  => ['are playing', 'play', 'plays'],
+            ],
+            [
+                'question' => 'Quick! They {a1}.',
+                'answers'  => [['marker' => 'a1', 'answer' => "aren't looking", 'verb_hint' => 'not/look']],
+                'options'  => ["aren't looking", "don't look", 'look'],
+            ],
+            [
+                'question' => "My best friend {a1} meat. She's a vegetarian.",
+                'answers'  => [['marker' => 'a1', 'answer' => "doesn't eat", 'verb_hint' => 'not/eat']],
+                'options'  => ["doesn't eat", "isn't eating", 'eat'],
+            ],
+            [
+                'question' => 'Who {a1} you {a2} to now?',
+                'answers'  => [
+                    'a1' => ['answer' => 'are', 'verb_hint' => 'be'],
+                    'a2' => ['answer' => 'talking', 'verb_hint' => 'talk'],
+                ],
+                'options'  => ['are', 'do', 'talk', 'talking'],
+            ],
+            [
+                'question' => 'Shh! Dad {a1} the news.',
+                'answers'  => [['marker' => 'a1', 'answer' => 'is watching', 'verb_hint' => 'watch']],
+                'options'  => ['is watching', 'watches', 'watch'],
+            ],
+            [
+                'question' => '{a1} you {a2} chocolate?',
+                'answers'  => [
+                    'a1' => ['answer' => 'Do', 'verb_hint' => 'do'],
+                    'a2' => ['answer' => 'like', 'verb_hint' => 'like'],
+                ],
+                'options'  => ['Do', 'Are', 'like', 'liking'],
+            ],
+            [
+                'question' => 'We {a1} on a school trip today.',
+                'answers'  => [['marker' => 'a1', 'answer' => 'are going', 'verb_hint' => 'go']],
+                'options'  => ['are going', 'go', 'going'],
+            ],
+            [
+                'question' => 'I {a1} a bike every day. Only at weekends.',
+                'answers'  => [['marker' => 'a1', 'answer' => "don't ride", 'verb_hint' => 'not/ride']],
+                'options'  => ["don't ride", 'ride', 'am riding'],
+            ],
+            [
+                'question' => "I {a1} to school this week. I'm ill.",
+                'answers'  => [['marker' => 'a1', 'answer' => 'am not going', 'verb_hint' => 'not/go']],
+                'options'  => ['am not going', "don't go", 'go'],
+            ],
+            [
+                'question' => 'We usually {a1} the weekends in the mountains in our summer house.',
+                'answers'  => [['marker' => 'a1', 'answer' => 'spend', 'verb_hint' => 'spend']],
+                'options'  => ['spend', 'are spending', 'spends'],
+            ],
+            [
+                'question' => 'You {a1} to me again!',
+                'answers'  => [['marker' => 'a1', 'answer' => "aren't listening", 'verb_hint' => 'not/listen']],
+                'options'  => ["aren't listening", "don't listen", 'listen'],
+            ],
+            [
+                'question' => 'Rebecca {a1} books, she {a2} films.',
+                'answers'  => [
+                    'a1' => ['answer' => "doesn't read", 'verb_hint' => 'not/read'],
+                    'a2' => ['answer' => 'prefers', 'verb_hint' => 'prefer'],
+                ],
+                'options'  => ["doesn't read", "isn't reading", 'prefer', 'prefers'],
+            ],
+            [
+                'question' => 'Look! Who {a1} she {a2} to?',
+                'answers'  => [
+                    'a1' => ['answer' => 'is', 'verb_hint' => 'be'],
+                    'a2' => ['answer' => 'talking', 'verb_hint' => 'talk'],
+                ],
+                'options'  => ['is', 'does', 'talking', 'talks'],
+            ],
+            [
+                'question' => 'They {a1} tennis at the moment.',
+                'answers'  => [['marker' => 'a1', 'answer' => 'are playing', 'verb_hint' => 'play']],
+                'options'  => ['are playing', 'play', 'plays'],
+            ],
+        ];
+
+        $service = new QuestionSeedingService();
+        $items = [];
+        foreach ($data as $i => $d) {
+            $index = $i + 1;
+            $slug = Str::slug(class_basename(self::class));
+            $max = 36 - strlen((string) $index) - 1;
+            $uuid = substr($slug, 0, $max) . '-' . $index;
+
+            $items[] = [
+                'uuid' => $uuid,
+                'question' => $d['question'],
+                'difficulty' => 2,
+                'category_id' => $catId,
+                'source_id' => $sourceId,
+                'flag' => 0,
+                'tag_ids' => [$themeTag->id, $simpleTag->id, $contTag->id],
+                'answers' => $d['answers'],
+                'options' => $d['options'],
+            ];
+        }
+
+        $service->seed($items);
+    }
+}

--- a/database/seeders/PresentSimpleOrContinuousSeeder.php
+++ b/database/seeders/PresentSimpleOrContinuousSeeder.php
@@ -28,16 +28,16 @@ class PresentSimpleOrContinuousSeeder extends Seeder
             [
                 'question' => 'How often {a1} you {a2} to the cinema?',
                 'answers'  => [
-                    'a1' => ['answer' => 'do', 'verb_hint' => 'do'],
-                    'a2' => ['answer' => 'go', 'verb_hint' => 'go'],
+                    ['marker' => 'a1', 'answer' => 'do', 'verb_hint' => 'do'],
+                    ['marker' => 'a2', 'answer' => 'go', 'verb_hint' => 'go'],
                 ],
                 'options'  => ['do', 'are', 'go', 'going'],
             ],
             [
                 'question' => 'Why {a1} you {a2} at me now?',
                 'answers'  => [
-                    'a1' => ['answer' => 'are', 'verb_hint' => 'be'],
-                    'a2' => ['answer' => 'shouting', 'verb_hint' => 'shout'],
+                    ['marker' => 'a1', 'answer' => 'are', 'verb_hint' => 'be'],
+                    ['marker' => 'a2', 'answer' => 'shouting', 'verb_hint' => 'shout'],
                 ],
                 'options'  => ['are', 'do', 'shout', 'shouting'],
             ],
@@ -49,16 +49,16 @@ class PresentSimpleOrContinuousSeeder extends Seeder
             [
                 'question' => '{a1} you {a2} who I am?',
                 'answers'  => [
-                    'a1' => ['answer' => 'Do', 'verb_hint' => 'do'],
-                    'a2' => ['answer' => 'know', 'verb_hint' => 'know'],
+                    ['marker' => 'a1', 'answer' => 'Do', 'verb_hint' => 'do'],
+                    ['marker' => 'a2', 'answer' => 'know', 'verb_hint' => 'know'],
                 ],
                 'options'  => ['Do', 'Are', 'know', 'knowing'],
             ],
             [
                 'question' => 'How much coffee {a1} you {a2}?',
                 'answers'  => [
-                    'a1' => ['answer' => 'do', 'verb_hint' => 'do'],
-                    'a2' => ['answer' => 'drink', 'verb_hint' => 'drink'],
+                    ['marker' => 'a1', 'answer' => 'do', 'verb_hint' => 'do'],
+                    ['marker' => 'a2', 'answer' => 'drink', 'verb_hint' => 'drink'],
                 ],
                 'options'  => ['do', 'are', 'drink', 'drinking'],
             ],
@@ -80,8 +80,8 @@ class PresentSimpleOrContinuousSeeder extends Seeder
             [
                 'question' => 'Who {a1} you {a2} to now?',
                 'answers'  => [
-                    'a1' => ['answer' => 'are', 'verb_hint' => 'be'],
-                    'a2' => ['answer' => 'talking', 'verb_hint' => 'talk'],
+                    ['marker' => 'a1', 'answer' => 'are', 'verb_hint' => 'be'],
+                    ['marker' => 'a2', 'answer' => 'talking', 'verb_hint' => 'talk'],
                 ],
                 'options'  => ['are', 'do', 'talk', 'talking'],
             ],
@@ -93,8 +93,8 @@ class PresentSimpleOrContinuousSeeder extends Seeder
             [
                 'question' => '{a1} you {a2} chocolate?',
                 'answers'  => [
-                    'a1' => ['answer' => 'Do', 'verb_hint' => 'do'],
-                    'a2' => ['answer' => 'like', 'verb_hint' => 'like'],
+                    ['marker' => 'a1', 'answer' => 'Do', 'verb_hint' => 'do'],
+                    ['marker' => 'a2', 'answer' => 'like', 'verb_hint' => 'like'],
                 ],
                 'options'  => ['Do', 'Are', 'like', 'liking'],
             ],
@@ -126,16 +126,16 @@ class PresentSimpleOrContinuousSeeder extends Seeder
             [
                 'question' => 'Rebecca {a1} books, she {a2} films.',
                 'answers'  => [
-                    'a1' => ['answer' => "doesn't read", 'verb_hint' => 'not/read'],
-                    'a2' => ['answer' => 'prefers', 'verb_hint' => 'prefer'],
+                    ['marker' => 'a1', 'answer' => "doesn't read", 'verb_hint' => 'not/read'],
+                    ['marker' => 'a2', 'answer' => 'prefers', 'verb_hint' => 'prefer'],
                 ],
                 'options'  => ["doesn't read", "isn't reading", 'prefer', 'prefers'],
             ],
             [
                 'question' => 'Look! Who {a1} she {a2} to?',
                 'answers'  => [
-                    'a1' => ['answer' => 'is', 'verb_hint' => 'be'],
-                    'a2' => ['answer' => 'talking', 'verb_hint' => 'talk'],
+                    ['marker' => 'a1', 'answer' => 'is', 'verb_hint' => 'be'],
+                    ['marker' => 'a2', 'answer' => 'talking', 'verb_hint' => 'talk'],
                 ],
                 'options'  => ['is', 'does', 'talking', 'talks'],
             ],

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,7 +9,14 @@
         .text-base{
             line-height: 2.2rem !important;
         }
-    </style>    
+        .test-description {
+            background-color: #fefce8; /* yellow-50 */
+            border-left: 4px solid #f59e0b; /* yellow-500 */
+            padding: 1rem;
+            border-radius: 0.5rem;
+            margin-bottom: 1rem;
+        }
+    </style>
 </head>
 <body class="bg-gray-50 min-h-screen flex flex-col">
 

--- a/resources/views/saved-test-random.blade.php
+++ b/resources/views/saved-test-random.blade.php
@@ -8,6 +8,9 @@
         <h1 class="text-2xl font-bold mb-2">{{ $test->name }} - Random Inputs</h1>
         <a href="{{ route('saved-test.show', $test->slug) }}" class="text-sm text-blue-600 underline">Back</a>
     </div>
+    @if($test->description)
+        <div class="mb-6 text-gray-800">{{ $test->description }}</div>
+    @endif
     <form action="{{ route('grammar-test.check') }}" method="POST" class="space-y-6">
         @csrf
         @foreach($questions as $q)

--- a/resources/views/saved-test-random.blade.php
+++ b/resources/views/saved-test-random.blade.php
@@ -9,7 +9,7 @@
         <a href="{{ route('saved-test.show', $test->slug) }}" class="text-sm text-blue-600 underline">Back</a>
     </div>
     @if($test->description)
-        <div class="mb-6 text-gray-800">{{ $test->description }}</div>
+        <div class="test-description text-gray-800">{{ $test->description }}</div>
     @endif
     <form action="{{ route('grammar-test.check') }}" method="POST" class="space-y-6">
         @csrf

--- a/resources/views/saved-test-step.blade.php
+++ b/resources/views/saved-test-step.blade.php
@@ -9,7 +9,7 @@
         <a href="{{ route('saved-test.show', $test->slug) }}" class="text-sm text-blue-600 underline">Back</a>
     </div>
     @if($test->description)
-        <div class="mb-4 text-gray-800">{{ $test->description }}</div>
+        <div class="test-description text-gray-800">{{ $test->description }}</div>
     @endif
     <div class="mb-4 flex gap-4 text-gray-600 text-base">
         <div>Total: <b>{{ $stats['total'] }} / {{ $totalCount }}</b></div>

--- a/resources/views/saved-test-step.blade.php
+++ b/resources/views/saved-test-step.blade.php
@@ -8,6 +8,9 @@
         <h1 class="text-2xl font-bold">{{ $test->name }} - Step Mode</h1>
         <a href="{{ route('saved-test.show', $test->slug) }}" class="text-sm text-blue-600 underline">Back</a>
     </div>
+    @if($test->description)
+        <div class="mb-4 text-gray-800">{{ $test->description }}</div>
+    @endif
     <div class="mb-4 flex gap-4 text-gray-600 text-base">
         <div>Total: <b>{{ $stats['total'] }} / {{ $totalCount }}</b></div>
         <div>Correct: <b class="text-green-700">{{ $stats['correct'] }}</b></div>

--- a/resources/views/saved-test.blade.php
+++ b/resources/views/saved-test.blade.php
@@ -24,6 +24,9 @@
             <a href="{{ route('saved-test.step', $test->slug) }}" class="text-blue-600 underline">Step Mode</a>
         </div>
     </div>
+    @if($test->description)
+        <div class="mb-6 text-gray-800">{{ $test->description }}</div>
+    @endif
     <form action="{{ route('grammar-test.check') }}" method="POST" class="space-y-6">
         @csrf
         @foreach($questions as $q)

--- a/resources/views/saved-test.blade.php
+++ b/resources/views/saved-test.blade.php
@@ -25,7 +25,7 @@
         </div>
     </div>
     @if($test->description)
-        <div class="mb-6 text-gray-800">{{ $test->description }}</div>
+        <div class="test-description text-gray-800">{{ $test->description }}</div>
     @endif
     <form action="{{ route('grammar-test.check') }}" method="POST" class="space-y-6">
         @csrf

--- a/resources/views/saved-tests-cards.blade.php
+++ b/resources/views/saved-tests-cards.blade.php
@@ -59,6 +59,9 @@
                                 <span class="inline-block bg-gray-200 px-2 py-0.5 mr-1 mb-1 rounded">{{ $t }}</span>
                             @endforeach
                         </div>
+                        @if($test->description)
+                            <div class="text-sm mb-3 text-gray-800">{{ \Illuminate\Support\Str::limit($test->description, 120) }}</div>
+                        @endif
                         <a href="{{ route('saved-test.show', $test->slug) }}" class="mt-auto inline-block text-center bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-2xl text-sm font-semibold">Пройти тест</a>
                     </div>
                 @endforeach

--- a/resources/views/saved-tests-cards.blade.php
+++ b/resources/views/saved-tests-cards.blade.php
@@ -60,7 +60,7 @@
                             @endforeach
                         </div>
                         @if($test->description)
-                            <div class="text-sm mb-3 text-gray-800">{{ \Illuminate\Support\Str::limit($test->description, 120) }}</div>
+                            <div class="test-description text-sm text-gray-800 mb-3">{{ \Illuminate\Support\Str::limit($test->description, 120) }}</div>
                         @endif
                         <a href="{{ route('saved-test.show', $test->slug) }}" class="mt-auto inline-block text-center bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-2xl text-sm font-semibold">Пройти тест</a>
                     </div>

--- a/resources/views/saved-tests.blade.php
+++ b/resources/views/saved-tests.blade.php
@@ -24,7 +24,7 @@
                         <span>Питань: {{ is_array($test->questions) ? count($test->questions) : (is_string($test->questions) ? count(json_decode($test->questions, true) ?? []) : 0) }}</span>
                     </div>
                     @if($test->description)
-                        <div class="text-sm text-gray-800 mt-1">{{ \Illuminate\Support\Str::limit($test->description, 120) }}</div>
+                        <div class="test-description text-sm text-gray-800 mt-1">{{ \Illuminate\Support\Str::limit($test->description, 120) }}</div>
                     @endif
                 </div>
                 <div class="flex gap-2">

--- a/resources/views/saved-tests.blade.php
+++ b/resources/views/saved-tests.blade.php
@@ -23,6 +23,9 @@
                         <span>Створено: {{ $test->created_at->format('d.m.Y H:i') }}</span>
                         <span>Питань: {{ is_array($test->questions) ? count($test->questions) : (is_string($test->questions) ? count(json_decode($test->questions, true) ?? []) : 0) }}</span>
                     </div>
+                    @if($test->description)
+                        <div class="text-sm text-gray-800 mt-1">{{ \Illuminate\Support\Str::limit($test->description, 120) }}</div>
+                    @endif
                 </div>
                 <div class="flex gap-2">
                     <a href="{{ route('saved-test.show', $test->slug) }}"


### PR DESCRIPTION
## Summary
- add `PresentSimpleOrContinuousSeeder` with 20 questions
- register new seeder in `DatabaseSeeder`

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688c95d6501c832aacb1181bf6d5c882