### PR TITLE
Add question deletion to saved tests

### DIFF
--- a/resources/views/saved-test-step.blade.php
+++ b/resources/views/saved-test-step.blade.php
@@ -28,10 +28,17 @@
         <div>Wrong: <b class="text-red-700">{{ $stats['wrong'] }}</b></div>
         <div>Percent: <b>{{ $percentage }}%</b></div>
     </div>
-    <form method="POST" action="{{ route('saved-test.step.reset', $test->slug) }}" class="mb-4">
-        @csrf
-        <button type="submit" class="bg-gray-200 px-4 py-1 rounded hover:bg-gray-300 transition text-sm">Reset</button>
-    </form>
+    <div class="mb-4 flex gap-2">
+        <form method="POST" action="{{ route('saved-test.step.reset', $test->slug) }}">
+            @csrf
+            <button type="submit" class="bg-gray-200 px-4 py-1 rounded hover:bg-gray-300 transition text-sm">Reset</button>
+        </form>
+        <form method="POST" action="{{ route('saved-test.question.destroy', [$test->slug, $question->id]) }}" onsubmit="return confirm('Delete this question?')">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="bg-red-200 px-4 py-1 rounded hover:bg-red-300 transition text-sm">Delete</button>
+        </form>
+    </div>
 
     @if(isset($feedback))
         <div class="mb-4">

--- a/resources/views/saved-test.blade.php
+++ b/resources/views/saved-test.blade.php
@@ -45,8 +45,8 @@
             <div class="bg-white shadow rounded-2xl p-4 mb-4">
                
                 <div class="flex gap-2 items-baseline">
-                     <span class="font-bold text-base">{{ $loop->iteration }}.</span>
-                    
+                    <span class="font-bold text-base">{{ $loop->iteration }}.</span>
+
 @php preg_match_all('/\{a(\d+)\}/', $q->question, $matches); @endphp
 @include('components.question-input', [
     'question' => $q,
@@ -56,6 +56,7 @@
     'builderInput' => $builderInput,
 ])
 <a href="{{ route('question-review.edit', $q->id) }}" class="ml-2 text-sm text-blue-600 underline">Edit</a>
+<button type="submit" form="delete-question-{{ $q->id }}" class="text-sm text-red-600 underline" onclick="return confirm('Delete this question?')">Delete</button>
                 </div>
                 @if($q->tags->count())
                     <div class="mt-1 space-x-1">
@@ -74,6 +75,12 @@
             Перевірити
         </button>
     </form>
+@foreach($questions as $q)
+    <form id="delete-question-{{ $q->id }}" action="{{ route('saved-test.question.destroy', [$test->slug, $q->id]) }}" method="POST" class="hidden">
+        @csrf
+        @method('DELETE')
+    </form>
+@endforeach
 </div>
 <script>
 function builder(route, prefix) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,6 +62,7 @@ Route::get('/test/{slug}/step', [GrammarTestController::class, 'showSavedTestSte
 Route::post('/test/{slug}/refresh-description', [GrammarTestController::class, 'refreshDescription'])->name('saved-test.refresh');
 Route::post('/test/{slug}/step/check', [GrammarTestController::class, 'checkSavedTestStep'])->name('saved-test.step.check');
 Route::post('/test/{slug}/step/reset', [GrammarTestController::class, 'resetSavedTestStep'])->name('saved-test.step.reset');
+Route::delete('/test/{slug}/question/{question}', [GrammarTestController::class, 'deleteQuestion'])->name('saved-test.question.destroy');
 Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
 Route::delete('/tests/{test}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
 Route::get('/tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('saved-tests.cards');

--- a/tests/Feature/DeleteQuestionTest.php
+++ b/tests/Feature/DeleteQuestionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+use App\Models\{Category, Question, QuestionOption, QuestionAnswer};
+
+class DeleteQuestionTest extends TestCase
+{
+    /** @test */
+    public function question_can_be_deleted_from_saved_test(): void
+    {
+        $migrations = [
+            '2025_07_20_143201_create_categories_table.php',
+            '2025_07_20_143210_create_quastion_table.php',
+            '2025_07_20_143230_create_quastion_options_table.php',
+            '2025_07_20_143243_create_quastion_answers_table.php',
+            '2025_07_20_164021_add_verb_hint_to_question_answers.php',
+            '2025_07_20_180521_add_flag_to_question_table.php',
+            '2025_07_20_193626_add_source_to_qustion_table.php',
+            '2025_07_27_000001_add_unique_index_to_question_answers.php',
+            '2025_07_28_000002_create_verb_hints_table.php',
+            '2025_07_29_000001_create_question_option_question_table.php',
+            '2025_07_30_000003_create_question_tag_table.php',
+            '2025_07_31_000002_add_uuid_to_questions_table.php',
+            '2025_07_20_184450_create_tests_table.php',
+        ];
+        foreach ($migrations as $file) {
+            Artisan::call('migrate', ['--path' => 'database/migrations/' . $file]);
+        }
+
+        \Illuminate\Support\Facades\Schema::table('question_option_question', function ($table) {
+            $table->tinyInteger('flag')->nullable()->after('option_id');
+        });
+
+        $category = Category::create(['name' => 'test']);
+
+        $q1 = Question::create([
+            'uuid' => 'uuid-1',
+            'question' => 'Choose {a1}',
+            'difficulty' => 1,
+            'category_id' => $category->id,
+        ]);
+        $opt1 = new QuestionOption(['option' => 'yes']);
+        $opt1->question_id = $q1->id;
+        $opt1->save();
+        $q1->options()->attach($opt1->id);
+        $qa1 = new QuestionAnswer(['marker' => 'a1']);
+        $qa1->question_id = $q1->id;
+        $qa1->answer = 'yes';
+        $qa1->save();
+
+        $q2 = Question::create([
+            'uuid' => 'uuid-2',
+            'question' => 'Choose {a1} too',
+            'difficulty' => 1,
+            'category_id' => $category->id,
+        ]);
+        $opt2 = new QuestionOption(['option' => 'no']);
+        $opt2->question_id = $q2->id;
+        $opt2->save();
+        $q2->options()->attach($opt2->id);
+        $qa2 = new QuestionAnswer(['marker' => 'a1']);
+        $qa2->question_id = $q2->id;
+        $qa2->answer = 'no';
+        $qa2->save();
+
+        $test = \App\Models\Test::create([
+            'name' => 'sample',
+            'slug' => 'sample',
+            'filters' => [],
+            'questions' => [$q1->id, $q2->id],
+        ]);
+
+        $response = $this->delete('/test/'.$test->slug.'/question/'.$q1->id, [], ['HTTP_REFERER' => '/test/'.$test->slug]);
+        $response->assertRedirect('/test/'.$test->slug);
+
+        $test->refresh();
+        $this->assertEquals([$q2->id], $test->questions);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add deleteQuestion controller method and routing
- show delete buttons on saved test and step pages
- cover question removal with feature test

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6890aa6be274832a8c845cacc1e42fd3