### PR TITLE
Add word scanning service and artisan command

### DIFF
--- a/app/Console/Commands/ScanWordsCommand.php
+++ b/app/Console/Commands/ScanWordsCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Services\WordScanningService;
+
+class ScanWordsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'words:scan';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Scan questions and options and store unique words';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(WordScanningService $service): int
+    {
+        $count = $service->scan();
+        $this->info("Inserted {$count} new words.");
+        return Command::SUCCESS;
+    }
+}

--- a/app/Services/WordScanningService.php
+++ b/app/Services/WordScanningService.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Question;
+use App\Models\QuestionOption;
+use App\Models\Word;
+
+class WordScanningService
+{
+    /**
+     * Scan questions and options for words and insert missing ones into words table.
+     *
+     * @return int Number of new words inserted.
+     */
+    public function scan(): int
+    {
+        // Collect all text from questions and options
+        $texts = Question::pluck('question')
+            ->merge(QuestionOption::pluck('option'));
+
+        $words = [];
+        foreach ($texts as $text) {
+            $parts = preg_split('/[^\p{L}]+/u', mb_strtolower($text));
+            foreach ($parts as $part) {
+                if ($part !== '') {
+                    $words[$part] = true;
+                }
+            }
+        }
+
+        $words = array_keys($words);
+        if (empty($words)) {
+            return 0;
+        }
+
+        $existing = Word::whereIn('word', $words)->pluck('word')->all();
+        $newWords = array_diff($words, $existing);
+
+        foreach ($newWords as $word) {
+            Word::create(['word' => $word]);
+        }
+
+        return count($newWords);
+    }
+}


### PR DESCRIPTION
## Summary
- add `WordScanningService` to extract unique words from questions and options
- introduce `words:scan` artisan command to trigger word extraction

## Testing
- `php artisan list | grep words:scan`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6895f845a904832aabea9de2caa31f4a