### PR TITLE
Show tags on step test page

### DIFF
--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -148,7 +148,7 @@ class GrammarTestController extends Controller
             session([$key . '_queue' => $queue, $key . '_current' => $currentId]);
         }
 
-        $question = \App\Models\Question::with(['options', 'answers.option', 'verbHints.option'])
+        $question = \App\Models\Question::with(['options', 'answers.option', 'verbHints.option', 'tags'])
             ->findOrFail($currentId);
         $feedback = session($key . '_feedback');
         session()->forget($key . '_feedback');

--- a/resources/views/saved-test-step.blade.php
+++ b/resources/views/saved-test-step.blade.php
@@ -100,6 +100,16 @@
             <a href="{{ route('question-review.edit', $question->id) }}" class="text-sm text-blue-600 underline">Edit</a>
             <button type="submit" form="delete-question-{{ $question->id }}" class="text-sm text-red-600 underline" onclick="return confirm('Delete this question?')">Delete</button>
         </div>
+        @if($question->tags->count())
+            <div class="mt-1 space-x-1">
+                @php
+                    $colors = ['bg-blue-200 text-blue-800', 'bg-green-200 text-green-800', 'bg-red-200 text-red-800', 'bg-purple-200 text-purple-800', 'bg-pink-200 text-pink-800', 'bg-yellow-200 text-yellow-800', 'bg-indigo-200 text-indigo-800', 'bg-teal-200 text-teal-800'];
+                @endphp
+                @foreach($question->tags as $tag)
+                    <a href="{{ route('saved-tests.cards', ['tag' => $tag->name]) }}" class="inline-block px-2 py-0.5 rounded text-xs font-semibold hover:underline {{ $colors[$loop->index % count($colors)] }}">{{ $tag->name }}</a>
+                @endforeach
+            </div>
+        @endif
         <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-xl font-semibold">
             {{ isset($feedback) ? 'Next' : 'Check' }}
         </button>

--- a/tests/Feature/SavedTestStepTagsTest.php
+++ b/tests/Feature/SavedTestStepTagsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\{Artisan, Schema, DB};
+use Tests\TestCase;
+use App\Models\{Category, Question, QuestionOption, QuestionAnswer, Test, Tag};
+
+class SavedTestStepTagsTest extends TestCase
+{
+    /** @test */
+    public function step_page_displays_question_tags(): void
+    {
+        $migrations = [
+            '2025_07_20_143201_create_categories_table.php',
+            '2025_07_20_143210_create_quastion_table.php',
+            '2025_07_20_143230_create_quastion_options_table.php',
+            '2025_07_20_143243_create_quastion_answers_table.php',
+            '2025_07_20_164021_add_verb_hint_to_question_answers.php',
+            '2025_07_20_180521_add_flag_to_question_table.php',
+            '2025_07_20_193626_add_source_to_qustion_table.php',
+            '2025_07_27_000001_add_unique_index_to_question_answers.php',
+            '2025_07_28_000002_create_verb_hints_table.php',
+            '2025_07_29_000001_create_question_option_question_table.php',
+            '2025_07_30_000001_create_tags_table.php',
+            '2025_07_30_000003_create_question_tag_table.php',
+            '2025_07_31_000002_add_uuid_to_questions_table.php',
+            '2025_07_20_184450_create_tests_table.php',
+            '2025_08_04_000002_add_description_to_tests_table.php',
+        ];
+        foreach ($migrations as $file) {
+            Artisan::call('migrate', ['--path' => 'database/migrations/' . $file]);
+        }
+
+        DB::statement('DROP TABLE question_options');
+        DB::statement('CREATE TABLE question_options (id INTEGER PRIMARY KEY AUTOINCREMENT, option VARCHAR UNIQUE, created_at DATETIME, updated_at DATETIME)');
+
+        Schema::table('question_option_question', function ($table) {
+            $table->tinyInteger('flag')->nullable()->after('option_id');
+        });
+
+        $category = Category::create(['name' => 'test']);
+
+        $question = Question::create([
+            'uuid' => 'q1',
+            'question' => 'Q1 {a1}',
+            'difficulty' => 1,
+            'category_id' => $category->id,
+        ]);
+
+        $option = QuestionOption::create(['option' => 'yes']);
+        $question->options()->attach($option->id);
+        $answer = new QuestionAnswer();
+        $answer->marker = 'a1';
+        $answer->answer = 'yes';
+        $answer->question_id = $question->id;
+        $answer->save();
+
+        $tag = Tag::create(['name' => 'sample-tag']);
+        $question->tags()->attach($tag->id);
+
+        $testModel = Test::create([
+            'name' => 'sample',
+            'slug' => 'sample',
+            'filters' => [],
+            'questions' => [$question->id],
+        ]);
+
+        $response = $this->get('/test/' . $testModel->slug . '/step');
+        $response->assertStatus(200);
+        $response->assertSee($tag->name);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Load question tags in step-mode controller
- Render tag badges on /test/{slug}/step page
- Test that step page displays associated tags

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689a3e19f640832aaa192ade1d60d174