### PR TITLE
Fix Add Tag button submitting form

### DIFF
--- a/resources/views/saved-test-step.blade.php
+++ b/resources/views/saved-test-step.blade.php
@@ -217,6 +217,7 @@ document.getElementById('determine-tense').addEventListener('click', () => {
                     const btn = document.createElement('button');
                     btn.textContent = 'Додати тег';
                     btn.className = 'text-xs text-blue-600 underline';
+                    btn.type = 'button';
                     btn.addEventListener('click', () => addTag(tag));
                     wrapper.appendChild(span);
                     wrapper.appendChild(btn);


### PR DESCRIPTION
## Summary
- prevent form submission when clicking dynamically added "Add Tag" button on saved test step

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689a4db0f5d4832aac16c4527c3a8c58