### PR TITLE
Enable tag removal and level selection

### DIFF
--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -374,6 +374,30 @@ class GrammarTestController extends Controller
         return response()->json(['tags' => $question->tags->pluck('name')]);
     }
 
+    public function removeTag(Request $request, $slug)
+    {
+        $test = Test::where('slug', $slug)->firstOrFail();
+        $request->validate([
+            'question_id' => 'required|integer',
+            'tag' => 'required|string',
+        ]);
+
+        $question = Question::findOrFail($request->input('question_id'));
+        if (! in_array($question->id, $test->questions)) {
+            abort(404);
+        }
+
+        $tag = Tag::where('name', $request->input('tag'))->first();
+        if (! $tag) {
+            return response()->json(['message' => 'Tag not found'], 404);
+        }
+
+        $question->tags()->detach($tag->id);
+        $question->load('tags');
+
+        return response()->json(['tags' => $question->tags->pluck('name')]);
+    }
+
     public function resetSavedTestStep($slug)
     {
         $test = \App\Models\Test::where('slug', $slug)->firstOrFail();

--- a/routes/web.php
+++ b/routes/web.php
@@ -69,6 +69,7 @@ Route::post('/test/{slug}/step/determine-level', [GrammarTestController::class, 
 Route::post('/test/{slug}/step/determine-level-gemini', [GrammarTestController::class, 'determineLevelGemini'])->name('saved-test.step.determine-level-gemini');
 Route::post('/test/{slug}/step/set-level', [GrammarTestController::class, 'setLevel'])->name('saved-test.step.set-level');
 Route::post('/test/{slug}/step/add-tag', [GrammarTestController::class, 'addTag'])->name('saved-test.step.add-tag');
+Route::delete('/test/{slug}/step/remove-tag', [GrammarTestController::class, 'removeTag'])->name('saved-test.step.remove-tag');
 Route::delete('/test/{slug}/question/{question}', [GrammarTestController::class, 'deleteQuestion'])->name('saved-test.question.destroy');
 Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
 Route::delete('/tests/{test}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');

--- a/tests/Feature/RemoveTagFromQuestionTest.php
+++ b/tests/Feature/RemoveTagFromQuestionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\{Artisan, Schema, DB};
+use Tests\TestCase;
+use App\Models\{Category, Question, QuestionOption, QuestionAnswer, Test, Tag};
+
+class RemoveTagFromQuestionTest extends TestCase
+{
+    /** @test */
+    public function remove_tag_endpoint_detaches_tag_from_question(): void
+    {
+        $migrations = [
+            '2025_07_20_143201_create_categories_table.php',
+            '2025_07_20_143210_create_quastion_table.php',
+            '2025_07_20_143230_create_quastion_options_table.php',
+            '2025_07_20_143243_create_quastion_answers_table.php',
+            '2025_07_20_164021_add_verb_hint_to_question_answers.php',
+            '2025_07_20_180521_add_flag_to_question_table.php',
+            '2025_07_20_193626_add_source_to_qustion_table.php',
+            '2025_07_27_000001_add_unique_index_to_question_answers.php',
+            '2025_07_28_000002_create_verb_hints_table.php',
+            '2025_07_29_000001_create_question_option_question_table.php',
+            '2025_07_30_000001_create_tags_table.php',
+            '2025_07_30_000003_create_question_tag_table.php',
+            '2025_07_31_000002_add_uuid_to_questions_table.php',
+            '2025_07_20_184450_create_tests_table.php',
+            '2025_08_01_000001_add_category_to_tags_table.php',
+            '2025_08_04_000002_add_description_to_tests_table.php',
+        ];
+        foreach ($migrations as $file) {
+            Artisan::call('migrate', ['--path' => 'database/migrations/' . $file]);
+        }
+
+        DB::statement('DROP TABLE question_options');
+        DB::statement('CREATE TABLE question_options (id INTEGER PRIMARY KEY AUTOINCREMENT, option VARCHAR UNIQUE, created_at DATETIME, updated_at DATETIME)');
+
+        Schema::table('question_option_question', function ($table) {
+            $table->tinyInteger('flag')->nullable()->after('option_id');
+        });
+
+        $category = Category::create(['name' => 'test']);
+
+        $question = Question::create([
+            'uuid' => 'q1',
+            'question' => 'Q1 {a1}',
+            'difficulty' => 1,
+            'category_id' => $category->id,
+        ]);
+
+        $option = QuestionOption::create(['option' => 'yes']);
+        $question->options()->attach($option->id);
+        $answer = new QuestionAnswer();
+        $answer->marker = 'a1';
+        $answer->answer = 'yes';
+        $answer->question_id = $question->id;
+        $answer->save();
+
+        $tag = Tag::create(['name' => 'Past Simple', 'category' => 'Tenses']);
+        $question->tags()->attach($tag->id);
+
+        $testModel = Test::create([
+            'name' => 'sample',
+            'slug' => 'sample',
+            'filters' => [],
+            'questions' => [$question->id],
+        ]);
+
+        $response = $this->deleteJson('/test/' . $testModel->slug . '/step/remove-tag', [
+            'question_id' => $question->id,
+            'tag' => $tag->name,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['tags' => []]);
+        $this->assertDatabaseMissing('question_tag', [
+            'question_id' => $question->id,
+            'tag_id' => $tag->id,
+        ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Allow deleting question tags with inline `x` controls
- Display and set question level via selectable A1–C2 tags
- Add remove-tag endpoint with test coverage

## Testing
- `php artisan test` *(fails: Tests\Feature\AiGrammarTestPageTest)*
- `php artisan test tests/Feature/RemoveTagFromQuestionTest.php` *(warn: missing .env)*

------
https://chatgpt.com/codex/tasks/task_e_68a185579d30832abeecb8161a651c48