### PR TITLE
Enable hints for AI-generated questions without database ID

### DIFF
--- a/database/seeders/GrammarTestAISeeder.php
+++ b/database/seeders/GrammarTestAISeeder.php
@@ -167,50 +167,7 @@ class GrammarTestAISeeder extends Seeder
                 'answers' => [['marker' => 'a1', 'answer' => 'will be', 'verb_hint' => 'be']],
                 'options' => ['is', 'was', 'be', 'will be', 'being'],
             ],
-            // Додаємо ще 30 питань для всіх рівнів складності і різних часів (буде частина скопійовано зі змінами!)
         ];
-
-        // --- Генеруємо ще питання (для прикладу просто змінюємо дані на схожі) ---
-        $catIds = [1,2,3,4,5,6]; // Приклад категорій
-        $verbs = [
-            ['play', 'plays', 'played', 'playing', 'has played'],
-            ['run', 'runs', 'ran', 'running', 'has run'],
-            ['swim', 'swims', 'swam', 'swimming', 'has swum'],
-            ['drive', 'drives', 'drove', 'driving', 'has driven'],
-            ['eat', 'eats', 'ate', 'eating', 'has eaten'],
-        ];
-        for ($i=0; $i<30; $i++) {
-            $diff = 5 + ($i % 6); // 5–10
-            $cat = $catIds[$i % count($catIds)];
-            $v = $verbs[$i % count($verbs)];
-            $aiQuestions[] = [
-                'question' => 'He {a1} and then {a2} every morning.',
-                'difficulty' => $diff,
-                'category_id' => $cat,
-                'flag' => 1,
-                'source_id' => $sourceIds['AI: Mixed Tenses'],
-                'answers' => [
-                    ['marker' => 'a1', 'answer' => $v[1], 'verb_hint' => $v[0]],
-                    ['marker' => 'a2', 'answer' => $v[3], 'verb_hint' => $v[0]],
-                ],
-                'options' => [$v[0], $v[1], $v[2], $v[3], $v[4]],
-            ];
-        }
-        // --- Додаємо ще декілька для max diff ---
-        for ($i=0; $i<5; $i++) {
-            $aiQuestions[] = [
-                'question' => 'If I {a1} enough time, I {a2} this project.',
-                'difficulty' => 10,
-                'category_id' => 6,
-                'flag' => 1,
-                'source_id' => $sourceIds['AI: Conditionals Advanced'],
-                'answers' => [
-                    ['marker' => 'a1', 'answer' => 'had', 'verb_hint' => 'have'],
-                    ['marker' => 'a2', 'answer' => 'would finish', 'verb_hint' => 'finish'],
-                ],
-                'options' => ['have', 'had', 'will finish', 'finished', 'would finish'],
-            ];
-        }
 
         $service = new QuestionSeedingService();
         $items = [];

--- a/resources/views/components/question-input.blade.php
+++ b/resources/views/components/question-input.blade.php
@@ -94,24 +94,35 @@ HTML;
 
 @endphp
 
-<div 
-    x-data="{
-        hints: { chatgpt:'', gemini:'' }, 
-        fetchHints(refresh = false) {
-            let qid = {{ $question?->id ?? 'null' }};
-            if (!qid) return; // немає question_id
-            fetch('{{ route('question.hint') }}', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                },
-                body: JSON.stringify({ question_id: qid, refresh })
-            })
-            .then(r => r.json())
-            .then(d => this.hints = d);
+<div
+    x-data='{
+        qid: {{ $question?->id ?? 'null' }},
+        qtext: @json($question->question),
+        hints: { chatgpt: "", gemini: "" },
+        async fetchHints(refresh = false) {
+            if (!this.qid && !this.qtext) return; // немає даних питання
+            const payload = { refresh };
+            if (this.qid) {
+                payload.question_id = this.qid;
+            } else {
+                payload.question = this.qtext;
+            }
+            try {
+                const r = await fetch("{{ route('question.hint') }}", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "X-CSRF-TOKEN": "{{ csrf_token() }}"
+                    },
+                    body: JSON.stringify(payload)
+                });
+                const d = await r.json();
+                this.hints = d;
+            } catch (e) {
+                console.error(e);
+            }
         }
-    }"
+    }'
 ><label class="text-base" style="white-space:normal">{!! $finalQuestion !!}</label>
     <button type="button" class="text-xs text-blue-600 underline ml-1" @click="fetchHints()">Help</button>
     <template x-if="hints.chatgpt || hints.gemini">

--- a/tests/Feature/QuestionHintCacheTest.php
+++ b/tests/Feature/QuestionHintCacheTest.php
@@ -16,6 +16,7 @@ class QuestionHintCacheTest extends TestCase
         $migrations = [
             '2025_07_20_143201_create_categories_table.php',
             '2025_07_20_143210_create_quastion_table.php',
+            '2025_07_20_143243_create_quastion_answers_table.php',
             '2025_07_31_000002_add_uuid_to_questions_table.php',
             '2025_08_05_000001_create_question_hints_table.php',
         ];
@@ -72,5 +73,26 @@ class QuestionHintCacheTest extends TestCase
             'provider' => 'chatgpt',
             'hint' => 'second-gpt',
         ]);
+    }
+
+    /** @test */
+    public function hints_can_be_generated_from_question_text()
+    {
+        $this->mock(ChatGPTService::class, function ($mock) {
+            $mock->shouldReceive('hintSentenceStructure')
+                ->once()
+                ->andReturn('text-gpt');
+        });
+        $this->mock(GeminiService::class, function ($mock) {
+            $mock->shouldReceive('hintSentenceStructure')
+                ->once()
+                ->andReturn('text-gemini');
+        });
+
+        $this->postJson(route('question.hint'), ['question' => 'Sample sentence?'])
+            ->assertJson([
+                'chatgpt' => 'text-gpt',
+                'gemini' => 'text-gemini',
+            ]);
     }
 }


### PR DESCRIPTION
## Summary
- Allow question hints to be generated using raw question text when no `question_id` is provided
- Update question input component to send question text to the hint endpoint and fetch hints asynchronously
- Fix x-data quoting so the Help button works on the AI test step
- Cover new hint behaviour with tests
- Remove autogenerated questions from AI grammar test seeder so question order matches reference

## Testing
- `composer install`
- `vendor/bin/phpunit tests/Feature/QuestionHintCacheTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1c03a3854832a866b8abf72155f54