### PR TITLE
Preserve seeder order for grammar test questions

### DIFF
--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -517,11 +517,11 @@ class GrammarTestController extends Controller
                 $query->where('flag', 0);
             }
     
-            $questions = $questions->merge($query->inRandomOrder()->limit($take)->get());
+            $questions = $questions->merge($query->orderBy('id')->limit($take)->get());
         }
-    
-        // Перемішати всі питання
-        $questions = $questions->shuffle();
+
+        // Відсортувати питання за ID, щоб зберегти порядок із сидера
+        $questions = $questions->sortBy('id')->values();
     
         // Автоматичне ім'я тесту
        // $sourcesForName = collect($questions)->pluck('source.name')->filter()->unique()->values();


### PR DESCRIPTION
## Summary
- keep generated grammar test questions ordered by ID
- sort final question set to match seeder order

## Testing
- `php artisan test` *(fails: 7 failed, 1 warning, 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a1d83b60832ab387ab3ef38dfb9f