### PR TITLE
Clear saved answers after navigation

### DIFF
--- a/resources/views/components/question-input.blade.php
+++ b/resources/views/components/question-input.blade.php
@@ -246,6 +246,21 @@ HTML;
                 localStorage.setItem(key, el.value);
             }
         });
-        window.addEventListener('DOMContentLoaded', restoreSavedAnswers);
+
+        function clearSavedAnswers() {
+            Object.keys(localStorage)
+                .filter(k => k.startsWith(`answer:${location.pathname}:`))
+                .forEach(k => localStorage.removeItem(k));
+        }
+
+        window.addEventListener('DOMContentLoaded', () => {
+            restoreSavedAnswers();
+            document.querySelectorAll('form').forEach(f => {
+                f.addEventListener('submit', clearSavedAnswers);
+            });
+            document.querySelectorAll('a[href*="nav=next"], a[href*="nav=prev"]').forEach(a => {
+                a.addEventListener('click', clearSavedAnswers);
+            });
+        });
     </script>
 @endonce


### PR DESCRIPTION
## Summary
- Clear localStorage answer cache before submitting forms or navigating via next/prev links so fields reset after check, skip, or navigation

## Testing
- `php artisan test` *(fails: Expected response status code [201, 301, 302, 303, 307, 308] but received 500)*

------
https://chatgpt.com/codex/tasks/task_e_68ab68ee2c54832a83cd62dd9a35897a