### PR TITLE
Allow removing AI-suggested tags

### DIFF
--- a/resources/views/saved-test-step.blade.php
+++ b/resources/views/saved-test-step.blade.php
@@ -209,6 +209,8 @@ function builder(route, prefix) {
 }
 
 const tagColors = @json($colors);
+let selectedGptTags = [];
+let selectedGeminiTags = [];
 
 function renderTags(tags) {
     const container = document.getElementById('question-tags');
@@ -231,8 +233,26 @@ function renderTags(tags) {
     });
 }
 
+function renderSelected(container, tags) {
+    container.innerHTML = '';
+    tags.forEach(tag => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'flex items-center gap-1';
+        const span = document.createElement('span');
+        span.textContent = tag;
+        const btn = document.createElement('button');
+        btn.textContent = 'x';
+        btn.className = 'text-xs text-red-600 underline';
+        btn.type = 'button';
+        btn.addEventListener('click', () => removeTag(tag));
+        wrapper.appendChild(span);
+        wrapper.appendChild(btn);
+        container.appendChild(wrapper);
+    });
+}
+
 function addTag(tag) {
-    fetch('{{ route('saved-test.step.add-tag', $test->slug) }}', {
+    return fetch('{{ route('saved-test.step.add-tag', $test->slug) }}', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -249,7 +269,7 @@ function addTag(tag) {
 }
 
 function removeTag(tag) {
-    fetch('{{ route('saved-test.step.remove-tag', $test->slug) }}', {
+    return fetch('{{ route('saved-test.step.remove-tag', $test->slug) }}', {
         method: 'DELETE',
         headers: {
             'Content-Type': 'application/json',
@@ -261,6 +281,10 @@ function removeTag(tag) {
         .then(d => {
             if (Array.isArray(d.tags)) {
                 renderTags(d.tags);
+                selectedGptTags = selectedGptTags.filter(t => t !== tag);
+                selectedGeminiTags = selectedGeminiTags.filter(t => t !== tag);
+                renderSelected(document.getElementById('tense-result-gpt'), selectedGptTags);
+                renderSelected(document.getElementById('tense-result-gemini'), selectedGeminiTags);
             }
         });
 }
@@ -319,7 +343,14 @@ document.getElementById('determine-tense-gpt').addEventListener('click', () => {
                     btn.textContent = 'Додати тег';
                     btn.className = 'text-xs text-blue-600 underline';
                     btn.type = 'button';
-                    btn.addEventListener('click', () => addTag(tag));
+                    btn.addEventListener('click', () => {
+                        addTag(tag).then(() => {
+                            if (!selectedGptTags.includes(tag)) {
+                                selectedGptTags.push(tag);
+                            }
+                            renderSelected(container, selectedGptTags);
+                        });
+                    });
                     wrapper.appendChild(span);
                     wrapper.appendChild(btn);
                     container.appendChild(wrapper);
@@ -351,7 +382,14 @@ document.getElementById('determine-tense-gemini').addEventListener('click', () =
                     btn.textContent = 'Додати тег';
                     btn.className = 'text-xs text-blue-600 underline';
                     btn.type = 'button';
-                    btn.addEventListener('click', () => addTag(tag));
+                    btn.addEventListener('click', () => {
+                        addTag(tag).then(() => {
+                            if (!selectedGeminiTags.includes(tag)) {
+                                selectedGeminiTags.push(tag);
+                            }
+                            renderSelected(container, selectedGeminiTags);
+                        });
+                    });
                     wrapper.appendChild(span);
                     wrapper.appendChild(btn);
                     container.appendChild(wrapper);

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,9 +2,9 @@
 
 use App\Http\Controllers\GrammarTestController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\QuestionHelpController;
 use App\Http\Controllers\TrainController;
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\QuestionHelpController;
 
 /*
 |--------------------------------------------------------------------------
@@ -32,8 +32,8 @@ Route::get('/', [HomeController::class, 'index'])->name('home');
 
 Route::get('/train/{topic?}', [TrainController::class, 'index'])->name('train');
 
-use App\Http\Controllers\WordsTestController;
 use App\Http\Controllers\SentenceTranslationTestController;
+use App\Http\Controllers\WordsTestController;
 
 Route::get('/words/test', [WordsTestController::class, 'index'])->name('words.test');
 Route::post('/words/test/check', [WordsTestController::class, 'check'])->name('words.test.check');
@@ -77,6 +77,7 @@ Route::delete('/tests/{test}', [\App\Http\Controllers\GrammarTestController::cla
 Route::get('/tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('saved-tests.cards');
 
 use App\Http\Controllers\AiTestController;
+
 Route::get('/ai-test', [AiTestController::class, 'form'])->name('ai-test.form');
 Route::post('/ai-test/start', [AiTestController::class, 'start'])->name('ai-test.start');
 Route::get('/ai-test/step', [AiTestController::class, 'step'])->name('ai-test.step');
@@ -91,15 +92,18 @@ Route::post('/ai-test/step/determine-level', [AiTestController::class, 'determin
 Route::post('/ai-test/step/determine-level-gemini', [AiTestController::class, 'determineLevelGemini'])->name('ai-test.step.determine-level-gemini');
 Route::post('/ai-test/step/set-level', [AiTestController::class, 'setLevel'])->name('ai-test.step.set-level');
 Route::post('/ai-test/step/add-tag', [AiTestController::class, 'addTag'])->name('ai-test.step.add-tag');
+Route::delete('/ai-test/step/remove-tag', [AiTestController::class, 'removeTag'])->name('ai-test.step.remove-tag');
 
 use App\Http\Controllers\QuestionReviewController;
+
 Route::get('/question-review', [QuestionReviewController::class, 'index'])->name('question-review.index');
 Route::post('/question-review', [QuestionReviewController::class, 'store'])->name('question-review.store');
 Route::get('/question-review/{question}', [QuestionReviewController::class, 'edit'])->name('question-review.edit');
 
+use App\Http\Controllers\QuestionController;
 use App\Http\Controllers\QuestionReviewResultController;
 use App\Http\Controllers\VerbHintController;
-use App\Http\Controllers\QuestionController;
+
 Route::get('/question-review-results', [QuestionReviewResultController::class, 'index'])->name('question-review-results.index');
 
 Route::post('/verb-hints', [VerbHintController::class, 'store'])->name('verb-hints.store');
@@ -108,4 +112,3 @@ Route::delete('/verb-hints/{verbHint}', [VerbHintController::class, 'destroy'])-
 Route::put('/questions/{question}', [QuestionController::class, 'update'])->name('questions.update');
 
 Route::post('/question-hint', [QuestionHelpController::class, 'hint'])->name('question.hint');
-

--- a/tests/Feature/AiTestRemoveTagTest.php
+++ b/tests/Feature/AiTestRemoveTagTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tag;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class AiTestRemoveTagTest extends TestCase
+{
+    /** @test */
+    public function remove_tag_endpoint_updates_session_tags(): void
+    {
+        $migrations = [
+            '2025_07_30_000001_create_tags_table.php',
+            '2025_08_01_000001_add_category_to_tags_table.php',
+        ];
+        foreach ($migrations as $file) {
+            Artisan::call('migrate', ['--path' => 'database/migrations/'.$file]);
+        }
+
+        $tag = Tag::create(['name' => 'Past Simple', 'category' => 'Tenses']);
+
+        $response = $this->withSession(['ai_step.tags' => [$tag->id]])
+            ->deleteJson('/ai-test/step/remove-tag', ['tag' => $tag->name]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['tags' => []]);
+        $this->assertEquals([], session('ai_step.tags'));
+    }
+}


### PR DESCRIPTION
## Summary
- show only tags that have been added and include an `x` button to detach them
- support tag detaching on AI test step via new route and controller method
- cover removing tags from AI step with a feature test

## Testing
- `./vendor/bin/phpunit tests/Feature/AiTestAddTagTest.php tests/Feature/AiTestRemoveTagTest.php`
- `./vendor/bin/phpunit` *(fails: Expected response status code [200] but received 500)*


------
https://chatgpt.com/codex/tasks/task_e_68ab76aa8c68832a92fd4d6c0883d835