### PR TITLE
Fix step test navigation counter increment bug

### DIFF
--- a/resources/views/saved-test-step.blade.php
+++ b/resources/views/saved-test-step.blade.php
@@ -141,9 +141,16 @@
                 </div>
             </div>
         </div>
-        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-xl font-semibold">
-            {{ isset($feedback) ? 'Next' : 'Check' }}
-        </button>
+        @if(isset($feedback))
+            <a href="{{ route('saved-test.step', ['slug' => $test->slug, 'nav' => 'next', 'order' => $order]) }}"
+               class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-xl font-semibold inline-block text-center">
+                Next
+            </a>
+        @else
+            <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-xl font-semibold">
+                Check
+            </button>
+        @endif
     </form>
     <form id="delete-question-{{ $question->id }}" action="{{ route('saved-test.question.destroy', [$test->slug, $question->id]) }}" method="POST" class="hidden">
         @csrf


### PR DESCRIPTION
## Summary
- Avoid incrementing total counter when navigating in step test by using GET link for Next when feedback is present

## Testing
- `vendor/bin/phpunit` *(fails: Tests\Feature\AiGrammarTestPageTest::page_generates_question_and_stores_it; Tests\Feature\AiTestStepWrongAnswerTest::step_mode_shows_user_answer_when_wrong)*

------
https://chatgpt.com/codex/tasks/task_e_68b4648f2328832aae789af95219957b