### PR TITLE
feat: add catalog tests page and predictive search

### DIFF
--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -117,16 +117,29 @@ class GrammarTestController extends Controller
             ->orderBy('id')
             ->get()
             ->map(function ($q) {
-                $answer = $q->answers->first()->option->option ?? $q->answers->first()->answer ?? '';
+                $answers = $q->answers->map(function ($a) {
+                    return $a->option->option ?? $a->answer ?? '';
+                });
+
+                $answerList = $answers->values()->toArray();
                 $options = $q->options->pluck('option')->toArray();
-                if ($answer && ! in_array($answer, $options)) {
-                    $options[] = $answer;
+                foreach ($answerList as $ans) {
+                    if ($ans && ! in_array($ans, $options)) {
+                        $options[] = $ans;
+                    }
                 }
+
+                $verbHints = $q->verbHints
+                    ->mapWithKeys(fn($vh) => [$vh->marker => $vh->option->option ?? ''])
+                    ->toArray();
+
                 return [
                     'id' => $q->id,
                     'question' => $q->question,
-                    'answer' => $answer,
-                    'verb_hint' => $q->verbHints->first()->option->option ?? '',
+                    'answer' => $answerList[0] ?? '',
+                    'answers' => $answerList,
+                    'verb_hint' => $verbHints['a1'] ?? '',
+                    'verb_hints' => $verbHints,
                     'options' => $options,
                     'tense' => $q->category->name ?? '',
                     'level' => $q->level ?? '',
@@ -804,7 +817,11 @@ class GrammarTestController extends Controller
             })->values();
         }
 
-        return view('saved-tests-cards', [
+        $view = $request->routeIs('catalog-tests.cards')
+            ? 'catalog-tests-cards'
+            : 'saved-tests-cards';
+
+        return view($view, [
             'tests' => $tests,
             'tags' => $tagsByCategory,
             'selectedTags' => $selectedTags,

--- a/app/Http/Controllers/SiteSearchController.php
+++ b/app/Http/Controllers/SiteSearchController.php
@@ -35,7 +35,7 @@ class SiteSearchController extends Controller
                 ->map(fn($t) => [
                     'title' => $t->name,
                     'type' => 'test',
-                    'url' => route('saved-test.show', $t->slug),
+                    'url' => route('saved-test.js', $t->slug),
                 ]);
         }
 

--- a/resources/views/catalog-tests-cards.blade.php
+++ b/resources/views/catalog-tests-cards.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 <div class="flex flex-col md:flex-row gap-6">
     <aside class="md:w-48 w-full md:shrink-0">
-        <form id="tag-filter" action="{{ route('saved-tests.cards') }}" method="GET">
+        <form id="tag-filter" action="{{ route('catalog-tests.cards') }}" method="GET">
             @if(isset($availableLevels) && $availableLevels->count())
                 <div class="mb-4">
                     <label class="block text-sm mb-1">Level:</label>
@@ -54,7 +54,7 @@
         </form>
         @if(!empty($selectedTags) || !empty($selectedLevels))
             <div class="mt-2">
-                <a href="{{ route('saved-tests.cards') }}" class="text-xs text-muted-foreground hover:underline">Скинути фільтр</a>
+                <a href="{{ route('catalog-tests.cards') }}" class="text-xs text-muted-foreground hover:underline">Скинути фільтр</a>
             </div>
         @endif
     </aside>

--- a/resources/views/layouts/engram.blade.php
+++ b/resources/views/layouts/engram.blade.php
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="uk" class="h-full">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>@yield('title', 'Engram — Вивчення англійської')</title>
+  <meta name="description" content="Короткі тести з англійської, проста теорія, прогрес та рекомендації." />
+
+  <!-- Google Font: Montserrat -->
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+  <!-- Tailwind CDN + runtime config -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: { sans: ['Montserrat', 'ui-sans-serif', 'system-ui', 'sans-serif'] },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            accent: { DEFAULT: 'hsl(var(--accent))', foreground: 'hsl(var(--accent-foreground))' },
+            popover: { DEFAULT: 'hsl(var(--popover))', foreground: 'hsl(var(--popover-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            success: 'hsl(var(--success))',
+            warning: 'hsl(var(--warning))',
+            destructive: { DEFAULT: 'hsl(var(--destructive))', foreground: 'hsl(var(--destructive-foreground))' },
+            info: 'hsl(var(--info))',
+          },
+          borderRadius: { xl: '0.75rem', '2xl': '1rem', '3xl': '1.5rem' },
+          boxShadow: { soft: '0 10px 30px -12px rgba(0,0,0,0.15)' }
+        }
+      }
+    }
+  </script>
+
+  <!-- Design tokens (light/dark) -->
+  <style>
+    :root {
+      /* Vibrant Surfaces */
+      --background: 0 0% 100%;
+      --foreground: 15 7% 11%;
+      --card: 0 0% 100%;
+      --card-foreground: 15 7% 11%;
+      --popover: 0 0% 100%;
+      --popover-foreground: 15 7% 11%;
+
+      /* Vivid Brand / Semantic */
+      --primary: 262 83% 58%;
+      --primary-foreground: 0 0% 100%;
+
+      --secondary: 188 85% 45%;
+      --secondary-foreground: 0 0% 100%;
+
+      --muted: 0 0% 96%;
+      --muted-foreground: 15 7% 35%;
+
+      --accent: 24 94% 50%;
+      --accent-foreground: 0 0% 100%;
+
+      --destructive: 0 84% 60%;
+      --destructive-foreground: 0 0% 100%;
+
+      --success: 142 76% 36%;
+      --warning: 38 92% 50%;
+      --info: 217 91% 60%;
+
+      --border: 0 0% 88%;
+      --input: 0 0% 88%;
+      --ring: 262 83% 58%;
+    }
+    .dark {
+      --background: 222 15% 10%;
+      --foreground: 0 0% 98%;
+      --card: 222 15% 13%;
+      --card-foreground: 0 0% 98%;
+      --popover: 222 15% 13%;
+      --popover-foreground: 0 0% 98%;
+
+      --primary: 262 91% 70%;
+      --primary-foreground: 0 0% 10%;
+
+      --secondary: 188 85% 52%;
+      --secondary-foreground: 0 0% 10%;
+
+      --muted: 222 15% 16%;
+      --muted-foreground: 0 0% 80%;
+
+      --accent: 24 94% 55%;
+      --accent-foreground: 0 0% 10%;
+
+      --destructive: 0 72% 55%;
+      --destructive-foreground: 0 0% 100%;
+
+      --success: 142 55% 45%;
+      --warning: 38 90% 55%;
+      --info: 217 80% 65%;
+
+      --border: 222 15% 22%;
+      --input: 222 15% 22%;
+      --ring: 262 83% 60%;
+    }
+    html, body { height: 100%; }
+    body { background: hsl(var(--background)); color: hsl(var(--foreground)); }
+    .container { max-width: 72rem; }
+  </style>
+</head>
+
+<body class="font-sans antialiased selection:bg-primary/15 selection:text-primary">
+  <!-- HEADER / NAV -->
+  <header class="sticky top-0 z-40 border-b border-border/70 backdrop-blur bg-background/80">
+    <div class="container mx-auto px-4">
+      <div class="flex h-16 items-center justify-between gap-4">
+        <div class="flex items-center gap-3">
+          <div class="h-9 w-9 rounded-2xl bg-primary text-primary-foreground grid place-items-center font-bold">E</div>
+          <span class="text-lg font-semibold tracking-tight">Engram</span>
+          <span class="ml-2 inline-flex items-center rounded-lg bg-accent text-accent-foreground px-2 py-0.5 text-xs font-medium">beta</span>
+        </div>
+        <nav class="hidden md:flex items-center gap-6 text-sm">
+          <a class="text-muted-foreground hover:text-foreground" href="{{ route('catalog-tests.cards') }}">Тести</a>
+          <a class="text-muted-foreground hover:text-foreground" href="{{ route('pages.index') }}">Теорія</a>
+        </nav>
+        <div class="flex items-center gap-2">
+          <form action="{{ route('site.search') }}" method="GET" class="hidden md:block relative">
+            <input type="search" name="q" id="search-box" autocomplete="off" placeholder="Пошук..." class="w-48 rounded-xl border border-input bg-background px-3 py-2 text-sm" />
+            <div id="search-box-list" class="absolute left-0 mt-1 w-full bg-background border border-border rounded-xl shadow-soft text-sm hidden z-50"></div>
+          </form>
+          <button id="mobile-search-btn" class="md:hidden rounded-xl border border-border p-2 text-sm">🔍</button>
+          <button id="theme-toggle" class="hidden sm:inline-flex rounded-xl border border-border px-3 py-2 text-sm">🌙 Тема</button>
+          <button class="rounded-2xl bg-primary px-4 py-2 text-primary-foreground text-sm">Реєстрація</button>
+        </div>
+      </div>
+      <div id="mobile-search" class="md:hidden hidden pb-3">
+        <form action="{{ route('site.search') }}" method="GET" class="relative">
+          <input type="search" name="q" id="search-box-mobile" autocomplete="off" placeholder="Пошук..." class="mt-3 w-full rounded-xl border border-input bg-background px-3 py-2 text-sm" />
+          <div id="search-box-mobile-list" class="absolute left-0 right-0 mt-1 bg-background border border-border rounded-xl shadow-soft text-sm hidden z-50"></div>
+        </form>
+      </div>
+    </div>
+  </header>
+
+  <main class="container mx-auto px-4 py-8">
+    @yield('content')
+  </main>
+
+  <footer class="border-t border-border mt-10 py-6 text-sm">
+    <div class="container mx-auto px-4 flex flex-col sm:flex-row items-center justify-between gap-4">
+      <div class="flex items-center gap-2">
+        <div class="h-6 w-6 rounded-md bg-primary text-primary-foreground grid place-items-center font-semibold text-xs">E</div>
+        <span>Engram <span id="year"></span></span>
+      </div>
+      <div class="flex md:justify-end gap-4 text-sm">
+        <a class="text-muted-foreground hover:text-foreground" href="#">Політика</a>
+        <a class="text-muted-foreground hover:text-foreground" href="#">Умови</a>
+        <a class="text-muted-foreground hover:text-foreground" href="#faq">Підтримка</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // Dark mode toggle with persistence
+    (function themeInit(){
+      const saved = localStorage.getItem('theme');
+      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (saved === 'dark' || (!saved && systemDark)) document.documentElement.classList.add('dark');
+      document.getElementById('theme-toggle')?.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark');
+        const isDark = document.documentElement.classList.contains('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    })();
+
+    document.getElementById('year').textContent = new Date().getFullYear();
+    document.getElementById('mobile-search-btn')?.addEventListener('click', () => {
+      document.getElementById('mobile-search')?.classList.toggle('hidden');
+    });
+
+    function setupPredictiveSearch(inputId, listId) {
+      const input = document.getElementById(inputId);
+      const list = document.getElementById(listId);
+      if (!input || !list) return;
+      let controller;
+      input.addEventListener('input', async () => {
+        const q = input.value.trim();
+        if (q.length < 2) { list.innerHTML = ''; list.classList.add('hidden'); return; }
+        controller?.abort();
+        controller = new AbortController();
+        try {
+          const res = await fetch(input.form.action + '?q=' + encodeURIComponent(q), {
+            headers: { 'Accept': 'application/json' },
+            signal: controller.signal,
+          });
+          const data = await res.json();
+          if (!data.length) { list.innerHTML = ''; list.classList.add('hidden'); return; }
+          list.innerHTML = data.map(item => `<a href="${item.url}" class="block px-3 py-2 hover:bg-muted">${item.title}</a>`).join('');
+          list.classList.remove('hidden');
+        } catch (e) {}
+      });
+      input.addEventListener('blur', () => setTimeout(() => list.classList.add('hidden'), 200));
+    }
+    setupPredictiveSearch('search-box', 'search-box-list');
+    setupPredictiveSearch('search-box-mobile', 'search-box-mobile-list');
+  </script>
+
+  @yield('scripts')
+</body>
+</html>

--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -1,11 +1,11 @@
-@extends('layouts.app')
+@extends('layouts.engram')
 
 @section('title', 'Theory')
 
 @section('content')
-    <div class="grid gap-4">
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         @foreach($pages as $page)
-            <a href="{{ route('pages.show', $page->slug) }}" class="block p-4 bg-white rounded-lg shadow hover:bg-gray-50">
+            <a href="{{ route('pages.show', $page->slug) }}" class="block p-4 bg-card text-card-foreground rounded-xl shadow-soft hover:bg-muted">
                 {{ $page->title }}
             </a>
         @endforeach

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -1,7 +1,7 @@
-@extends('layouts.app')
+@extends('layouts.engram')
 
 @section('title', $page->title)
 
 @section('content')
-    {!! $page->text !!}
+    <article class="max-w-none space-y-4">{!! $page->text !!}</article>
 @endsection

--- a/resources/views/saved-test-js-step-input.blade.php
+++ b/resources/views/saved-test-js-step-input.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends('layouts.engram')
 
 @section('title', $test->name)
 
@@ -8,6 +8,12 @@
         <h1 class="text-2xl sm:text-3xl font-bold text-stone-900">{{ $test->name }}</h1>
         <p class="text-sm text-stone-600 mt-1">Введи відповідь, використовуючи підказки.</p>
     </header>
+
+    <nav class="mb-6 flex gap-2 text-sm">
+        <a href="{{ route('saved-test.js', $test->slug) }}" class="px-3 py-1 rounded-lg border border-stone-300 {{ request()->routeIs('saved-test.js') ? 'bg-stone-900 text-white' : '' }}">Карти</a>
+        <a href="{{ route('saved-test.js.step', $test->slug) }}" class="px-3 py-1 rounded-lg border border-stone-300 {{ request()->routeIs('saved-test.js.step') ? 'bg-stone-900 text-white' : '' }}">Step</a>
+        <a href="{{ route('saved-test.js.step-input', $test->slug) }}" class="px-3 py-1 rounded-lg border border-stone-300 {{ request()->routeIs('saved-test.js.step-input') ? 'bg-stone-900 text-white' : '' }}">Input</a>
+    </nav>
 
     @include('components.word-search')
 
@@ -67,8 +73,9 @@ function showLoader(show) {
 function init() {
   state.items = QUESTIONS.map((q) => ({
     ...q,
-    words: [''],
-    input: '',
+    inputs: Array(q.answers.length)
+      .fill(null)
+      .map(() => ['']),
     isCorrect: null,
     explanation: '',
   }));
@@ -80,25 +87,10 @@ function init() {
   updateProgress();
 }
 
-function buildInputs(q) {
-  const fields = q.words
-    .map((w, i) => `
-      <span class="inline-flex items-center">
-        <input type="text" data-idx="${i}" class="w-20 px-1 py-0.5 text-center border-b border-stone-400 focus:outline-none" list="opts-${state.current}-${i}" value="${html(w)}">
-        <datalist id="opts-${state.current}-${i}"></datalist>
-      </span>`)
-    .join(' ');
-  return `<span id="builder" class="inline-flex items-center gap-1">${fields}<button type="button" id="add-word" class="ml-1 px-2 py-1 rounded border border-stone-300">+</button><button type="button" id="remove-word" class="px-2 py-1 rounded border border-stone-300">-</button></span>`;
-}
-
 function render() {
   const wrap = document.getElementById('question-card');
   const q = state.items[state.current];
-  const hint = q.verb_hint ? ` <span class="verb-hint text-red-700 text-xs font-bold">(${html(q.verb_hint)})</span>` : '';
-  const blank = q.isCorrect === null
-    ? buildInputs(q) + hint
-    : `<mark class="px-1 py-0.5 rounded bg-amber-100">${html(q.words.join(' '))}</mark>` + hint;
-  const sentence = q.question.replace(/\{a\d+\}/, blank);
+  const sentence = renderSentence(q);
   wrap.innerHTML = `
     <article class="rounded-2xl border border-stone-200 bg-white p-4 focus-within:ring-2 ring-stone-900/20 outline-none" data-idx="${state.current}">
       <div class="flex items-start justify-between gap-3">
@@ -121,18 +113,29 @@ function render() {
   renderHints(q);
   if (q.isCorrect === null) {
     document.getElementById('check').addEventListener('click', onCheck);
-    document.querySelectorAll('#builder input').forEach((inp) => {
+    document.querySelectorAll('input[data-idx][data-word]').forEach((inp) => {
       const idx = parseInt(inp.dataset.idx);
+      const widx = parseInt(inp.dataset.word);
       inp.addEventListener('input', () => {
-        q.words[idx] = inp.value;
-        fetchSuggestions(inp, idx);
+        q.inputs[idx][widx] = inp.value;
+        fetchSuggestions(inp, idx, widx);
       });
-      inp.addEventListener('keydown', (e) => { if (e.key === 'Enter') onCheck(); });
-      fetchSuggestions(inp, idx);
+      inp.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') onCheck();
+      });
+      fetchSuggestions(inp, idx, widx);
     });
-    document.getElementById('add-word').addEventListener('click', () => { q.words.push(''); render(); });
-    document.getElementById('remove-word').addEventListener('click', () => { if (q.words.length > 1) { q.words.pop(); render(); } });
-    const first = document.querySelector('#builder input');
+    document.querySelectorAll('button[data-add]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        addWord(q, parseInt(btn.dataset.add));
+      });
+    });
+    document.querySelectorAll('button[data-remove]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        removeWord(q, parseInt(btn.dataset.remove));
+      });
+    });
+    const first = document.querySelector('input[data-idx][data-word]');
     if (first) first.focus();
   }
 }
@@ -140,9 +143,12 @@ function render() {
 function onCheck() {
   const q = state.items[state.current];
   if (q.isCorrect !== null) return;
-  const val = q.words.join(' ').trim();
+  const valParts = q.inputs.map((words) => words.join(' ').trim());
+  const val = valParts.join(' ');
   q.input = val;
-  q.isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+  q.isCorrect = q.answers.every((ans, i) =>
+    valParts[i].toLowerCase() === (ans || '').toLowerCase()
+  );
   if (q.isCorrect) {
     state.correct += 1;
   } else {
@@ -246,14 +252,28 @@ function fetchExplanation(q, given) {
     .finally(() => showLoader(false));
 }
 
-function fetchSuggestions(input, idx) {
-  const query = input.value.trim();
-  const listId = `opts-${state.current}-${idx}`;
+function addWord(q, idx) {
+  q.inputs[idx].push('');
+  render();
+}
+
+function removeWord(q, idx) {
+  if (q.inputs[idx].length > 1) {
+    q.inputs[idx].pop();
+    render();
+  }
+}
+
+function fetchSuggestions(input, idx, widx) {
+  const val = input.value.trim();
+  const listId = `opts-${state.current}-${idx}-${widx}`;
   const dl = document.getElementById(listId);
-  if (!query) { dl.innerHTML = ''; return; }
-  fetch('/api/search?lang=en&q=' + encodeURIComponent(query))
+  if (!val) { dl.innerHTML = ''; return; }
+  fetch('/api/search?lang=en&q=' + encodeURIComponent(val))
     .then(res => res.json())
-    .then(data => { dl.innerHTML = data.map(it => `<option value="${html(it.en)}"></option>`).join(''); });
+    .then(data => {
+      dl.innerHTML = data.map(it => `<option value="${html(it.en)}"></option>`).join('');
+    });
 }
 
 function renderFeedback(q) {
@@ -261,13 +281,40 @@ function renderFeedback(q) {
     return '<div class="text-sm text-emerald-700">✅ Вірно!</div>';
   }
   if (q.isCorrect === false) {
-    let htmlStr = '<div class="text-sm text-rose-700">❌ Невірно. Правильна відповідь: <b>' + html(q.answer) + '</b></div>';
+    let htmlStr = '<div class="text-sm text-rose-700">❌ Невірно. Правильна відповідь: <b>' + html(q.answers.join(' ')) + '</b></div>';
     if (q.explanation) {
       htmlStr += '<div class="mt-1 text-xs bg-blue-50 text-blue-800 rounded px-2 py-1">' + html(q.explanation) + '</div>';
     }
     return htmlStr;
   }
   return '';
+}
+
+function renderSentence(q) {
+  let text = q.question;
+  q.answers.forEach((ans, i) => {
+    let replacement = '';
+    if (q.isCorrect === null) {
+      const words = q.inputs[i];
+      const inputs = words
+        .map((w, j) => `<span class=\"inline-block\"><input type=\"text\" data-idx=\"${i}\" data-word=\"${j}\" class=\"w-20 px-1 py-0.5 text-center border-b border-stone-400 focus:outline-none\" list=\"opts-${state.current}-${i}-${j}\" value=\"${html(w)}\"><datalist id=\"opts-${state.current}-${i}-${j}\"></datalist></span>`)
+        .join(' ');
+      const addBtn = `<button type=\"button\" data-add=\"${i}\" class=\"ml-1 px-2 py-0.5 rounded bg-stone-200\">+</button>`;
+      const removeBtn = words.length > 1
+        ? `<button type=\"button\" data-remove=\"${i}\" class=\"ml-1 px-2 py-0.5 rounded bg-stone-200\">-</button>`
+        : '';
+      replacement = `<span class=\"inline-flex items-center gap-1\">${inputs}${addBtn}${removeBtn}</span>`;
+    } else {
+      replacement = `<mark class=\"px-1 py-0.5 rounded bg-amber-100\">${html(q.inputs[i].join(' '))}</mark>`;
+    }
+    const regex = new RegExp(`\\{a${i + 1}\\}`);
+    const marker = `a${i + 1}`;
+    const hint = q.verb_hints && q.verb_hints[marker]
+      ? ` <span class="verb-hint text-red-700 text-xs font-bold">(${html(q.verb_hints[marker])})</span>`
+      : '';
+    text = text.replace(regex, replacement + hint);
+  });
+  return text;
 }
 
 function pct(a, b) { return Math.round((a / (b || 1)) * 100); }

--- a/resources/views/saved-test-js-step.blade.php
+++ b/resources/views/saved-test-js-step.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends('layouts.engram')
 
 @section('title', $test->name)
 
@@ -8,6 +8,12 @@
         <h1 class="text-2xl sm:text-3xl font-bold text-stone-900">{{ $test->name }}</h1>
         <p class="text-sm text-stone-600 mt-1">Перевіряй відповіді одразу, клавіші 1–4 працюють для активного запитання.</p>
     </header>
+
+    <nav class="mb-6 flex gap-2 text-sm">
+        <a href="{{ route('saved-test.js', $test->slug) }}" class="px-3 py-1 rounded-lg border border-stone-300 {{ request()->routeIs('saved-test.js') ? 'bg-stone-900 text-white' : '' }}">Карти</a>
+        <a href="{{ route('saved-test.js.step', $test->slug) }}" class="px-3 py-1 rounded-lg border border-stone-300 {{ request()->routeIs('saved-test.js.step') ? 'bg-stone-900 text-white' : '' }}">Step</a>
+        <a href="{{ route('saved-test.js.step-input', $test->slug) }}" class="px-3 py-1 rounded-lg border border-stone-300 {{ request()->routeIs('saved-test.js.step-input') ? 'bg-stone-900 text-white' : '' }}">Input</a>
+    </nav>
 
     @include('components.word-search')
 
@@ -49,7 +55,6 @@
 <script>
 const QUESTIONS = @json($questionData);
 const CSRF_TOKEN = '{{ csrf_token() }}';
-const EXPLAIN_URL = '{{ route('question.explain') }}';
 </script>
 <script>
 const state = {
@@ -71,9 +76,12 @@ function init() {
     return {
       ...q,
       options: opts,
-      chosen: null,
-      isCorrect: null,
-      explanation: '',
+      chosen: Array(q.answers.length).fill(null),
+      slot: 0,
+      done: false,
+      wrongAttempt: false,
+      lastWrong: null,
+      feedback: '',
     };
   });
   state.current = 0;
@@ -88,7 +96,7 @@ function init() {
 function render() {
   const wrap = document.getElementById('question-card');
   const q = state.items[state.current];
-  const sentence = q.question.replace(/\{a\d+\}/, `<mark class="px-1 py-0.5 rounded bg-amber-100">${q.chosen ?? '____'}</mark>`);
+  const sentence = renderSentence(q);
   wrap.innerHTML = `
     <article class="rounded-2xl border border-stone-200 bg-white p-4 focus-within:ring-2 ring-stone-900/20 outline-none" data-idx="${state.current}">
       <div class="flex items-start justify-between gap-3">
@@ -108,25 +116,22 @@ function render() {
   `;
 
   document.getElementById('prev').disabled = state.current === 0;
-  document.getElementById('next').disabled = q.isCorrect === null;
+  document.getElementById('next').disabled = !q.done;
   document.getElementById('help').addEventListener('click', () => fetchHints(q));
   renderHints(q);
 }
 
 function renderOptionButton(q, opt, i) {
-  const chosen = q.chosen === opt;
-  const answered = q.isCorrect !== null;
   const base = 'w-full text-left px-3 py-2 rounded-xl border transition';
   let cls = 'border-stone-300 hover:border-stone-400 bg-white';
-  if (answered) {
-    if (opt === q.answer) cls = 'border-emerald-300 bg-emerald-50';
-    if (chosen && opt !== q.answer) cls = 'border-rose-300 bg-rose-50';
-  } else if (chosen) {
-    cls = 'border-stone-900';
+  if (q.done) {
+    cls = 'border-stone-300 bg-stone-100';
+  } else if (q.lastWrong === opt) {
+    cls = 'border-rose-300 bg-rose-50';
   }
   const hotkey = i + 1;
   return `
-    <button type="button" class="${base} ${cls}" data-opt="${html(opt)}" title="Натисни ${hotkey}" ${answered ? 'disabled' : ''}>
+    <button type="button" class="${base} ${cls}" data-opt="${html(opt)}" title="Натисни ${hotkey}" ${q.done ? 'disabled' : ''}>
       <span class="mr-2 inline-flex h-5 w-5 items-center justify-center rounded-md border text-xs">${hotkey}</span>
       ${opt}
     </button>
@@ -134,17 +139,10 @@ function renderOptionButton(q, opt, i) {
 }
 
 function renderFeedback(q) {
-  if (q.isCorrect === true) {
+  if (q.done || q.feedback === 'correct') {
     return '<div class="text-sm text-emerald-700">✅ Вірно!</div>';
   }
-  if (q.isCorrect === false) {
-    let htmlStr = '<div class="text-sm text-rose-700">❌ Невірно. Правильна відповідь: <b>' + html(q.answer) + '</b></div>';
-    if (q.explanation) {
-      htmlStr += '<div class="mt-1 text-xs bg-blue-50 text-blue-800 rounded px-2 py-1">' + html(q.explanation) + '</div>';
-    }
-    return htmlStr;
-  }
-  return '';
+  return q.feedback ? `<div class="text-sm text-rose-700">${html(q.feedback)}</div>` : '';
 }
 
 document.getElementById('question-card').addEventListener('click', (e) => {
@@ -155,13 +153,21 @@ document.getElementById('question-card').addEventListener('click', (e) => {
 
 function onChoose(opt) {
   const q = state.items[state.current];
-  if (q.isCorrect !== null) return;
-  q.chosen = opt;
-  q.isCorrect = (opt === q.answer);
-  if (q.isCorrect) {
-    state.correct += 1;
+  if (q.done) return;
+
+  if (opt === q.answers[q.slot]) {
+    q.chosen[q.slot] = opt;
+    q.slot += 1;
+    q.lastWrong = null;
+    q.feedback = 'correct';
+    if (q.slot === q.answers.length) {
+      q.done = true;
+      if (!q.wrongAttempt) state.correct += 1;
+    }
   } else {
-    fetchExplanation(q, opt);
+    q.wrongAttempt = true;
+    q.lastWrong = opt;
+    q.feedback = 'Невірно, спробуй ще раз';
   }
   render();
   updateProgress();
@@ -186,10 +192,28 @@ document.getElementById('next').addEventListener('click', () => {
 });
 
 function updateProgress() {
-  const answered = state.items.filter(it => it.isCorrect !== null).length;
+  const answered = state.items.filter(it => it.done).length;
   document.getElementById('progress-label').textContent = `${state.current + 1} / ${state.items.length}`;
   document.getElementById('score-label').textContent = `Точність: ${pct(state.correct, state.items.length)}%`;
   document.getElementById('progress-bar').style.width = `${(answered / state.items.length) * 100}%`;
+}
+
+function renderSentence(q) {
+  let text = q.question;
+  q.answers.forEach((ans, i) => {
+    const replacement = q.chosen[i]
+      ? `<mark class=\"px-1 py-0.5 rounded bg-amber-100\">${html(q.chosen[i])}</mark>`
+      : (i === q.slot
+        ? `<mark class=\"px-1 py-0.5 rounded bg-amber-200\">____</mark>`
+        : '____');
+    const regex = new RegExp(`\\{a${i + 1}\\}`);
+    const marker = `a${i + 1}`;
+    const hint = q.verb_hints && q.verb_hints[marker]
+      ? ` <span class=\"verb-hint text-red-700 text-xs font-bold\">(${html(q.verb_hints[marker])})</span>`
+      : '';
+    text = text.replace(regex, replacement + hint);
+  });
+  return text;
 }
 
 function showSummary() {
@@ -242,31 +266,12 @@ function renderHints(q) {
   document.getElementById('refresh-hint').addEventListener('click', () => fetchHints(q, true));
 }
 
-function fetchExplanation(q, given) {
-  showLoader(true);
-  fetch(EXPLAIN_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-CSRF-TOKEN': CSRF_TOKEN,
-    },
-    body: JSON.stringify({ question_id: q.id, answer: given }),
-  })
-    .then((r) => r.json())
-    .then((d) => {
-      q.explanation = d.explanation || '';
-      render();
-    })
-    .catch((e) => console.error(e))
-    .finally(() => showLoader(false));
-}
-
 function hookGlobalEvents() {
   document.addEventListener('keydown', (e) => {
     const n = Number(e.key);
     if (!Number.isInteger(n) || n < 1 || n > 4) return;
     const q = state.items[state.current];
-    if (!q || q.isCorrect !== null) return;
+    if (!q || q.done) return;
     const opt = q.options[n - 1];
     if (opt) onChoose(opt);
   });

--- a/resources/views/saved-test-js.blade.php
+++ b/resources/views/saved-test-js.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends('layouts.engram')
 
 @section('title', $test->name)
 
@@ -8,6 +8,12 @@
         <h1 class="text-2xl sm:text-3xl font-bold text-stone-900">{{ $test->name }}</h1>
         <p class="text-sm text-stone-600 mt-1">Перевіряй відповіді одразу, клавіші 1–4 працюють для активного запитання.</p>
     </header>
+
+    <nav class="mb-6 flex gap-2 text-sm">
+        <a href="{{ route('saved-test.js', $test->slug) }}" class="px-3 py-1 rounded-lg border border-stone-300 {{ request()->routeIs('saved-test.js') ? 'bg-stone-900 text-white' : '' }}">Карти</a>
+        <a href="{{ route('saved-test.js.step', $test->slug) }}" class="px-3 py-1 rounded-lg border border-stone-300 {{ request()->routeIs('saved-test.js.step') ? 'bg-stone-900 text-white' : '' }}">Step</a>
+        <a href="{{ route('saved-test.js.step-input', $test->slug) }}" class="px-3 py-1 rounded-lg border border-stone-300 {{ request()->routeIs('saved-test.js.step-input') ? 'bg-stone-900 text-white' : '' }}">Input</a>
+    </nav>
 
     <div class="mb-6">
         <div class="flex items-center justify-between text-sm">
@@ -51,8 +57,12 @@ function init() {
     return {
       ...q,
       options: opts,
-      chosen: null,
-      isCorrect: null,
+      chosen: Array(q.answers.length).fill(null),
+      slot: 0,
+      done: false,
+      wrongAttempt: false,
+      lastWrong: null,
+      feedback: '',
     };
   });
   state.correct = 0;
@@ -68,15 +78,14 @@ function renderQuestions(showOnlyWrong = false) {
   wrap.innerHTML = '';
 
   state.items.forEach((q, idx) => {
-    if (showOnlyWrong && q.isCorrect !== false) return;
+    if (showOnlyWrong && (!q.done || !q.wrongAttempt)) return;
 
     const card = document.createElement('article');
     card.className = 'rounded-2xl border border-stone-200 bg-white p-4 focus-within:ring-2 ring-stone-900/20 outline-none';
     card.tabIndex = 0;
     card.dataset.idx = idx;
 
-    const slotText = q.chosen ?? '____';
-    const sentence = q.question.replace(/\{a\d+\}/, `<mark class="px-1 py-0.5 rounded bg-amber-100">${slotText}</mark>`);
+    const sentence = renderSentence(q);
 
     card.innerHTML = `
       <div class="flex items-start justify-between gap-3">
@@ -107,7 +116,7 @@ function renderQuestions(showOnlyWrong = false) {
     wrap.appendChild(card);
   });
 
-  const allDone = state.items.every(it => it.isCorrect !== null);
+  const allDone = state.items.every(it => it.done);
   document.getElementById('summary').classList.toggle('hidden', !allDone);
 
   if (allDone) {
@@ -119,21 +128,16 @@ function renderQuestions(showOnlyWrong = false) {
 }
 
 function renderOptionButton(q, idx, opt, i) {
-  const chosen = q.chosen === opt;
-  const answered = q.isCorrect !== null;
   const base = 'w-full text-left px-3 py-2 rounded-xl border transition';
-
   let cls = 'border-stone-300 hover:border-stone-400 bg-white';
-  if (answered) {
-    if (opt === q.answer) cls = 'border-emerald-300 bg-emerald-50';
-    if (chosen && opt !== q.answer) cls = 'border-rose-300 bg-rose-50';
-  } else if (chosen) {
-    cls = 'border-stone-900';
+  if (q.done) {
+    cls = 'border-stone-300 bg-stone-100';
+  } else if (q.lastWrong === opt) {
+    cls = 'border-rose-300 bg-rose-50';
   }
-
   const hotkey = i + 1;
   return `
-    <button type="button" class="${base} ${cls}" data-opt="${html(opt)}" title="Натисни ${hotkey}">
+    <button type="button" class="${base} ${cls}" data-opt="${html(opt)}" title="Натисни ${hotkey}" ${q.done ? 'disabled' : ''}>
       <span class="mr-2 inline-flex h-5 w-5 items-center justify-center rounded-md border text-xs">${hotkey}</span>
       ${opt}
     </button>
@@ -141,33 +145,39 @@ function renderOptionButton(q, idx, opt, i) {
 }
 
 function renderFeedback(q) {
-  if (q.isCorrect === true) {
+  if (q.done || q.feedback === 'correct') {
     return '<div class="text-sm text-emerald-700">✅ Вірно!</div>';
   }
-  if (q.isCorrect === false) {
-    return '<div class="text-sm text-rose-700">❌ Невірно. Правильна відповідь: <b>' + html(q.answer) + '</b></div>';
-  }
-  return '';
+  return q.feedback
+    ? `<div class="text-sm text-rose-700">${html(q.feedback)}</div>`
+    : '';
 }
 
 function onChoose(idx, opt) {
   const item = state.items[idx];
-  if (item.isCorrect !== null) {
-    return;
+  if (item.done) return;
+
+  if (opt === item.answers[item.slot]) {
+    item.chosen[item.slot] = opt;
+    item.slot += 1;
+    item.lastWrong = null;
+    item.feedback = 'correct';
+    if (item.slot === item.answers.length) {
+      item.done = true;
+      state.answered += 1;
+      if (!item.wrongAttempt) state.correct += 1;
+    }
+  } else {
+    item.wrongAttempt = true;
+    item.lastWrong = opt;
+    item.feedback = 'Невірно, спробуй ще раз';
   }
-  item.chosen = opt;
-  item.isCorrect = (opt === item.answer);
-  state.answered += 1;
-  if (item.isCorrect) state.correct += 1;
 
   const container = document.querySelector(`article[data-idx="${idx}"]`);
   if (container) {
-    const sentenceHtml = item.question.replace(/\{a\d+\}/, `<mark class="px-1 py-0.5 rounded bg-amber-100">${html(item.chosen)}</mark>`);
-    container.querySelector('.leading-relaxed').innerHTML = sentenceHtml;
-
+    container.querySelector('.leading-relaxed').innerHTML = renderSentence(item);
     const group = container.querySelector('[role="group"]');
     group.innerHTML = item.options.map((optText, i) => renderOptionButton(item, idx, optText, i)).join('');
-
     container.querySelector(`#feedback-${idx}`).innerHTML = renderFeedback(item);
   }
 
@@ -188,10 +198,28 @@ function updateProgress() {
 }
 
 function checkAllDone() {
-  const allDone = state.items.every(it => it.isCorrect !== null);
+  const allDone = state.items.every(it => it.done);
   if (allDone) {
     renderQuestions();
   }
+}
+
+function renderSentence(q) {
+  let text = q.question;
+  q.answers.forEach((ans, i) => {
+    const replacement = q.chosen[i]
+      ? `<mark class=\"px-1 py-0.5 rounded bg-amber-100\">${html(q.chosen[i])}</mark>`
+      : (i === q.slot
+        ? `<mark class=\"px-1 py-0.5 rounded bg-amber-200\">____</mark>`
+        : '____');
+    const regex = new RegExp(`\\{a${i + 1}\\}`);
+    const marker = `a${i + 1}`;
+    const hint = q.verb_hints && q.verb_hints[marker]
+      ? ` <span class=\"verb-hint text-red-700 text-xs font-bold\">(${html(q.verb_hints[marker])})</span>`
+      : '';
+    text = text.replace(regex, replacement + hint);
+  });
+  return text;
 }
 
 function hookGlobalEvents() {
@@ -201,7 +229,7 @@ function hookGlobalEvents() {
 
     const idx = state.activeCardIdx ?? 0;
     const item = state.items[idx];
-    if (!item || item.isCorrect !== null) return;
+    if (!item || item.done) return;
 
     const opt = item.options[n - 1];
     if (!opt) return;

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,6 +84,7 @@ Route::delete('/test/{slug}/question/{question}', [GrammarTestController::class,
 Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
 Route::delete('/tests/{test}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
 Route::get('/tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('saved-tests.cards');
+Route::get('/catalog-tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('catalog-tests.cards');
 
 Route::get('/words', [WordSearchController::class, 'search'])->name('words.search');
 


### PR DESCRIPTION
## Summary
- duplicate tests catalog at /catalog-tests/cards and link cards to JS runner
- add navigation switch between card, step and input modes on JS test pages
- implement predictive search in header with AJAX suggestions
- support multiple blanks per question with sequential filling on JS test pages
- show which blank is being answered and persist on last blank until correct
- highlight the current blank instead of displaying "Поточний пропуск" text
- display "Вірно!" after resolving the final blank even if earlier attempts were wrong
- show "Вірно!" after each correctly answered blank in JS card and step modes
- remove AI-generated explanations for incorrect answers in JS step mode
- enable word-level predictive suggestions in JS step-input mode
- add per-word builder with +/− controls and predictive suggestions for each answer slot in step-input tests
- add verb hints for every blank in step-input mode
- show verb hints for each blank in JS card and step views

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit` *(fails: Failed asserting that an array has the subset; Tests: 48, Assertions: 197, Errors: 2, Failures: 3)*

------
https://chatgpt.com/codex/tasks/task_e_68c563036544832a94f0f53c4ee6eede