### PR TITLE
Move question verification to test end

### DIFF
--- a/resources/views/saved-test-js-input.blade.php
+++ b/resources/views/saved-test-js-input.blade.php
@@ -25,6 +25,8 @@
 
     <div id="questions" class="space-y-4"></div>
 
+    <div id="final-check" class="mt-6"><button id="check-all" class="px-4 py-2 rounded-xl bg-stone-900 text-white">Перевірити всі</button></div>
+
     <div id="summary" class="mt-8 hidden">
         <div class="rounded-2xl border border-stone-200 bg-white p-4">
             <div class="text-lg font-semibold">Підсумок</div>
@@ -56,6 +58,10 @@ function init() {
   state.answered = 0;
   renderQuestions();
   updateProgress();
+  document.getElementById('final-check').classList.remove('hidden');
+  document.getElementById('check-all').onclick = () => {
+    state.items.forEach((_, i) => onCheck(i));
+  };
 }
 
 function renderQuestions() {
@@ -76,7 +82,6 @@ function renderQuestion(idx) {
       </div>
       <div class="text-xs text-stone-500 shrink-0">[${idx + 1}/${state.items.length}]</div>
     </div>
-    ${q.isCorrect === null ? '<div class="mt-3"><button data-check class="px-4 py-2 rounded-xl bg-stone-900 text-white">Перевірити</button></div>' : ''}
     <div class="mt-2 h-5" id="feedback-${idx}">${renderFeedback(q)}</div>
   `;
   if (q.isCorrect === null) {
@@ -87,7 +92,6 @@ function renderQuestion(idx) {
         q.inputs[aIdx][wIdx] = inp.value;
         fetchSuggestions(inp, idx, aIdx, wIdx);
       });
-      inp.addEventListener('keydown', e => { if (e.key === 'Enter') onCheck(idx); });
       fetchSuggestions(inp, idx, aIdx, wIdx);
     });
     card.querySelectorAll('button[data-add]').forEach(btn => {
@@ -96,8 +100,6 @@ function renderQuestion(idx) {
     card.querySelectorAll('button[data-remove]').forEach(btn => {
       btn.addEventListener('click', () => { removeWord(q, parseInt(btn.dataset.remove)); renderQuestion(idx); });
     });
-    const checkBtn = card.querySelector('button[data-check]');
-    if (checkBtn) checkBtn.addEventListener('click', () => onCheck(idx));
   }
 }
 
@@ -178,6 +180,7 @@ function updateProgress() {
     document.getElementById('summary').classList.remove('hidden');
     document.getElementById('summary-text').textContent = `Правильних відповідей: ${state.correct} із ${state.items.length} (${pct(state.correct, state.items.length)}%).`;
     document.getElementById('retry').onclick = init;
+    document.getElementById('final-check').classList.add('hidden');
   }
 }
 

--- a/resources/views/saved-test-js-manual.blade.php
+++ b/resources/views/saved-test-js-manual.blade.php
@@ -23,6 +23,8 @@
 
     <div id="questions" class="space-y-4"></div>
 
+    <div id="final-check" class="mt-6"><button id="check-all" class="px-4 py-2 rounded-xl bg-stone-900 text-white">Перевірити всі</button></div>
+
     <div id="summary" class="mt-8 hidden">
         <div class="rounded-2xl border border-stone-200 bg-white p-4">
             <div class="text-lg font-semibold">Підсумок</div>
@@ -57,6 +59,10 @@ function init() {
   state.answered = 0;
   renderQuestions();
   updateProgress();
+  document.getElementById('final-check').classList.remove('hidden');
+  document.getElementById('check-all').onclick = () => {
+    state.items.forEach((_, i) => onCheck(i));
+  };
 }
 
 function renderQuestions(showOnlyWrong = false) {
@@ -80,25 +86,16 @@ function renderQuestions(showOnlyWrong = false) {
         </div>
         <div class="text-xs text-stone-500 shrink-0">[${idx + 1}/${state.items.length}]</div>
       </div>
-      <div class="mt-3">
-        <button type="button" data-check="${idx}" class="px-4 py-2 rounded-xl bg-stone-900 text-white" ${q.done ? 'disabled' : ''}>Перевірити</button>
-      </div>
       <div class="mt-2 h-5" id="feedback-${idx}">${renderFeedback(q)}</div>
     `;
 
     wrap.appendChild(card);
 
-    if (!q.done) {
-      const btn = card.querySelector('button[data-check]');
-      btn.addEventListener('click', () => onCheck(idx));
-      card.querySelectorAll('input').forEach(inp => {
-        inp.addEventListener('keydown', (e) => { if (e.key === 'Enter') onCheck(idx); });
-      });
-    }
   });
 
   const allDone = state.items.every(it => it.done);
   document.getElementById('summary').classList.toggle('hidden', !allDone);
+  document.getElementById('final-check').classList.toggle('hidden', allDone);
   if (allDone) {
     document.getElementById('summary-text').textContent = `Правильних відповідей: ${state.correct} із ${state.items.length} (${pct(state.correct, state.items.length)}%).`;
     document.getElementById('retry').onclick = init;

--- a/resources/views/saved-test-js-select.blade.php
+++ b/resources/views/saved-test-js-select.blade.php
@@ -25,6 +25,8 @@
 
     <div id="questions" class="space-y-4"></div>
 
+    <div id="final-check" class="mt-6"><button id="check-all" class="px-4 py-2 rounded-xl bg-stone-900 text-white">Перевірити всі</button></div>
+
     <div id="summary" class="mt-8 hidden">
         <div class="rounded-2xl border border-stone-200 bg-white p-4">
             <div class="text-lg font-semibold">Підсумок</div>
@@ -56,6 +58,10 @@ function init() {
   state.answered = 0;
   renderQuestions();
   updateProgress();
+  document.getElementById('final-check').classList.remove('hidden');
+  document.getElementById('check-all').onclick = () => {
+    state.items.forEach((_, i) => onCheck(i));
+  };
 }
 
 function renderQuestions() {
@@ -76,7 +82,6 @@ function renderQuestion(idx) {
       </div>
       <div class="text-xs text-stone-500 shrink-0">[${idx + 1}/${state.items.length}]</div>
     </div>
-    ${q.isCorrect === null ? '<div class="mt-3"><button data-check class="px-4 py-2 rounded-xl bg-stone-900 text-white">Перевірити</button></div>' : ''}
     <div class="mt-2 h-5" id="feedback-${idx}">${renderFeedback(q)}</div>
   `;
   if (q.isCorrect === null) {
@@ -84,8 +89,6 @@ function renderQuestion(idx) {
       const aIdx = parseInt(sel.dataset.idx);
       sel.addEventListener('change', () => { q.chosen[aIdx] = sel.value; });
     });
-    const checkBtn = card.querySelector('button[data-check]');
-    if (checkBtn) checkBtn.addEventListener('click', () => onCheck(idx));
   }
 }
 
@@ -140,6 +143,7 @@ function updateProgress() {
     document.getElementById('summary').classList.remove('hidden');
     document.getElementById('summary-text').textContent = `Правильних відповідей: ${state.correct} із ${state.items.length} (${pct(state.correct, state.items.length)}%).`;
     document.getElementById('retry').onclick = init;
+    document.getElementById('final-check').classList.add('hidden');
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove per-question "Перевірити" buttons from JS input, select, and manual test views
- Add a single "Перевірити всі" button at the end to check all questions at once
- Hide the new button after all questions are answered

## Testing
- `npm test` *(fails: Missing script "test")*
- `php vendor/bin/phpunit` *(fails: Undefined variable $flatTenses; 2 errors, 3 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e4a1b4b4832aad8d381156115be3