### PR TITLE
Fix dropdown layout in JS input quiz views

### DIFF
--- a/resources/views/engram/saved-test-js-input.blade.php
+++ b/resources/views/engram/saved-test-js-input.blade.php
@@ -241,12 +241,12 @@ function renderSentence(q, qIdx) {
         .map((w, j) => {
           const inputId = `input-${qIdx}-${i}-${j}`;
           const listId = `opts-${qIdx}-${i}-${j}`;
-          return `<span class=\"inline-flex flex-col items-start gap-1\"><input id=\"${inputId}\" type=\"text\" data-idx=\"${i}\" data-word=\"${j}\" class=\"px-1 py-0.5 text-center border-b border-stone-400 focus:outline-none\" style=\"width:auto\" value=\"${html(w)}\" data-list=\"${listId}\"><ul id=\"${listId}\" data-input=\"${inputId}\" data-has-options=\"0\" role=\"listbox\" class=\"suggestion-list hidden mt-1 w-full max-h-40 overflow-auto rounded border border-stone-300 bg-white text-sm text-stone-700 shadow list-none p-0\"></ul></span>`;
+          return `<span class=\"relative inline-flex flex-col items-start gap-1\"><input id=\"${inputId}\" type=\"text\" data-idx=\"${i}\" data-word=\"${j}\" class=\"px-1 py-0.5 text-center border-b border-stone-400 focus:outline-none\" style=\"width:auto\" value=\"${html(w)}\" data-list=\"${listId}\"><ul id=\"${listId}\" data-input=\"${inputId}\" data-has-options=\"0\" role=\"listbox\" class=\"suggestion-list hidden absolute left-0 top-full mt-1 z-10 w-full max-h-40 overflow-auto rounded border border-stone-300 bg-white text-sm text-stone-700 shadow list-none p-0\"></ul></span>`;
         })
         .join(' ');
-      const addBtn = `<button type=\"button\" data-add=\"${i}\" class=\"ml-1 px-2 py-0.5 rounded bg-stone-200\">+</button>`;
-      const removeBtn = words.length > 1 ? `<button type=\"button\" data-remove=\"${i}\" class=\"ml-1 px-2 py-0.5 rounded bg-stone-200\">-</button>` : '';
-      replacement = `<span class=\"inline-flex items-center gap-1\">${inputs}${addBtn}${removeBtn}</span>`;
+      const addBtn = `<button type=\"button\" data-add=\"${i}\" class=\"ml-1 px-2 py-0.5 rounded bg-stone-200 self-start flex-shrink-0\">+</button>`;
+      const removeBtn = words.length > 1 ? `<button type=\"button\" data-remove=\"${i}\" class=\"ml-1 px-2 py-0.5 rounded bg-stone-200 self-start flex-shrink-0\">-</button>` : '';
+      replacement = `<span class=\"inline-flex items-start gap-1\">${inputs}${addBtn}${removeBtn}</span>`;
     } else {
       replacement = `<mark class=\"px-1 py-0.5 rounded bg-amber-100\">${html(q.inputs[i].join(' '))}</mark>`;
     }

--- a/resources/views/engram/saved-test-js-step-input.blade.php
+++ b/resources/views/engram/saved-test-js-step-input.blade.php
@@ -381,14 +381,14 @@ function renderSentence(q) {
         .map((w, j) => {
           const inputId = `input-${state.current}-${i}-${j}`;
           const listId = `opts-${state.current}-${i}-${j}`;
-          return `<span class=\"inline-flex flex-col items-start gap-1\"><input id=\"${inputId}\"  autocomplete="off" type=\"text\" data-idx=\"${i}\" data-word=\"${j}\" class=\"px-1 py-0.5 text-center border-b border-stone-400 focus:outline-none\" style=\"width:auto\" value=\"${html(w)}\" data-list=\"${listId}\"><ul id=\"${listId}\" data-input=\"${inputId}\" data-has-options=\"0\" role=\"listbox\" class=\"suggestion-list hidden mt-1 w-full max-h-40 overflow-auto rounded border border-stone-300 bg-white text-sm text-stone-700 shadow list-none p-0\"></ul></span>`;
+          return `<span class=\"relative inline-flex flex-col items-start gap-1\"><input id=\"${inputId}\"  autocomplete="off" type=\"text\" data-idx=\"${i}\" data-word=\"${j}\" class=\"px-1 py-0.5 text-center border-b border-stone-400 focus:outline-none\" style=\"width:auto\" value=\"${html(w)}\" data-list=\"${listId}\"><ul id=\"${listId}\" data-input=\"${inputId}\" data-has-options=\"0\" role=\"listbox\" class=\"suggestion-list hidden absolute left-0 top-full mt-1 z-10 w-full max-h-40 overflow-auto rounded border border-stone-300 bg-white text-sm text-stone-700 shadow list-none p-0\"></ul></span>`;
         })
         .join(' ');
-      const addBtn = `<button type=\"button\" data-add=\"${i}\" class=\"ml-1 px-2 py-0.5 rounded bg-stone-200\">+</button>`;
+      const addBtn = `<button type=\"button\" data-add=\"${i}\" class=\"ml-1 px-2 py-0.5 rounded bg-stone-200 self-start flex-shrink-0\">+</button>`;
       const removeBtn = words.length > 1
-        ? `<button type=\"button\" data-remove=\"${i}\" class=\"ml-1 px-2 py-0.5 rounded bg-stone-200\">-</button>`
+        ? `<button type=\"button\" data-remove=\"${i}\" class=\"ml-1 px-2 py-0.5 rounded bg-stone-200 self-start flex-shrink-0\">-</button>`
         : '';
-      replacement = `<span class=\"inline-flex items-center gap-1\">${inputs}${addBtn}${removeBtn}</span>`;
+      replacement = `<span class=\"inline-flex items-start gap-1\">${inputs}${addBtn}${removeBtn}</span>`;
     } else {
       replacement = `<mark class=\"px-1 py-0.5 rounded bg-amber-100\">${html(q.inputs[i].join(' '))}</mark>`;
     }


### PR DESCRIPTION
## Summary
- prevent the autocomplete suggestion list from collapsing layout in the JS input quiz modes
- keep add/remove buttons visible by anchoring the input controls to the top and fixing dropdown positioning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c951303e24832a88aff60601b35b6c