### PR TITLE
Handle variant fallback when variants table missing

### DIFF
--- a/app/Http/Controllers/AiTestController.php
+++ b/app/Http/Controllers/AiTestController.php
@@ -177,7 +177,7 @@ class AiTestController extends Controller
                         $question = $gemini->generateGrammarQuestion($flatTenses, $answersCount);
                     } else {
                         $model = session('ai_step.model') ?? 'random';
-                        $question = $gpt->generateGrammarQuestion($tenseNames, $responseAnswersCount, $model);
+                        $question = $gpt->generateGrammarQuestion($flatTenses, $responseAnswersCount, $model);
                     }
                     $attempts++;
                 } while ($question && $lastQuestion && $question['question'] === $lastQuestion && $attempts < 3);
@@ -361,6 +361,10 @@ class AiTestController extends Controller
                 return $items->pluck('name')->toArray();
             })
             ->toArray();
+        $flatTenses = [];
+        foreach ($tenseNames as $arr) {
+            $flatTenses = array_merge($flatTenses, $arr);
+        }
         $range = session('ai_step.answers_range', [1, 1]);
         $answersCount = random_int($range[0], $range[1]);
         $lastQuestion = session('ai_step.last_question');

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -4,11 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Tag;
+use App\Models\QuestionVariant;
 
 class Question extends Model
 {
     protected $casts = [
-        'flag' => 'boolean',
+        'flag' => 'integer',
     ];
 
 
@@ -18,10 +19,9 @@ class Question extends Model
 
         foreach ($this->answers as $answer) {
             $replacement = $answer->option->option ?? $answer->answer;
-            $questionText = str_replace("{$answer->marker}", $replacement, $questionText);
+            $questionText = str_replace('{' . $answer->marker . '}', $replacement, $questionText);
         }
 
-    
         return $questionText;
     }
 
@@ -63,5 +63,10 @@ class Question extends Model
     public function tags()
     {
         return $this->belongsToMany(Tag::class);
+    }
+
+    public function variants()
+    {
+        return $this->hasMany(QuestionVariant::class);
     }
 }

--- a/app/Models/QuestionVariant.php
+++ b/app/Models/QuestionVariant.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class QuestionVariant extends Model
+{
+    protected $fillable = ['question_id', 'text'];
+
+    public function question()
+    {
+        return $this->belongsTo(Question::class);
+    }
+}

--- a/app/Services/QuestionVariantService.php
+++ b/app/Services/QuestionVariantService.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Question;
+use App\Models\Test;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+
+class QuestionVariantService
+{
+    private ?bool $supportsVariants = null;
+
+    public function supportsVariants(): bool
+    {
+        if ($this->supportsVariants === null) {
+            $this->supportsVariants = Schema::hasTable('question_variants');
+        }
+
+        return $this->supportsVariants;
+    }
+
+    public function clearForTest(string $slug): void
+    {
+        session()->forget($this->namespaceKey($slug));
+    }
+
+    public function applyRandomVariant(Test $test, Question $question): void
+    {
+        if (! $this->supportsVariants()) {
+            return;
+        }
+
+        if (! $question->relationLoaded('variants')) {
+            $question->load('variants');
+        }
+
+        $variants = $question->variants
+            ->pluck('text')
+            ->filter()
+            ->unique()
+            ->values();
+
+        if ($variants->isEmpty()) {
+            session()->forget($this->questionKey($test->slug, $question->id));
+            return;
+        }
+
+        $options = $variants->prepend($question->getOriginal('question'))
+            ->unique()
+            ->values();
+
+        $choice = $options->random();
+
+        session()->put($this->questionKey($test->slug, $question->id), $choice);
+        $question->setAttribute('question', $choice);
+    }
+
+    public function applyRandomVariants(Test $test, Collection $questions): Collection
+    {
+        if (! $this->supportsVariants()) {
+            return $questions;
+        }
+
+        return $questions->map(function (Question $question) use ($test) {
+            $this->applyRandomVariant($test, $question);
+
+            return $question;
+        });
+    }
+
+    public function applyStoredVariant(?string $slug, Question $question): void
+    {
+        if (! $this->supportsVariants()) {
+            return;
+        }
+
+        if (! $slug) {
+            return;
+        }
+
+        $variant = session($this->questionKey($slug, $question->id));
+        if ($variant) {
+            $question->setAttribute('question', $variant);
+        }
+    }
+
+    private function namespaceKey(string $slug): string
+    {
+        return "test_variants.$slug";
+    }
+
+    private function questionKey(string $slug, int $questionId): string
+    {
+        return $this->namespaceKey($slug) . '.' . $questionId;
+    }
+}

--- a/database/migrations/2025_09_10_000000_create_question_variants_table.php
+++ b/database/migrations/2025_09_10_000000_create_question_variants_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('question_variants', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('question_id')->constrained()->cascadeOnDelete();
+            $table->text('text');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('question_variants');
+    }
+};

--- a/database/seeders/Ai/MixedTenseUsageAiSeeder.php
+++ b/database/seeders/Ai/MixedTenseUsageAiSeeder.php
@@ -1,0 +1,629 @@
+<?php
+
+namespace Database\Seeders\Ai;
+
+use App\Models\Category;
+use App\Models\ChatGPTExplanation;
+use App\Models\Question;
+use App\Models\QuestionHint;
+use App\Models\Source;
+use App\Models\Tag;
+use App\Services\QuestionSeedingService;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+class MixedTenseUsageAiSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $categoryId = Category::firstOrCreate(['name' => 'Mixed Tenses'])->id;
+        $sourceId = Source::firstOrCreate(['name' => 'AI: Mixed Tense Usage Review'])->id;
+
+        $grammarTags = [
+            'duration_result' => Tag::firstOrCreate(['name' => 'Duration vs Result'], ['category' => 'Grammar Focus'])->id,
+            'past_habit' => Tag::firstOrCreate(['name' => 'Past Habit Statements'], ['category' => 'Grammar Focus'])->id,
+            'unfinished_period' => Tag::firstOrCreate(['name' => 'Unfinished Time Periods'], ['category' => 'Grammar Focus'])->id,
+            'long_project' => Tag::firstOrCreate(['name' => 'Ongoing Projects'], ['category' => 'Grammar Focus'])->id,
+            'question_yet' => Tag::firstOrCreate(['name' => 'Questions with Yet'], ['category' => 'Grammar Focus'])->id,
+            'past_marker' => Tag::firstOrCreate(['name' => 'Past Simple Time Markers'], ['category' => 'Grammar Focus'])->id,
+            'present_result' => Tag::firstOrCreate(['name' => 'Present Result Situations'], ['category' => 'Grammar Focus'])->id,
+            'negative_yet' => Tag::firstOrCreate(['name' => 'Negative with Yet'], ['category' => 'Grammar Focus'])->id,
+            'duration_focus' => Tag::firstOrCreate(['name' => 'Duration Emphasis'], ['category' => 'Grammar Focus'])->id,
+            'already_statement' => Tag::firstOrCreate(['name' => 'Already Statements'], ['category' => 'Grammar Focus'])->id,
+            'negative_habit' => Tag::firstOrCreate(['name' => 'Negative Habit Statements'], ['category' => 'Grammar Focus'])->id,
+            'limited_activity' => Tag::firstOrCreate(['name' => 'Limited Activity Frequency'], ['category' => 'Grammar Focus'])->id,
+            'experience_gap' => Tag::firstOrCreate(['name' => 'Experience Gaps'], ['category' => 'Grammar Focus'])->id,
+            'long_term' => Tag::firstOrCreate(['name' => 'Long-Term Actions'], ['category' => 'Grammar Focus'])->id,
+            'injury_result' => Tag::firstOrCreate(['name' => 'Injury Results'], ['category' => 'Grammar Focus'])->id,
+            'interrupted_action' => Tag::firstOrCreate(['name' => 'Interrupted Actions'], ['category' => 'Grammar Focus'])->id,
+            'sequencing' => Tag::firstOrCreate(['name' => 'Sequencing with By the Time'], ['category' => 'Grammar Focus'])->id,
+            'prior_action' => Tag::firstOrCreate(['name' => 'Prior Past Actions'], ['category' => 'Grammar Focus'])->id,
+            'evidence_present' => Tag::firstOrCreate(['name' => 'Present Evidence'], ['category' => 'Grammar Focus'])->id,
+            'specific_time' => Tag::firstOrCreate(['name' => 'Specific Time in Past Continuous'], ['category' => 'Grammar Focus'])->id,
+            'future_deadline' => Tag::firstOrCreate(['name' => 'Future Perfect Deadlines'], ['category' => 'Grammar Focus'])->id,
+            'future_process' => Tag::firstOrCreate(['name' => 'Future Continuous Processes'], ['category' => 'Grammar Focus'])->id,
+        ];
+
+        $vocabularyTags = [
+            'housework' => Tag::firstOrCreate(['name' => 'Housework & Cleaning'], ['category' => 'Vocabulary Detail'])->id,
+            'childhood' => Tag::firstOrCreate(['name' => 'Childhood Memories'], ['category' => 'Vocabulary Detail'])->id,
+            'relationships' => Tag::firstOrCreate(['name' => 'Friendships & Relationships'], ['category' => 'Vocabulary Detail'])->id,
+            'renovation' => Tag::firstOrCreate(['name' => 'Home Renovation'], ['category' => 'Vocabulary Detail'])->id,
+            'family' => Tag::firstOrCreate(['name' => 'Family Life'], ['category' => 'Vocabulary Detail'])->id,
+            'travel' => Tag::firstOrCreate(['name' => 'Travel & Transport'], ['category' => 'Vocabulary Detail'])->id,
+            'daily_problem' => Tag::firstOrCreate(['name' => 'Daily Problems'], ['category' => 'Vocabulary Detail'])->id,
+            'thinking' => Tag::firstOrCreate(['name' => 'Thinking & Understanding'], ['category' => 'Vocabulary Detail'])->id,
+            'commuting' => Tag::firstOrCreate(['name' => 'Commuting'], ['category' => 'Vocabulary Detail'])->id,
+            'reading' => Tag::firstOrCreate(['name' => 'Reading & Study'], ['category' => 'Vocabulary Detail'])->id,
+            'beverages' => Tag::firstOrCreate(['name' => 'Beverages & Habits'], ['category' => 'Vocabulary Detail'])->id,
+            'media' => Tag::firstOrCreate(['name' => 'Entertainment & Media'], ['category' => 'Vocabulary Detail'])->id,
+            'technology' => Tag::firstOrCreate(['name' => 'Technology Use'], ['category' => 'Vocabulary Detail'])->id,
+            'driving' => Tag::firstOrCreate(['name' => 'Driving'], ['category' => 'Vocabulary Detail'])->id,
+            'living' => Tag::firstOrCreate(['name' => 'Home & Living'], ['category' => 'Vocabulary Detail'])->id,
+            'health' => Tag::firstOrCreate(['name' => 'Health & Injuries'], ['category' => 'Vocabulary Detail'])->id,
+            'meals' => Tag::firstOrCreate(['name' => 'Meals & Dining'], ['category' => 'Vocabulary Detail'])->id,
+            'borrowing' => Tag::firstOrCreate(['name' => 'Borrowing & Sharing'], ['category' => 'Vocabulary Detail'])->id,
+            'incidents' => Tag::firstOrCreate(['name' => 'Home Incidents'], ['category' => 'Vocabulary Detail'])->id,
+            'study' => Tag::firstOrCreate(['name' => 'Study Routine'], ['category' => 'Vocabulary Detail'])->id,
+            'education_goal' => Tag::firstOrCreate(['name' => 'Education Goals'], ['category' => 'Vocabulary Detail'])->id,
+            'holiday' => Tag::firstOrCreate(['name' => 'Holidays & Leisure'], ['category' => 'Vocabulary Detail'])->id,
+        ];
+
+        $questionData = [
+            [
+                'question' => 'Jane {a1} in the house for hours. He {a2} three rooms so far.',
+                'verb_hint' => ['a1' => '(work)', 'a2' => '(clean)'],
+                'options' => [
+                    'a1' => ['has worked', 'has been working'],
+                    'a2' => ['has cleaned', 'has been cleaning'],
+                ],
+                'answers' => ['a1' => 'has been working', 'a2' => 'has cleaned'],
+                'explanations' => [
+                    'has worked' => "Форма Present Perfect Simple підкреслює результат, але у виразі 'for hours' важлива саме тривалість процесу. Тому відповідь неправильна.",
+                    'has been working' => "Правильна відповідь. 'For hours' вказує на дію, яка триває вже певний час, тому тут потрібен Present Perfect Continuous.",
+                    'has cleaned' => "Правильна відповідь. Вираз 'so far' показує результат до цього моменту, тому вживаємо Present Perfect Simple.",
+                    'has been cleaning' => "Ця форма підкреслює сам процес, але контекст говорить про результат (закінчив три кімнати). Тому неправильна.",
+                ],
+                'hints' => [
+                    'a1' => 'Present Perfect Continuous: have/has + been + V-ing. Використовується для дій, що тривають до тепер.',
+                    'a2' => "Present Perfect Simple: have/has + V3. Використовується з 'so far', щоб підкреслити результат.",
+                ],
+                'level' => 'B2',
+                'tense' => ['Present Perfect Continuous', 'Present Perfect Simple'],
+                'grammar' => 'duration_result',
+                'vocab' => 'housework',
+            ],
+            [
+                'question' => 'He {a1} there when he was a child.',
+                'verb_hint' => ['a1' => '(live)'],
+                'options' => ['lived', 'has lived', 'has been living'],
+                'answers' => ['a1' => 'lived'],
+                'explanations' => [
+                    'has lived' => "Ця форма означає досвід, який актуальний тепер. Але у виразі 'when he was a child' мова йде про завершений минулий період. Тому ця форма неправильна.",
+                    'lived' => "Правильна відповідь. Минуле обставинне речення вимагає Past Simple, бо дія завершена ('when he was a child').",
+                    'has been living' => "Ця форма описує процес, що триває й досі. Але дія обмежена минулим періодом, тому це неправильно.",
+                ],
+                'hints' => [
+                    'a1' => 'Past Simple: V2. Використовується для завершених дій у минулому з маркерами часу (when, ago, yesterday).',
+                ],
+                'level' => 'A2',
+                'tense' => ['Past Simple'],
+                'grammar' => 'past_habit',
+                'vocab' => 'childhood',
+            ],
+            [
+                'question' => 'I {a1} her since last year.',
+                'verb_hint' => ['a1' => '(not/see)'],
+                'options' => ["haven't seen", "didn't see", "haven't been seeing"],
+                'answers' => ['a1' => "haven't seen"],
+                'explanations' => [
+                    "haven't seen" => "Правильна відповідь. 'Since last year' показує період від минулого до теперішнього моменту. Використовуємо Present Perfect Simple.",
+                    "didn't see" => "Past Simple означає завершену дію в минулому, але тут дія ще триває ('з того часу і досі'). Тому ця форма неправильна.",
+                    "haven't been seeing" => "Continuous з дієсловом 'see' звучить неприродно, адже 'see' — це статичне дієслово. Тому ця відповідь неправильна.",
+                ],
+                'hints' => [
+                    'a1' => "Present Perfect Simple: have/has + not + V3. Використовується з 'since/for'.",
+                ],
+                'level' => 'B1',
+                'tense' => ['Present Perfect Simple'],
+                'grammar' => 'unfinished_period',
+                'vocab' => 'relationships',
+            ],
+            [
+                'question' => 'They {a1} this room for a month. I’m sure they will never be ready with it.',
+                'verb_hint' => ['a1' => '(decorate)'],
+                'options' => ['have decorated', 'decorated', 'have been decorating'],
+                'answers' => ['a1' => 'have been decorating'],
+                'explanations' => [
+                    'have decorated' => 'Ця форма підкреслює завершений результат. Але робота ще триває, тому вона неправильна.',
+                    'decorated' => 'Past Simple позначає завершену дію в минулому, але процес ще триває зараз. Тому ця відповідь не підходить.',
+                    'have been decorating' => 'Правильна відповідь. Вираз "for a month" означає дію, що триває певний час і досі не завершена, отже вживаємо Present Perfect Continuous.',
+                ],
+                'hints' => [
+                    'a1' => 'Present Perfect Continuous: have/has + been + V-ing. Показує процес, що триває.',
+                ],
+                'level' => 'B2',
+                'tense' => ['Present Perfect Continuous'],
+                'grammar' => 'long_project',
+                'vocab' => 'renovation',
+            ],
+            [
+                'question' => 'Dad, {a1} reading the paper yet?',
+                'verb_hint' => ['a1' => '(finish)'],
+                'options' => ['did you finish', 'have you finished', 'are you finishing'],
+                'answers' => ['a1' => 'have you finished'],
+                'explanations' => [
+                    'did you finish' => "Past Simple означає завершену дію в минулому, але слово 'yet' вказує на теперішній момент. Тому ця форма неправильна.",
+                    'have you finished' => "Правильна відповідь. 'Yet' сигналізує, що ми питаємо про завершення дії до теперішнього моменту. Це класичний випадок Present Perfect.",
+                    'are you finishing' => 'Present Continuous показує дію в процесі, але питання стосується завершення. Тому ця форма невірна.',
+                ],
+                'hints' => [
+                    'a1' => "Present Perfect Simple: have/has + V3. Використовується в питаннях із 'yet'.",
+                ],
+                'level' => 'B1',
+                'tense' => ['Present Perfect Simple'],
+                'grammar' => 'question_yet',
+                'vocab' => 'family',
+            ],
+            [
+                'question' => 'They {a1} a few minutes ago.',
+                'verb_hint' => ['a1' => '(leave)'],
+                'options' => ['left', 'have just left', 'have been leaving'],
+                'answers' => ['a1' => 'left'],
+                'explanations' => [
+                    'left' => "Правильна відповідь. Слово 'ago' є маркером Past Simple, тому ми використовуємо форму V2.",
+                    'have just left' => "Ця форма правильна зі словом 'just', але не з 'ago'. Тому вона тут неправильна.",
+                    'have been leaving' => "Continuous тут недоречний, бо дія завершена. 'Ago' вимагає Past Simple.",
+                ],
+                'hints' => [
+                    'a1' => "Past Simple: V2. Використовуємо з маркером 'ago'.",
+                ],
+                'level' => 'A2',
+                'tense' => ['Past Simple'],
+                'grammar' => 'past_marker',
+                'vocab' => 'travel',
+            ],
+            [
+                'question' => 'I can’t get into my house because I {a1} my keys.',
+                'verb_hint' => ['a1' => '(lose)'],
+                'options' => ['lost', 'have been losing', 'have lost'],
+                'answers' => ['a1' => 'have lost'],
+                'explanations' => [
+                    'lost' => 'Past Simple вказує на завершену дію в минулому, але тут ключі все ще відсутні й наслідок відчувається тепер. Тому ця форма неправильна.',
+                    'have been losing' => 'Continuous означає дію, що відбувалась неодноразово або тривало. Але тут ідеться про один конкретний випадок втрати, тому ця форма невірна.',
+                    'have lost' => 'Правильна відповідь. Present Perfect Simple показує дію в минулому з наслідком у теперішньому: ключі втрачені, і я не можу потрапити в дім.',
+                ],
+                'hints' => [
+                    'a1' => 'Present Perfect Simple: have/has + V3. Використовується для дій із результатом у теперішньому.',
+                ],
+                'level' => 'B1',
+                'tense' => ['Present Perfect Simple'],
+                'grammar' => 'present_result',
+                'vocab' => 'daily_problem',
+            ],
+            [
+                'question' => 'My mom {a1} the problem yet.',
+                'verb_hint' => ['a1' => '(understand/not)'],
+                'options' => ["hasn't been understanding", 'has not understood', "didn't understand"],
+                'answers' => ['a1' => 'has not understood'],
+                'explanations' => [
+                    "hasn't been understanding" => "Continuous не підходить, оскільки 'understand' належить до статичних дієслів, які рідко вживаються у тривалих формах. Тому ця форма неправильна.",
+                    'has not understood' => "Правильна відповідь. Слово 'yet' показує, що дія досі не завершена. Для цього використовують Present Perfect Simple у заперечній формі.",
+                    "didn't understand" => "Past Simple означає завершене нерозуміння в минулому, але з 'yet' ми маємо справу із теперішнім результатом. Тому відповідь невірна.",
+                ],
+                'hints' => [
+                    'a1' => "Present Perfect Simple: have/has + not + V3. Уживається у запереченнях із 'yet'.",
+                ],
+                'level' => 'B1',
+                'tense' => ['Present Perfect Simple'],
+                'grammar' => 'negative_yet',
+                'vocab' => 'thinking',
+            ],
+            [
+                'question' => 'She {a1} for the bus for twenty minutes.',
+                'verb_hint' => ['a1' => '(wait)'],
+                'options' => ['has waited', 'waited', 'has been waiting'],
+                'answers' => ['a1' => 'has been waiting'],
+                'explanations' => [
+                    'has waited' => 'Present Perfect Simple підкреслює завершення дії, але тут дія ще триває. Тому форма невірна.',
+                    'waited' => 'Past Simple позначає завершене очікування в минулому, тоді як у реченні йдеться про триваючу дію. Неправильна відповідь.',
+                    'has been waiting' => 'Правильна відповідь. Вираз "for twenty minutes" показує тривалість дії, яка почалась у минулому і триває досі. Це класичний випадок для Present Perfect Continuous.',
+                ],
+                'hints' => [
+                    'a1' => "Present Perfect Continuous: have/has + been + V-ing. Використовується з 'for' і 'since' для тривалості.",
+                ],
+                'level' => 'B1',
+                'tense' => ['Present Perfect Continuous'],
+                'grammar' => 'duration_focus',
+                'vocab' => 'commuting',
+            ],
+            [
+                'question' => 'We {a1} this book already.',
+                'verb_hint' => ['a1' => '(read)'],
+                'options' => ['have read', 'read', 'have been reading'],
+                'answers' => ['a1' => 'have read'],
+                'explanations' => [
+                    'have read' => "Правильна відповідь. Слово 'already' сигналізує про дію, яка завершилась до теперішнього моменту, тому тут потрібен Present Perfect Simple.",
+                    'read' => "Past Simple можливий у конкретному контексті з минулим маркером часу, але тут його немає. 'Already' вимагає зв’язку з теперішнім. Неправильна відповідь.",
+                    'have been reading' => "Ця форма підкреслює тривалий процес, але контекст говорить про завершення ('already'). Тому ця форма неправильна.",
+                ],
+                'hints' => [
+                    'a1' => "Present Perfect Simple: have/has + V3. Використовується з 'already' для завершених дій.",
+                ],
+                'level' => 'A2',
+                'tense' => ['Present Perfect Simple'],
+                'grammar' => 'already_statement',
+                'vocab' => 'reading',
+            ],
+            [
+                'question' => 'Mark {a1} coffee for three months. He switched to tea.',
+                'verb_hint' => ['a1' => '(drink/not)'],
+                'options' => ["hasn't drunk", "didn't drink", "hasn't been drinking"],
+                'answers' => ['a1' => "hasn't drunk"],
+                'explanations' => [
+                    "hasn't drunk" => "Правильна відповідь. Вираз 'for three months' підкреслює період, що триває до тепер. Тому ми використовуємо Present Perfect Simple у заперечній формі.",
+                    "didn't drink" => 'Past Simple позначає завершену дію в минулому. Але тут дія охоплює проміжок часу, який триває до тепер, тому ця форма невірна.',
+                    "hasn't been drinking" => "Continuous підкреслює процес, але в поєднанні з 'switched to tea' зрозуміло, що дія завершена як результат вибору. Тому невірно.",
+                ],
+                'hints' => [
+                    'a1' => "Present Perfect Simple: have/has + not + V3. Показує дію, яка триває або не триває протягом певного часу.",
+                ],
+                'level' => 'B2',
+                'tense' => ['Present Perfect Simple'],
+                'grammar' => 'negative_habit',
+                'vocab' => 'beverages',
+            ],
+            [
+                'question' => 'I {a1} TV this week – just today for half an hour.',
+                'verb_hint' => ['a1' => '(watch/not)'],
+                'options' => ["haven't watched", "haven't been watching", "didn't watch", "wasn't watching"],
+                'answers' => ['a1' => "haven't been watching"],
+                'explanations' => [
+                    "haven't watched" => "Ця форма могла б бути правильною, але контекст 'just today for half an hour' підкреслює, що дія майже не відбувалась, а не повністю відсутня. Тому менш природно.",
+                    "haven't been watching" => "Правильна відповідь. Фраза 'this week' вказує на період, який ще триває, а тривала форма Continuous підкреслює процес. Тому використовується Present Perfect Continuous.",
+                    "didn't watch" => "Past Simple описує завершений період у минулому, але тут період 'this week' ще триває. Тому ця форма невірна.",
+                    "wasn't watching" => 'Past Continuous використовується для конкретного моменту в минулому, а не для опису періоду до теперішнього моменту. Тому неправильно.',
+                ],
+                'hints' => [
+                    'a1' => "Present Perfect Continuous: have/has + been + V-ing. Використовується з виразами на кшталт 'this week', коли період ще триває.",
+                ],
+                'level' => 'B2',
+                'tense' => ['Present Perfect Continuous'],
+                'grammar' => 'limited_activity',
+                'vocab' => 'media',
+            ],
+            [
+                'question' => 'I {a1} the computer for half an hour, only for about 5 minutes.',
+                'verb_hint' => ['a1' => '(play/not)'],
+                'options' => ["haven't played", "haven't been playing", "didn't play", "wasn't playing"],
+                'answers' => ['a1' => "haven't been playing"],
+                'explanations' => [
+                    "haven't played" => "Ця форма могла б підійти, але вона підкреслює лише факт відсутності дії. Контекст 'for half an hour… only 5 minutes' робить акцент на тривалості. Тому менш природно.",
+                    "haven't been playing" => "Правильна відповідь. Вираз 'for half an hour' вказує на процес, який не відбувався у цей період. Це класичний випадок для Present Perfect Continuous у заперечній формі.",
+                    "didn't play" => "Past Simple використовується для завершених дій у минулому, але період 'for half an hour' ще охоплює теперішній момент. Тому ця форма неправильна.",
+                    "wasn't playing" => "Past Continuous вказує на дію у конкретний момент у минулому, але тут йдеться про період, що триває до теперішнього. Відповідь невірна.",
+                ],
+                'hints' => [
+                    'a1' => "Present Perfect Continuous: have/has + been + V-ing. Використовуємо з 'for'/'since', коли підкреслюється тривалість або відсутність процесу.",
+                ],
+                'level' => 'B2',
+                'tense' => ['Present Perfect Continuous'],
+                'grammar' => 'duration_focus',
+                'vocab' => 'technology',
+            ],
+            [
+                'question' => 'Bob {a1} a car for eight years.',
+                'verb_hint' => ['a1' => '(drive/not)'],
+                'options' => ["hasn't driven", "hasn't been driving", "didn't drive", "wasn't driving"],
+                'answers' => ['a1' => "hasn't driven"],
+                'explanations' => [
+                    "hasn't driven" => "Правильна відповідь. Вираз 'for eight years' описує тривалий проміжок часу до тепер. Тут важливий факт відсутності досвіду, тому Present Perfect Simple.",
+                    "hasn't been driving" => 'Ця форма підкреслює відсутність процесу. Але в реченні важливий саме факт, що він не мав досвіду керування протягом цього часу. Тому менш підходить.',
+                    "didn't drive" => 'Past Simple описує завершені дії у минулому, але період ще триває до тепер. Тому ця форма невірна.',
+                    "wasn't driving" => 'Past Continuous використовується для певного моменту у минулому, а не для багаторічного проміжку. Тому невірно.',
+                ],
+                'hints' => [
+                    'a1' => "Present Perfect Simple: have/has + not + V3. Використовується, коли говоримо про тривалий період відсутності дії до тепер.",
+                ],
+                'level' => 'B2',
+                'tense' => ['Present Perfect Simple'],
+                'grammar' => 'experience_gap',
+                'vocab' => 'driving',
+            ],
+            [
+                'question' => 'We {a1} in this city for ten years now.',
+                'verb_hint' => ['a1' => '(live)'],
+                'options' => ['have lived', 'lived', 'have been living'],
+                'answers' => ['a1' => 'have been living'],
+                'explanations' => [
+                    'have lived' => 'Ця форма також можлива, але вона підкреслює сам факт проживання. У реченні ж важлива тривалість процесу ("for ten years now"), тому краще Continuous.',
+                    'lived' => 'Past Simple не підходить, бо дія ще триває. Ми все ще живемо тут.',
+                    'have been living' => 'Правильна відповідь. "For ten years now" показує дію, яка почалась у минулому і триває досі. Це класичний випадок Present Perfect Continuous.',
+                ],
+                'hints' => [
+                    'a1' => "Present Perfect Continuous: have/has + been + V-ing. Використовується з 'for'/'since', коли підкреслюємо тривалість.",
+                ],
+                'level' => 'B1',
+                'tense' => ['Present Perfect Continuous'],
+                'grammar' => 'long_term',
+                'vocab' => 'living',
+            ],
+            [
+                'question' => 'She {a1} her leg and can’t walk.',
+                'verb_hint' => ['a1' => '(break)'],
+                'options' => ['broke', 'has broken', 'has been breaking'],
+                'answers' => ['a1' => 'has broken'],
+                'explanations' => [
+                    'broke' => 'Past Simple описує подію в минулому, але тоді не було б пояснення теперішньої проблеми. У реченні важливий наслідок, тому це неправильно.',
+                    'has broken' => 'Правильна відповідь. Present Perfect Simple підкреслює, що подія у минулому має наслідки зараз (вона не може ходити).',
+                    'has been breaking' => 'Continuous у такому контексті не вживається, бо "break" — це миттєва дія, а не процес. Тому ця форма неправильна.',
+                ],
+                'hints' => [
+                    'a1' => 'Present Perfect Simple: have/has + V3. Використовується, коли минула дія має теперішній результат.',
+                ],
+                'level' => 'A2',
+                'tense' => ['Present Perfect Simple'],
+                'grammar' => 'injury_result',
+                'vocab' => 'health',
+            ],
+            [
+                'question' => 'They {a1} dinner when I arrived.',
+                'verb_hint' => ['a1' => '(eat)'],
+                'options' => ['were eating', 'ate', 'have eaten'],
+                'answers' => ['a1' => 'were eating'],
+                'explanations' => [
+                    'were eating' => "Правильна відповідь. Past Continuous використовується для дій, що тривали у конкретний момент у минулому ('when I arrived').",
+                    'ate' => "Past Simple описує завершену дію. Але тут акцент на процесі, який відбувався саме у момент мого приходу.",
+                    'have eaten' => 'Present Perfect вживається для дій із результатом у теперішньому, а тут описується подія у минулому. Неправильна форма.',
+                ],
+                'hints' => [
+                    'a1' => 'Past Continuous: was/were + V-ing. Використовується для опису дій у процесі у минулому.',
+                ],
+                'level' => 'B1',
+                'tense' => ['Past Continuous'],
+                'grammar' => 'interrupted_action',
+                'vocab' => 'meals',
+            ],
+            [
+                'question' => 'By the time we arrived, the train {a1}.',
+                'verb_hint' => ['a1' => '(leave)'],
+                'options' => ['left', 'had left', 'has left'],
+                'answers' => ['a1' => 'had left'],
+                'explanations' => [
+                    'left' => "Past Simple означає, що дія і наша подорож відбулися одночасно. Але 'by the time' вимагає вживання минулого більш раннього часу. Тому ця форма невірна.",
+                    'had left' => "Правильна відповідь. Past Perfect вказує, що дія завершилась раніше іншої дії в минулому ('by the time we arrived').",
+                    'has left' => 'Present Perfect не підходить, бо мова йде про минулий момент, а не теперішній результат.',
+                ],
+                'hints' => [
+                    'a1' => 'Past Perfect: had + V3. Використовується для дії, що сталася перед іншою подією в минулому.',
+                ],
+                'level' => 'B2',
+                'tense' => ['Past Perfect'],
+                'grammar' => 'sequencing',
+                'vocab' => 'travel',
+            ],
+            [
+                'question' => 'When I got home, my brother {a1} my bike without asking.',
+                'verb_hint' => ['a1' => '(take)'],
+                'options' => ['took', 'had taken', 'has taken'],
+                'answers' => ['a1' => 'had taken'],
+                'explanations' => [
+                    'took' => 'Past Simple вказує, що дія відбулася одночасно з моїм поверненням. Але ми підкреслюємо, що це сталося РАНІШЕ. Тому ця форма неправильна.',
+                    'had taken' => 'Правильна відповідь. Past Perfect використовується, щоб показати, що одна дія (він узяв велосипед) сталася раніше іншої (я повернувся додому).',
+                    'has taken' => 'Present Perfect описує події з теперішнім результатом, але у реченні йдеться про минулий момент. Тому ця форма невірна.',
+                ],
+                'hints' => [
+                    'a1' => 'Past Perfect: had + V3. Використовується для дій, що сталися до іншої події у минулому.',
+                ],
+                'level' => 'B2',
+                'tense' => ['Past Perfect'],
+                'grammar' => 'prior_action',
+                'vocab' => 'borrowing',
+            ],
+            [
+                'question' => 'Look! Somebody {a1} the window.',
+                'verb_hint' => ['a1' => '(break)'],
+                'options' => ['broke', 'has broken', 'had broken'],
+                'answers' => ['a1' => 'has broken'],
+                'explanations' => [
+                    'broke' => "Past Simple описує подію у минулому, але ми бачимо результат прямо зараз (розбите вікно). Тому ця форма неправильна.",
+                    'has broken' => 'Правильна відповідь. Present Perfect використовується, коли минула дія має очевидний наслідок у теперішньому.',
+                    'had broken' => 'Past Perfect описує події, що сталися перед іншими діями в минулому, але тут йдеться про теперішній результат. Тому ця форма невірна.',
+                ],
+                'hints' => [
+                    'a1' => 'Present Perfect Simple: have/has + V3. Використовується, коли минула дія має результат зараз.',
+                ],
+                'level' => 'A2',
+                'tense' => ['Present Perfect Simple'],
+                'grammar' => 'evidence_present',
+                'vocab' => 'incidents',
+            ],
+            [
+                'question' => 'At 7 p.m. yesterday I {a1} my homework.',
+                'verb_hint' => ['a1' => '(do)'],
+                'options' => ['was doing', 'did', 'have done'],
+                'answers' => ['a1' => 'was doing'],
+                'explanations' => [
+                    'was doing' => "Правильна відповідь. Past Continuous використовується для дій, що відбувались у конкретний момент у минулому ('at 7 p.m. yesterday').",
+                    'did' => 'Past Simple означає завершену дію, але контекст показує процес у певний час. Тому ця форма невірна.',
+                    'have done' => "Present Perfect стосується теперішнього результату, але у реченні є минулий час 'yesterday'. Це робить варіант неправильним.",
+                ],
+                'hints' => [
+                    'a1' => 'Past Continuous: was/were + V-ing. Використовується для дій у процесі у конкретний момент у минулому.',
+                ],
+                'level' => 'B1',
+                'tense' => ['Past Continuous'],
+                'grammar' => 'specific_time',
+                'vocab' => 'study',
+            ],
+            [
+                'question' => 'By next year, she {a1} her studies.',
+                'verb_hint' => ['a1' => '(finish)'],
+                'options' => ['will finish', 'will have finished', 'is finishing'],
+                'answers' => ['a1' => 'will have finished'],
+                'explanations' => [
+                    'will finish' => "Future Simple означає дію в майбутньому, але не підкреслює, що вона завершиться ДО певного моменту. Тому ця форма неправильна.",
+                    'will have finished' => "Правильна відповідь. Future Perfect використовується, щоб показати, що дія завершиться до певного часу в майбутньому ('by next year').",
+                    'is finishing' => "Present Continuous може вживатися для запланованих дій, але тут потрібне підкреслення моменту завершення до конкретного майбутнього часу.",
+                ],
+                'hints' => [
+                    'a1' => 'Future Perfect: will have + V3. Використовується з "by" для позначення завершення дії до певного моменту.',
+                ],
+                'level' => 'C1',
+                'tense' => ['Future Perfect'],
+                'grammar' => 'future_deadline',
+                'vocab' => 'education_goal',
+            ],
+            [
+                'question' => 'This time tomorrow, we {a1} on the beach.',
+                'verb_hint' => ['a1' => '(lie)'],
+                'options' => ['will lie', 'will be lying', 'are lying'],
+                'answers' => ['a1' => 'will be lying'],
+                'explanations' => [
+                    'will lie' => 'Future Simple описує факт майбутньої дії, але не підкреслює її тривалість у конкретний момент. Тому ця форма менш точна.',
+                    'will be lying' => "Правильна відповідь. Future Continuous використовується для дій, що будуть у процесі у конкретний момент у майбутньому ('this time tomorrow').",
+                    'are lying' => "Present Continuous може описувати заплановані майбутні дії, але тут ключовий вираз 'this time tomorrow' вимагає Future Continuous.",
+                ],
+                'hints' => [
+                    'a1' => 'Future Continuous: will be + V-ing. Використовується, щоб описати дію у процесі в певний момент майбутнього.',
+                ],
+                'level' => 'B2',
+                'tense' => ['Future Continuous'],
+                'grammar' => 'future_process',
+                'vocab' => 'holiday',
+            ],
+        ];
+
+        $levelDifficulty = [
+            'A1' => 1,
+            'A2' => 2,
+            'B1' => 3,
+            'B2' => 4,
+            'C1' => 5,
+            'C2' => 5,
+        ];
+
+        $service = new QuestionSeedingService();
+        $items = [];
+        $meta = [];
+
+        foreach ($questionData as $index => $data) {
+            $uuid = (string) Str::uuid();
+            $answers = [];
+            $optionMarkerMap = [];
+            $options = $data['options'];
+
+            if (! empty($options) && is_array($options) && is_array(reset($options))) {
+                foreach ($options as $marker => $values) {
+                    foreach ($values as $value) {
+                        $optionMarkerMap[$value] = $marker;
+                    }
+                }
+                $flatOptions = array_values(array_unique(Arr::flatten($options)));
+            } else {
+                $marker = array_key_first($data['answers']);
+                foreach ($options as $value) {
+                    $optionMarkerMap[$value] = $marker;
+                }
+                $flatOptions = array_values(array_unique($options));
+            }
+
+            foreach ($data['answers'] as $marker => $answer) {
+                $answers[] = [
+                    'marker' => $marker,
+                    'answer' => $answer,
+                    'verb_hint' => $this->normalizeHint($data['verb_hint'][$marker] ?? null),
+                ];
+                $optionMarkerMap[$answer] = $marker;
+            }
+
+            $tenseTags = [];
+            foreach ($data['tense'] as $tenseName) {
+                $tenseTags[] = Tag::firstOrCreate(['name' => $tenseName], ['category' => 'Tenses'])->id;
+            }
+
+            $tagIds = array_values(array_unique(array_merge(
+                $tenseTags,
+                [$grammarTags[$data['grammar']], $vocabularyTags[$data['vocab']]]
+            )));
+
+            $items[] = [
+                'uuid' => $uuid,
+                'question' => $data['question'],
+                'category_id' => $categoryId,
+                'difficulty' => $levelDifficulty[$data['level']] ?? 3,
+                'source_id' => $sourceId,
+                'flag' => 2,
+                'level' => $data['level'],
+                'tag_ids' => $tagIds,
+                'answers' => $answers,
+                'options' => $flatOptions,
+            ];
+
+            $meta[] = [
+                'uuid' => $uuid,
+                'answers' => $data['answers'],
+                'option_markers' => $optionMarkerMap,
+                'hints' => $data['hints'],
+                'explanations' => $data['explanations'],
+            ];
+        }
+
+        $service->seed($items);
+
+        foreach ($meta as $item) {
+            $question = Question::where('uuid', $item['uuid'])->first();
+            if (! $question) {
+                continue;
+            }
+
+            $hintText = $this->combineHints($item['hints']);
+            if ($hintText !== null) {
+                QuestionHint::updateOrCreate(
+                    ['question_id' => $question->id, 'provider' => 'chatgpt', 'locale' => 'uk'],
+                    ['hint' => $hintText]
+                );
+            }
+
+            foreach ($item['explanations'] as $option => $text) {
+                $marker = $item['option_markers'][$option] ?? array_key_first($item['answers']);
+                $correct = $item['answers'][$marker] ?? reset($item['answers']);
+
+                ChatGPTExplanation::updateOrCreate(
+                    [
+                        'question' => $question->question,
+                        'wrong_answer' => $option,
+                        'correct_answer' => $correct,
+                        'language' => 'ua',
+                    ],
+                    ['explanation' => $text]
+                );
+            }
+        }
+    }
+
+    private function normalizeHint(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return trim($value, "() \t\n\r");
+    }
+
+    private function combineHints(array $hints): ?string
+    {
+        if (empty($hints)) {
+            return null;
+        }
+
+        $parts = [];
+        foreach ($hints as $marker => $text) {
+            $label = strtoupper($marker);
+            $parts[] = "$label: $text";
+        }
+
+        return implode("\n", $parts);
+    }
+}

--- a/database/seeders/Ai/NegativePresentPerfectHabitsTestSeeder.php
+++ b/database/seeders/Ai/NegativePresentPerfectHabitsTestSeeder.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Database\Seeders\Ai;
+
+use App\Models\Category;
+use App\Models\Source;
+use App\Models\Tag;
+use App\Services\QuestionSeedingService;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class NegativePresentPerfectHabitsTestSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $categoryId = Category::firstOrCreate(['name' => 'Present Perfect'])->id;
+        $sourceId = Source::firstOrCreate(['name' => 'AI: Present Perfect Negative Habits'])->id;
+
+        $tenseTag = Tag::firstOrCreate(['name' => 'Present Perfect'], ['category' => 'Tenses']);
+        $grammarTag = Tag::firstOrCreate(['name' => 'Negative Statements'], ['category' => 'Grammar Focus']);
+
+        $vocabularyTags = [
+            'food_drink' => Tag::firstOrCreate(['name' => 'Food & Drink'], ['category' => 'Vocabulary'])->id,
+            'media' => Tag::firstOrCreate(['name' => 'Entertainment & Media'], ['category' => 'Vocabulary'])->id,
+            'social' => Tag::firstOrCreate(['name' => 'Social Life'], ['category' => 'Vocabulary'])->id,
+            'health' => Tag::firstOrCreate(['name' => 'Health & Lifestyle'], ['category' => 'Vocabulary'])->id,
+            'fitness' => Tag::firstOrCreate(['name' => 'Fitness & Sports'], ['category' => 'Vocabulary'])->id,
+            'study' => Tag::firstOrCreate(['name' => 'School & Study'], ['category' => 'Vocabulary'])->id,
+            'hobbies' => Tag::firstOrCreate(['name' => 'Hobbies & Leisure'], ['category' => 'Vocabulary'])->id,
+            'communication' => Tag::firstOrCreate(['name' => 'Communication'], ['category' => 'Vocabulary'])->id,
+        ];
+
+        $questions = [
+            [
+                'question' => 'Emma {a1} chocolate this week – only fruit.',
+                'answer' => "hasn't eaten",
+                'verb_hint' => 'eat/not',
+                'options' => ["hasn't eaten", "hasn't been eating", "didn't eat", "wasn't eating"],
+                'variants' => [
+                    'Sophia {a1} bread today – she chose rice instead.',
+                    'Lucas {a1} cake this week – he prefers fruit salad.',
+                    'Isabella {a1} pizza for months – she’s been on a diet.',
+                    'Ethan {a1} meat recently – he became vegetarian.',
+                    'Olivia {a1} sweets all day – only vegetables and nuts.',
+                ],
+                'vocab' => 'food_drink',
+            ],
+            [
+                'question' => 'We {a1} TV lately, just a few short videos online.',
+                'answer' => "haven't watched",
+                'verb_hint' => 'watch/not',
+                'options' => ["haven't watched", "haven't been watching", "didn't watch", "weren't watching"],
+                'variants' => [
+                    'We {a1} movies lately – only some short clips.',
+                    'We {a1} the news today – just scrolled headlines.',
+                    'We {a1} Netflix this month – too much work.',
+                    'We {a1} cartoons in weeks – the kids are busy.',
+                    'We {a1} any films since summer – no time for cinema.',
+                ],
+                'vocab' => 'media',
+            ],
+            [
+                'question' => 'Tom {a1} his friends for weeks. He’s been busy with exams.',
+                'answer' => "hasn't seen",
+                'verb_hint' => 'see/not',
+                'options' => ["hasn't seen", "hasn't been seeing", "didn't see", "wasn't seeing"],
+                'variants' => [
+                    'Daniel {a1} his cousins for a year – they live abroad.',
+                    'Mia {a1} her classmates this month – lessons moved online.',
+                    'James {a1} his best friend since Christmas – they lost contact.',
+                    'Lily {a1} her teacher for weeks – school was closed.',
+                    'Benjamin {a1} his parents much recently – he’s been traveling.',
+                ],
+                'vocab' => 'social',
+            ],
+            [
+                'question' => 'I {a1} much coffee this morning – only half a cup.',
+                'answer' => "haven't drunk",
+                'verb_hint' => 'drink/not',
+                'options' => ["haven't drunk", "haven't been drinking", "didn't drink", "wasn't drinking"],
+                'variants' => [
+                    'I {a1} tea today – I felt like juice instead.',
+                    'I {a1} juice this week – only plain water.',
+                    'I {a1} milk recently – my fridge is empty.',
+                    'I {a1} enough water this morning – just one glass.',
+                    'I {a1} cola since last month – I’m trying to stay healthy.',
+                ],
+                'vocab' => 'food_drink',
+            ],
+            [
+                'question' => 'They {a1} the gym for months, that’s why they lost shape.',
+                'answer' => "haven't gone",
+                'verb_hint' => 'go/not',
+                'options' => ["haven't gone", "haven't been going", "didn't go", "weren't going"],
+                'variants' => [
+                    'Noah and Emma {a1} swimming for a long time – the pool is closed.',
+                    'Ava and Liam {a1} dancing classes recently – the teacher left.',
+                    'Sophia and Jack {a1} hiking since last year – the weather was bad.',
+                    'Oliver and Grace {a1} jogging this week – they’re both sick.',
+                    'Ella and Henry {a1} yoga for months – too busy at work.',
+                ],
+                'vocab' => 'fitness',
+            ],
+            [
+                'question' => 'She {a1} enough sleep recently – she looks really tired.',
+                'answer' => "hasn't slept",
+                'verb_hint' => 'sleep/not',
+                'options' => ["hasn't slept", "hasn't been sleeping", "didn't sleep", "wasn't sleeping"],
+                'variants' => [
+                    'Amelia {a1} well this week – always waking up at night.',
+                    'Matthew {a1} at night recently – too much stress.',
+                    'Hannah {a1} properly for days – exams are coming.',
+                    'Jacob {a1} much since Monday – too many projects.',
+                    'Emily {a1} peacefully lately – bad dreams disturb her.',
+                ],
+                'vocab' => 'health',
+            ],
+            [
+                'question' => 'I {a1} my English homework today – I was too busy.',
+                'answer' => "haven't done",
+                'verb_hint' => 'do/not',
+                'options' => ["haven't done", "haven't been doing", "didn't do", "wasn't doing"],
+                'variants' => [
+                    'I {a1} the dishes today – I left them in the sink.',
+                    'I {a1} the shopping yet – the store was closed.',
+                    'I {a1} my project this week – the deadline moved.',
+                    'I {a1} the cleaning – the room is still messy.',
+                    'I {a1} my assignment – I completely forgot.',
+                ],
+                'vocab' => 'study',
+            ],
+            [
+                'question' => 'David {a1} his guitar for weeks – he needs to practice.',
+                'answer' => "hasn't played",
+                'verb_hint' => 'play/not',
+                'options' => ["hasn't played", "hasn't been playing", "didn't play", "wasn't playing"],
+                'variants' => [
+                    'Oliver {a1} the piano for weeks – he lost motivation.',
+                    'Sophia {a1} football recently – her leg hurts.',
+                    'William {a1} the drums this month – his set is broken.',
+                    'Chloe {a1} video games for days – no free time.',
+                    'Alexander {a1} tennis lately – it’s been raining.',
+                ],
+                'vocab' => 'hobbies',
+            ],
+            [
+                'question' => 'We {a1} any news from Anna since the party.',
+                'answer' => "haven't heard",
+                'verb_hint' => 'hear/not',
+                'options' => ["haven't heard", "haven't been hearing", "didn't hear", "weren't hearing"],
+                'variants' => [
+                    'We {a1} from Peter since April – he moved abroad.',
+                    'We {a1} any news lately – the group chat is silent.',
+                    'We {a1} anything from Sarah – no emails came.',
+                    'We {a1} from John for a long time – he deleted social media.',
+                    'We {a1} any updates this week – nothing happened.',
+                ],
+                'vocab' => 'communication',
+            ],
+            [
+                'question' => 'I {a1} running these days – only walking in the park.',
+                'answer' => "haven't been running",
+                'verb_hint' => 'run/not',
+                'options' => ["haven't run", "haven't been running", "didn't run", "wasn't running"],
+                'variants' => [
+                    'I {a1} swimming these days – the pool is under repair.',
+                    'I {a1} cycling this month – my bike has a flat tire.',
+                    'I {a1} exercising recently – I caught a cold.',
+                    'I {a1} working out this week – too much office work.',
+                    'I {a1} training much lately – my schedule is full.',
+                ],
+                'vocab' => 'fitness',
+            ],
+        ];
+
+        $service = new QuestionSeedingService();
+        $items = [];
+
+        foreach ($questions as $data) {
+            $items[] = [
+                'uuid' => (string) Str::uuid(),
+                'question' => $data['question'],
+                'category_id' => $categoryId,
+                'difficulty' => 3,
+                'source_id' => $sourceId,
+                'flag' => 2,
+                'level' => 'B1',
+                'tag_ids' => [
+                    $tenseTag->id,
+                    $grammarTag->id,
+                    $vocabularyTags[$data['vocab']],
+                ],
+                'answers' => [
+                    [
+                        'marker' => 'a1',
+                        'answer' => $data['answer'],
+                        'verb_hint' => $data['verb_hint'],
+                    ],
+                ],
+                'options' => $data['options'],
+                'variants' => $data['variants'],
+            ];
+        }
+
+        $service->seed($items);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use App\Models\Category;
 use Illuminate\Database\Seeder;
+use Database\Seeders\Ai\NegativePresentPerfectHabitsTestSeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -95,6 +96,7 @@ class DatabaseSeeder extends Seeder
             IrregularVerbsSeeder::class,
             FutureSimpleFutureContinuousFuturePerfectTestSeeder::class,
             FutureSimpleOrFutureContinuousSeeder::class,
+            NegativePresentPerfectHabitsTestSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use App\Models\Category;
 use Illuminate\Database\Seeder;
+use Database\Seeders\Ai\MixedTenseUsageAiSeeder;
 use Database\Seeders\Ai\NegativePresentPerfectHabitsTestSeeder;
 
 class DatabaseSeeder extends Seeder
@@ -97,6 +98,7 @@ class DatabaseSeeder extends Seeder
             FutureSimpleFutureContinuousFuturePerfectTestSeeder::class,
             FutureSimpleOrFutureContinuousSeeder::class,
             NegativePresentPerfectHabitsTestSeeder::class,
+            MixedTenseUsageAiSeeder::class,
         ]);
     }
 }

--- a/resources/views/components/question-input.blade.php
+++ b/resources/views/components/question-input.blade.php
@@ -9,6 +9,7 @@
     'methodMap' => [],
     'showVerbHintEdit' => false,
     'showQuestionEdit' => false,
+    'testSlug' => null,
 ])
 @php
     $questionText = $question->question;
@@ -101,6 +102,7 @@ HTML;
     x-data="{
         qid: {{ $question?->id ?? 'null' }},
         qtext: @js($question->question),
+        testSlug: @js($testSlug),
         hints: { chatgpt: '', gemini: '' },
         fetchHints(refresh = false) {
             if (!this.qid && !this.qtext) return; // немає даних питання
@@ -109,6 +111,9 @@ HTML;
                 payload.question_id = this.qid;
             } else {
                 payload.question = this.qtext;
+            }
+            if (this.testSlug) {
+                payload.test_slug = this.testSlug;
             }
             fetch('{{ route('question.hint') }}', {
                 method: 'POST',

--- a/resources/views/components/saved-test-js-persistence.blade.php
+++ b/resources/views/components/saved-test-js-persistence.blade.php
@@ -3,6 +3,7 @@ window.JS_TEST_PERSISTENCE = {
     endpoint: '{{ route('saved-test.js.state', $test->slug) }}',
     mode: '{{ $mode }}',
     token: '{{ csrf_token() }}',
+    questionsEndpoint: '{{ route('saved-test.js.questions', $test->slug) }}',
     saved: @json($savedState),
 };
 </script>

--- a/resources/views/components/saved-test-js-persistence.blade.php
+++ b/resources/views/components/saved-test-js-persistence.blade.php
@@ -1,0 +1,8 @@
+<script>
+window.JS_TEST_PERSISTENCE = {
+    endpoint: '{{ route('saved-test.js.state', $test->slug) }}',
+    mode: '{{ $mode }}',
+    token: '{{ csrf_token() }}',
+    saved: @json($savedState),
+};
+</script>

--- a/resources/views/engram/saved-test-js-input.blade.php
+++ b/resources/views/engram/saved-test-js-input.blade.php
@@ -35,7 +35,10 @@
   }
 </style>
 <script>
-const QUESTIONS = @json($questionData);
+window.__INITIAL_JS_TEST_QUESTIONS__ = @json($questionData);
+let QUESTIONS = Array.isArray(window.__INITIAL_JS_TEST_QUESTIONS__)
+    ? window.__INITIAL_JS_TEST_QUESTIONS__
+    : [];
 </script>
 @include('components.saved-test-js-persistence', ['mode' => $jsStateMode, 'savedState' => $savedState])
 @include('components.saved-test-js-helpers')
@@ -46,7 +49,10 @@ const state = {
   answered: 0,
 };
 
-function init(forceFresh = false) {
+async function init(forceFresh = false) {
+  const baseQuestions = await loadQuestions(forceFresh);
+  QUESTIONS = Array.isArray(baseQuestions) ? baseQuestions : [];
+
   let restored = false;
   if (!forceFresh) {
     const saved = getSavedState();

--- a/resources/views/engram/saved-test-js-manual.blade.php
+++ b/resources/views/engram/saved-test-js-manual.blade.php
@@ -36,7 +36,10 @@
   }
 </style>
 <script>
-const QUESTIONS = @json($questionData);
+window.__INITIAL_JS_TEST_QUESTIONS__ = @json($questionData);
+let QUESTIONS = Array.isArray(window.__INITIAL_JS_TEST_QUESTIONS__)
+    ? window.__INITIAL_JS_TEST_QUESTIONS__
+    : [];
 </script>
 @include('components.saved-test-js-persistence', ['mode' => $jsStateMode, 'savedState' => $savedState])
 @include('components.saved-test-js-helpers')
@@ -47,7 +50,10 @@ const state = {
   answered: 0,
 };
 
-function init(forceFresh = false) {
+async function init(forceFresh = false) {
+  const baseQuestions = await loadQuestions(forceFresh);
+  QUESTIONS = Array.isArray(baseQuestions) ? baseQuestions : [];
+
   let restored = false;
   if (!forceFresh) {
     const saved = getSavedState();

--- a/resources/views/engram/saved-test-js-select.blade.php
+++ b/resources/views/engram/saved-test-js-select.blade.php
@@ -34,7 +34,10 @@
   }
 </style>
 <script>
-const QUESTIONS = @json($questionData);
+window.__INITIAL_JS_TEST_QUESTIONS__ = @json($questionData);
+let QUESTIONS = Array.isArray(window.__INITIAL_JS_TEST_QUESTIONS__)
+    ? window.__INITIAL_JS_TEST_QUESTIONS__
+    : [];
 </script>
 @include('components.saved-test-js-persistence', ['mode' => $jsStateMode, 'savedState' => $savedState])
 @include('components.saved-test-js-helpers')
@@ -45,7 +48,10 @@ const state = {
   answered: 0,
 };
 
-function init(forceFresh = false) {
+async function init(forceFresh = false) {
+  const baseQuestions = await loadQuestions(forceFresh);
+  QUESTIONS = Array.isArray(baseQuestions) ? baseQuestions : [];
+
   let restored = false;
   if (!forceFresh) {
     const saved = getSavedState();

--- a/resources/views/engram/saved-test-js-step-input.blade.php
+++ b/resources/views/engram/saved-test-js-step-input.blade.php
@@ -51,7 +51,10 @@
   }
 </style>
 <script>
-const QUESTIONS = @json($questionData);
+window.__INITIAL_JS_TEST_QUESTIONS__ = @json($questionData);
+let QUESTIONS = Array.isArray(window.__INITIAL_JS_TEST_QUESTIONS__)
+    ? window.__INITIAL_JS_TEST_QUESTIONS__
+    : [];
 const CSRF_TOKEN = '{{ csrf_token() }}';
 const EXPLAIN_URL = '{{ route('question.explain') }}';
 </script>
@@ -70,7 +73,10 @@ function showLoader(show) {
   loaderEl.classList.toggle('hidden', !show);
 }
 
-function init(forceFresh = false) {
+async function init(forceFresh = false) {
+  const baseQuestions = await loadQuestions(forceFresh);
+  QUESTIONS = Array.isArray(baseQuestions) ? baseQuestions : [];
+
   let restored = false;
   if (!forceFresh) {
     const saved = getSavedState();

--- a/resources/views/engram/saved-test-js-step-manual.blade.php
+++ b/resources/views/engram/saved-test-js-step-manual.blade.php
@@ -39,7 +39,10 @@
   }
 </style>
 <script>
-const QUESTIONS = @json($questionData);
+window.__INITIAL_JS_TEST_QUESTIONS__ = @json($questionData);
+let QUESTIONS = Array.isArray(window.__INITIAL_JS_TEST_QUESTIONS__)
+    ? window.__INITIAL_JS_TEST_QUESTIONS__
+    : [];
 </script>
 @include('components.saved-test-js-persistence', ['mode' => $jsStateMode, 'savedState' => $savedState])
 @include('components.saved-test-js-helpers')
@@ -50,7 +53,10 @@ const state = {
   correct: 0,
 };
 
-function init(forceFresh = false) {
+async function init(forceFresh = false) {
+  const baseQuestions = await loadQuestions(forceFresh);
+  QUESTIONS = Array.isArray(baseQuestions) ? baseQuestions : [];
+
   let restored = false;
   if (!forceFresh) {
     const saved = getSavedState();

--- a/resources/views/engram/saved-test-js-step-select.blade.php
+++ b/resources/views/engram/saved-test-js-step-select.blade.php
@@ -47,7 +47,10 @@
   }
 </style>
 <script>
-const QUESTIONS = @json($questionData);
+window.__INITIAL_JS_TEST_QUESTIONS__ = @json($questionData);
+let QUESTIONS = Array.isArray(window.__INITIAL_JS_TEST_QUESTIONS__)
+    ? window.__INITIAL_JS_TEST_QUESTIONS__
+    : [];
 const CSRF_TOKEN = '{{ csrf_token() }}';
 const EXPLAIN_URL = '{{ route('question.explain') }}';
 </script>
@@ -66,7 +69,10 @@ function showLoader(show) {
   loaderEl.classList.toggle('hidden', !show);
 }
 
-function init(forceFresh = false) {
+async function init(forceFresh = false) {
+  const baseQuestions = await loadQuestions(forceFresh);
+  QUESTIONS = Array.isArray(baseQuestions) ? baseQuestions : [];
+
   let restored = false;
   if (!forceFresh) {
     const saved = getSavedState();

--- a/resources/views/engram/saved-test-js-step.blade.php
+++ b/resources/views/engram/saved-test-js-step.blade.php
@@ -45,7 +45,10 @@
   }
 </style>
 <script>
-const QUESTIONS = @json($questionData);
+window.__INITIAL_JS_TEST_QUESTIONS__ = @json($questionData);
+let QUESTIONS = Array.isArray(window.__INITIAL_JS_TEST_QUESTIONS__)
+    ? window.__INITIAL_JS_TEST_QUESTIONS__
+    : [];
 const CSRF_TOKEN = '{{ csrf_token() }}';
 </script>
 @include('components.saved-test-js-persistence', ['mode' => $jsStateMode, 'savedState' => $savedState])
@@ -71,7 +74,10 @@ function ensureGlobalEvents() {
   globalEventsHooked = true;
 }
 
-function init(forceFresh = false) {
+async function init(forceFresh = false) {
+  const baseQuestions = await loadQuestions(forceFresh);
+  QUESTIONS = Array.isArray(baseQuestions) ? baseQuestions : [];
+
   let restored = false;
   if (!forceFresh) {
     const saved = getSavedState();

--- a/resources/views/engram/saved-test-js.blade.php
+++ b/resources/views/engram/saved-test-js.blade.php
@@ -34,7 +34,10 @@
   }
 </style>
 <script>
-const QUESTIONS = @json($questionData);
+window.__INITIAL_JS_TEST_QUESTIONS__ = @json($questionData);
+let QUESTIONS = Array.isArray(window.__INITIAL_JS_TEST_QUESTIONS__)
+    ? window.__INITIAL_JS_TEST_QUESTIONS__
+    : [];
 </script>
 @include('components.saved-test-js-persistence', ['mode' => $jsStateMode, 'savedState' => $savedState])
 @include('components.saved-test-js-helpers')
@@ -54,7 +57,10 @@ function ensureGlobalEvents() {
   globalEventsHooked = true;
 }
 
-function init(forceFresh = false) {
+async function init(forceFresh = false) {
+  const baseQuestions = await loadQuestions(forceFresh);
+  QUESTIONS = Array.isArray(baseQuestions) ? baseQuestions : [];
+
   let restored = false;
   if (!forceFresh) {
     const saved = getSavedState();

--- a/resources/views/grammar-test.blade.php
+++ b/resources/views/grammar-test.blade.php
@@ -165,6 +165,20 @@
                 >
                 <span class="ml-2 text-orange-700">Тільки AI-згенеровані питання</span>
             </label>
+            <label class="inline-flex items-center">
+                <input type="checkbox" name="include_ai_v2" value="1"
+                    {{ !empty($includeAiV2) ? 'checked' : '' }}
+                    class="form-checkbox h-5 w-5 text-sky-600"
+                >
+                <span class="ml-2 text-sky-700">Додати AI (flag = 2)</span>
+            </label>
+            <label class="inline-flex items-center">
+                <input type="checkbox" name="only_ai_v2" value="1"
+                    {{ !empty($onlyAiV2) ? 'checked' : '' }}
+                    class="form-checkbox h-5 w-5 text-cyan-600"
+                >
+                <span class="ml-2 text-cyan-700">Тільки AI (flag = 2)</span>
+            </label>
         </div>
 
         <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-2xl shadow font-semibold text-lg">

--- a/resources/views/saved-test-random.blade.php
+++ b/resources/views/saved-test-random.blade.php
@@ -44,6 +44,7 @@
     @endif
     <form action="{{ route('grammar-test.check') }}" method="POST" class="space-y-6">
         @csrf
+        <input type="hidden" name="test_slug" value="{{ $test->slug }}">
         @foreach($questions as $q)
             <input type="hidden" name="questions[{{ $q->id }}]" value="1">
             <div class="bg-white shadow rounded-2xl p-4 mb-4">
@@ -66,6 +67,7 @@
     'methodMap' => $methodMap,
     'autocompleteRoute' => $autocompleteRoute,
     'showQuestionEdit' => true,
+    'testSlug' => $test->slug,
 ])
 <a href="{{ route('question-review.edit', $q->id) }}" class="ml-2 text-sm text-blue-600 underline">Review</a>
                 @if($q->tags->count())

--- a/resources/views/saved-test-step.blade.php
+++ b/resources/views/saved-test-step.blade.php
@@ -112,6 +112,7 @@
             'autocompleteRoute' => $autocompleteRoute,
             'showVerbHintEdit' => true,
             'showQuestionEdit' => true,
+            'testSlug' => $test->slug,
         ])
         <div class="flex gap-2 mt-2">
             <a href="{{ route('question-review.edit', $question->id) }}" class="text-sm text-blue-600 underline">Review</a>

--- a/resources/views/saved-test.blade.php
+++ b/resources/views/saved-test.blade.php
@@ -61,6 +61,7 @@
     @include('components.word-search')
     <form action="{{ route('grammar-test.check') }}" method="POST" class="space-y-6">
         @csrf
+        <input type="hidden" name="test_slug" value="{{ $test->slug }}">
         @foreach($questions as $q)
             <input type="hidden" name="questions[{{ $q->id }}]" value="1">
             <div class="bg-white shadow rounded-2xl p-4 mb-4">
@@ -77,6 +78,7 @@
     'builderInput' => $builderInput,
     'showVerbHintEdit' => true,
     'showQuestionEdit' => true,
+    'testSlug' => $test->slug,
 ])
 <a href="{{ route('question-review.edit', $q->id) }}" class="ml-2 text-sm text-blue-600 underline">Review</a>
 <button type="submit" form="delete-question-{{ $q->id }}" class="text-sm text-red-600 underline" onclick="return confirm('Delete this question?')">Delete</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,6 +63,7 @@ Route::get('/grammar-test-autocomplete', [GrammarTestController::class, 'autocom
 Route::post('/grammar-test-check-answer', [GrammarTestController::class, 'checkOneAnswer'])->name('grammar-test.checkOne');
 
 Route::post('/grammar-test-save', [GrammarTestController::class, 'save'])->name('grammar-test.save');
+Route::post('/test/{slug}/js/state', [GrammarTestController::class, 'storeSavedTestJsState'])->name('saved-test.js.state');
 Route::get('/test/{slug}/js', [GrammarTestController::class, 'showSavedTestJs'])->name('saved-test.js');
 Route::get('/test/{slug}/js/step', [GrammarTestController::class, 'showSavedTestJsStep'])->name('saved-test.js.step');
 Route::get('/test/{slug}/js/manual', [GrammarTestController::class, 'showSavedTestJsManual'])->name('saved-test.js.manual');

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,6 +64,7 @@ Route::post('/grammar-test-check-answer', [GrammarTestController::class, 'checkO
 
 Route::post('/grammar-test-save', [GrammarTestController::class, 'save'])->name('grammar-test.save');
 Route::post('/test/{slug}/js/state', [GrammarTestController::class, 'storeSavedTestJsState'])->name('saved-test.js.state');
+Route::get('/test/{slug}/js/questions', [GrammarTestController::class, 'fetchSavedTestJsQuestions'])->name('saved-test.js.questions');
 Route::get('/test/{slug}/js', [GrammarTestController::class, 'showSavedTestJs'])->name('saved-test.js');
 Route::get('/test/{slug}/js/step', [GrammarTestController::class, 'showSavedTestJsStep'])->name('saved-test.js.step');
 Route::get('/test/{slug}/js/manual', [GrammarTestController::class, 'showSavedTestJsManual'])->name('saved-test.js.manual');

--- a/tests/Feature/SavedTestJsStateTest.php
+++ b/tests/Feature/SavedTestJsStateTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Test;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class SavedTestJsStateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! Schema::hasTable('tests')) {
+            Artisan::call('migrate', ['--path' => 'database/migrations/2025_07_20_184450_create_tests_table.php']);
+            Artisan::call('migrate', ['--path' => 'database/migrations/2025_08_04_000002_add_description_to_tests_table.php']);
+        }
+
+        Test::query()->delete();
+    }
+
+    private function createSavedTest(): Test
+    {
+        return Test::create([
+            'name' => 'Sample Test',
+            'slug' => uniqid('sample-test-', true),
+            'filters' => [],
+            'questions' => [],
+        ]);
+    }
+
+    private function postState(Test $test, array $payload, array $session = [])
+    {
+        $session = array_merge(['_token' => 'test-token'], $session);
+
+        return $this->withSession($session)->postJson(
+            route('saved-test.js.state', $test->slug),
+            $payload,
+            ['X-CSRF-TOKEN' => 'test-token']
+        );
+    }
+
+    public function test_it_stores_state_in_session(): void
+    {
+        $test = $this->createSavedTest();
+
+        $payload = [
+            'mode' => 'saved-test-js',
+            'state' => ['foo' => 'bar'],
+        ];
+
+        $response = $this->postState($test, $payload);
+
+        $response->assertNoContent();
+
+        $key = sprintf('saved_test_js_state:%s:%s', $test->slug, 'saved-test-js');
+        $this->assertSame($payload['state'], session($key));
+    }
+
+    public function test_it_clears_state_when_null(): void
+    {
+        $test = $this->createSavedTest();
+        $key = sprintf('saved_test_js_state:%s:%s', $test->slug, 'saved-test-js');
+
+        $response = $this->postState($test, [
+            'mode' => 'saved-test-js',
+            'state' => null,
+        ], [
+            $key => ['foo' => 'bar'],
+        ]);
+
+        $response->assertNoContent();
+        $this->assertNull(session($key));
+    }
+
+    public function test_it_rejects_invalid_payload(): void
+    {
+        $test = $this->createSavedTest();
+
+        $this->postState($test, [
+            'mode' => 'not-valid',
+            'state' => ['allowed' => true],
+        ])->assertStatus(422);
+
+        $invalidKey = sprintf('saved_test_js_state:%s:%s', $test->slug, 'not-valid');
+        $this->assertNull(session($invalidKey));
+
+        $this->postState($test, [
+            'mode' => 'saved-test-js',
+            'state' => 'nope',
+        ])->assertStatus(422);
+
+        $validKey = sprintf('saved_test_js_state:%s:%s', $test->slug, 'saved-test-js');
+        $this->assertNull(session($validKey));
+    }
+}

--- a/tests/Feature/SavedTestJsStateTest.php
+++ b/tests/Feature/SavedTestJsStateTest.php
@@ -2,9 +2,19 @@
 
 namespace Tests\Feature;
 
+use App\Http\Controllers\GrammarTestController;
+use App\Models\Category;
+use App\Models\Question;
+use App\Models\QuestionAnswer;
+use App\Models\QuestionOption;
+use App\Models\QuestionVariant;
 use App\Models\Test;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class SavedTestJsStateTest extends TestCase
@@ -18,17 +28,162 @@ class SavedTestJsStateTest extends TestCase
             Artisan::call('migrate', ['--path' => 'database/migrations/2025_08_04_000002_add_description_to_tests_table.php']);
         }
 
+        $this->ensureQuestionSchema();
+        $this->resetQuestionData();
+
+        session()->start();
+        session()->flush();
+
         Test::query()->delete();
     }
 
-    private function createSavedTest(): Test
+    private function createSavedTest(array $questionIds = []): Test
     {
         return Test::create([
             'name' => 'Sample Test',
             'slug' => uniqid('sample-test-', true),
             'filters' => [],
-            'questions' => [],
+            'questions' => $questionIds,
         ]);
+    }
+
+    private function createQuestionWithVariants(): array
+    {
+        $category = Category::create(['name' => 'Perfect Tenses']);
+        $questionText = 'Emma {a1} chocolate this week – only fruit.';
+
+        $question = Question::create([
+            'uuid' => (string) Str::uuid(),
+            'question' => $questionText,
+            'difficulty' => 1,
+            'flag' => 2,
+            'category_id' => $category->id,
+            'level' => 'B1',
+        ]);
+
+        $options = collect([
+            "hasn't eaten",
+            "hasn't been eating",
+            "didn't eat",
+            "wasn't eating",
+        ])->map(fn(string $text) => QuestionOption::create(['option' => $text]));
+
+        foreach ($options as $option) {
+            DB::table('question_option_question')->insert([
+                'question_id' => $question->id,
+                'option_id' => $option->id,
+                'flag' => null,
+            ]);
+        }
+
+        QuestionAnswer::create([
+            'question_id' => $question->id,
+            'marker' => 'a1',
+            'option_id' => $options->first()->id,
+        ]);
+
+        $variantTexts = [
+            'Sophia {a1} bread today – she chose rice instead.',
+            'Lucas {a1} cake this week – he prefers fruit salad.',
+        ];
+
+        foreach ($variantTexts as $text) {
+            QuestionVariant::create([
+                'question_id' => $question->id,
+                'text' => $text,
+            ]);
+        }
+
+        return [$question, array_merge([$questionText], $variantTexts)];
+    }
+
+    private function ensureQuestionSchema(): void
+    {
+        if (! Schema::hasTable('categories')) {
+            Schema::create('categories', function (Blueprint $table) {
+                $table->id();
+                $table->string('name');
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('questions')) {
+            Schema::create('questions', function (Blueprint $table) {
+                $table->id();
+                $table->uuid('uuid')->unique();
+                $table->text('question');
+                $table->unsignedTinyInteger('difficulty')->default(1);
+                $table->boolean('flag')->default(0);
+                $table->unsignedBigInteger('category_id');
+                $table->string('level', 2)->nullable();
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('question_options')) {
+            Schema::create('question_options', function (Blueprint $table) {
+                $table->id();
+                $table->string('option')->unique();
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('question_option_question')) {
+            Schema::create('question_option_question', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->tinyInteger('flag')->nullable();
+                $table->unique(['question_id', 'option_id', 'flag'], 'qoq_question_option_flag_unique');
+            });
+        }
+
+        if (! Schema::hasTable('question_answers')) {
+            Schema::create('question_answers', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->string('marker');
+                $table->timestamps();
+                $table->unique(['question_id', 'marker', 'option_id'], 'question_marker_option_unique');
+            });
+        }
+
+        if (! Schema::hasTable('verb_hints')) {
+            Schema::create('verb_hints', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id')->nullable();
+                $table->string('marker')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('question_variants')) {
+            Schema::create('question_variants', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->text('text');
+                $table->timestamps();
+            });
+        }
+    }
+
+    private function resetQuestionData(): void
+    {
+        foreach ([
+            'question_option_question',
+            'question_answers',
+            'question_variants',
+            'verb_hints',
+            'questions',
+            'question_options',
+            'categories',
+        ] as $table) {
+            if (Schema::hasTable($table)) {
+                DB::table($table)->delete();
+            }
+        }
     }
 
     private function postState(Test $test, array $payload, array $session = [])
@@ -94,5 +249,66 @@ class SavedTestJsStateTest extends TestCase
 
         $validKey = sprintf('saved_test_js_state:%s:%s', $test->slug, 'saved-test-js');
         $this->assertNull(session($validKey));
+    }
+
+    public function test_it_fetches_fresh_questions_and_clears_state(): void
+    {
+        $test = $this->createSavedTest();
+        $key = sprintf('saved_test_js_state:%s:%s', $test->slug, 'saved-test-js');
+
+        $response = $this->withSession([$key => ['foo' => 'bar']])->getJson(
+            route('saved-test.js.questions', $test->slug) . '?mode=saved-test-js'
+        );
+
+        $response->assertOk()->assertJson(['questions' => []]);
+        $this->assertNull(session($key));
+    }
+
+    public function test_it_rejects_invalid_mode_when_fetching_questions(): void
+    {
+        $test = $this->createSavedTest();
+
+        $this->getJson(route('saved-test.js.questions', $test->slug) . '?mode=invalid')
+            ->assertStatus(422);
+    }
+
+    public function test_it_rotates_variants_when_retrying_js_test(): void
+    {
+        if (! Schema::hasTable('question_variants')) {
+            $this->markTestSkipped('Question variants table is missing.');
+        }
+
+        [$question, $variants] = $this->createQuestionWithVariants();
+        $test = $this->createSavedTest([$question->id]);
+
+        /** @var GrammarTestController $controller */
+        $controller = app(GrammarTestController::class);
+
+        session()->start();
+
+        $requestOne = Request::create(
+            "/test/{$test->slug}/js/questions",
+            'GET',
+            ['mode' => 'saved-test-js']
+        );
+
+        $firstPayload = $controller->fetchSavedTestJsQuestions($requestOne, $test->slug)->getData(true);
+        $firstQuestion = $firstPayload['questions'][0]['question'] ?? null;
+
+        $requestTwo = Request::create(
+            "/test/{$test->slug}/js/questions",
+            'GET',
+            ['mode' => 'saved-test-js']
+        );
+
+        $secondPayload = $controller->fetchSavedTestJsQuestions($requestTwo, $test->slug)->getData(true);
+        $secondQuestion = $secondPayload['questions'][0]['question'] ?? null;
+
+        $this->assertNotNull($firstQuestion);
+        $this->assertNotNull($secondQuestion);
+
+        $this->assertNotSame($firstQuestion, $secondQuestion);
+        $this->assertContains($firstQuestion, $variants);
+        $this->assertContains($secondQuestion, $variants);
     }
 }


### PR DESCRIPTION
## Summary
- guard question variant loading so saved test pages work even when the `question_variants` table is absent
- restore Gemini hints and keep question text rendering accurate for hint/explain flows
- allow AI test seeding to skip the level column when migrations omit it and pass flattened tense lists to GPT to satisfy tests

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cc64a89d78832a9967c16cc7f9cdd5