### PR TITLE
Enable editing on saved test technical page

### DIFF
--- a/app/Http/Controllers/ChatGPTExplanationController.php
+++ b/app/Http/Controllers/ChatGPTExplanationController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ChatGPTExplanation;
+use Illuminate\Http\Request;
+
+class ChatGPTExplanationController extends Controller
+{
+    public function update(Request $request, ChatGPTExplanation $chatgptExplanation)
+    {
+        $data = $request->validate([
+            'question' => 'required|string',
+            'wrong_answer' => 'nullable|string|max:255',
+            'correct_answer' => 'required|string|max:255',
+            'language' => 'required|string|max:10',
+            'explanation' => 'required|string',
+        ]);
+
+        $chatgptExplanation->update($data);
+
+        if ($request->expectsJson()) {
+            return response()->noContent();
+        }
+
+        return redirect($request->input('from', url()->previous()));
+    }
+}

--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -60,6 +60,24 @@ class GrammarTestController extends Controller
         return redirect()->route('saved-test.show', $slug);
     }
 
+    public function update(Request $request, Test $test)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+        ]);
+
+        $test->name = $data['name'];
+        $test->save();
+
+        if ($request->expectsJson()) {
+            return response()->noContent();
+        }
+
+        $redirectTo = $request->input('from', route('saved-test.tech', $test->slug));
+
+        return redirect($redirectTo);
+    }
+
     public function showSavedTest($slug)
     {
         $test = \App\Models\Test::where('slug', $slug)->firstOrFail();

--- a/app/Http/Controllers/QuestionAnswerController.php
+++ b/app/Http/Controllers/QuestionAnswerController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\QuestionAnswer;
+use App\Models\QuestionOption;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class QuestionAnswerController extends Controller
+{
+    public function update(Request $request, QuestionAnswer $questionAnswer)
+    {
+        $data = $request->validate([
+            'marker' => 'required|string|max:10',
+            'value' => 'required|string|max:255',
+        ]);
+
+        DB::transaction(function () use ($questionAnswer, $data) {
+            $question = $questionAnswer->question()->lockForUpdate()->first();
+            $oldOption = $questionAnswer->option;
+
+            $marker = strtolower($data['marker']);
+            $value = trim($data['value']);
+
+            $option = QuestionOption::firstOrCreate(['option' => $value]);
+
+            $questionAnswer->marker = $marker;
+            $questionAnswer->option_id = $option->id;
+            $questionAnswer->save();
+
+            $pivotExists = DB::table('question_option_question')
+                ->where('question_id', $question->id)
+                ->where('option_id', $option->id)
+                ->where(function ($query) {
+                    $query->whereNull('flag')->orWhere('flag', 0);
+                })
+                ->exists();
+
+            if (! $pivotExists) {
+                $question->options()->attach($option->id, ['flag' => 0]);
+            }
+
+            if ($oldOption && $oldOption->id !== $option->id) {
+                $otherAnswersUse = $question->answers()
+                    ->where('id', '!=', $questionAnswer->id)
+                    ->where('option_id', $oldOption->id)
+                    ->exists();
+
+                $verbHintsUse = $question->verbHints()
+                    ->where('option_id', $oldOption->id)
+                    ->exists();
+
+                if (! $otherAnswersUse && ! $verbHintsUse) {
+                    DB::table('question_option_question')
+                        ->where('question_id', $question->id)
+                        ->where('option_id', $oldOption->id)
+                        ->where(function ($query) {
+                            $query->whereNull('flag')->orWhere('flag', 0);
+                        })
+                        ->delete();
+                }
+
+                $optionUsedElsewhere = $oldOption->answers()
+                    ->where('question_id', '!=', $question->id)
+                    ->exists()
+                    || $oldOption->verbHints()
+                        ->where('question_id', '!=', $question->id)
+                        ->exists()
+                    || DB::table('question_option_question')
+                        ->where('option_id', $oldOption->id)
+                        ->where('question_id', '!=', $question->id)
+                        ->exists();
+
+                if (! $otherAnswersUse && ! $verbHintsUse && ! $optionUsedElsewhere) {
+                    $oldOption->delete();
+                }
+            }
+        });
+
+        if ($request->expectsJson()) {
+            return response()->noContent();
+        }
+
+        return redirect($request->input('from', url()->previous()));
+    }
+}

--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -11,9 +11,15 @@ class QuestionController extends Controller
     {
         $data = $request->validate([
             'question' => 'required|string',
+            'level' => 'nullable|string|max:10',
         ]);
 
         $question->question = $data['question'];
+
+        if ($request->has('level')) {
+            $question->level = $data['level'] !== '' ? $data['level'] : null;
+        }
+
         $question->save();
 
         if ($request->wantsJson()) {

--- a/app/Http/Controllers/QuestionHintController.php
+++ b/app/Http/Controllers/QuestionHintController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\QuestionHint;
+use Illuminate\Http\Request;
+
+class QuestionHintController extends Controller
+{
+    public function update(Request $request, QuestionHint $questionHint)
+    {
+        $data = $request->validate([
+            'provider' => 'required|string|max:255',
+            'locale' => 'required|string|max:5',
+            'hint' => 'required|string',
+        ]);
+
+        $questionHint->update($data);
+
+        if ($request->expectsJson()) {
+            return response()->noContent();
+        }
+
+        return redirect($request->input('from', url()->previous()));
+    }
+}

--- a/app/Http/Controllers/QuestionOptionController.php
+++ b/app/Http/Controllers/QuestionOptionController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Question;
+use App\Models\QuestionAnswer;
+use App\Models\QuestionOption;
+use App\Models\VerbHint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class QuestionOptionController extends Controller
+{
+    public function update(Request $request, QuestionOption $questionOption)
+    {
+        $data = $request->validate([
+            'question_id' => 'required|exists:questions,id',
+            'option' => 'required|string|max:255',
+        ]);
+
+        $question = Question::findOrFail($data['question_id']);
+        $newValue = trim($data['option']);
+
+        if ($questionOption->option === $newValue) {
+            return $request->expectsJson()
+                ? response()->noContent()
+                : redirect($request->input('from', url()->previous()));
+        }
+
+        DB::transaction(function () use ($question, $questionOption, $newValue) {
+            $isExclusive = ! $questionOption->answers()
+                    ->where('question_id', '!=', $question->id)
+                    ->exists()
+                && ! $questionOption->verbHints()
+                    ->where('question_id', '!=', $question->id)
+                    ->exists()
+                && ! DB::table('question_option_question')
+                    ->where('option_id', $questionOption->id)
+                    ->where('question_id', '!=', $question->id)
+                    ->exists();
+
+            if ($isExclusive) {
+                $questionOption->option = $newValue;
+                $questionOption->save();
+
+                return;
+            }
+
+            $targetOption = QuestionOption::firstOrCreate(['option' => $newValue]);
+
+            if ($targetOption->id === $questionOption->id) {
+                $questionOption->option = $newValue;
+                $questionOption->save();
+
+                return;
+            }
+
+            QuestionAnswer::where('question_id', $question->id)
+                ->where('option_id', $questionOption->id)
+                ->update(['option_id' => $targetOption->id]);
+
+            VerbHint::where('question_id', $question->id)
+                ->where('option_id', $questionOption->id)
+                ->update(['option_id' => $targetOption->id]);
+
+            DB::table('question_option_question')
+                ->where('question_id', $question->id)
+                ->where('option_id', $questionOption->id)
+                ->where(function ($query) {
+                    $query->whereNull('flag')->orWhere('flag', 0);
+                })
+                ->delete();
+
+            $pivotExists = DB::table('question_option_question')
+                ->where('question_id', $question->id)
+                ->where('option_id', $targetOption->id)
+                ->where(function ($query) {
+                    $query->whereNull('flag')->orWhere('flag', 0);
+                })
+                ->exists();
+
+            if (! $pivotExists) {
+                $question->options()->attach($targetOption->id, ['flag' => 0]);
+            }
+
+            $stillUsed = $questionOption->answers()->exists()
+                || $questionOption->verbHints()->exists()
+                || DB::table('question_option_question')
+                    ->where('option_id', $questionOption->id)
+                    ->exists();
+
+            if (! $stillUsed) {
+                $questionOption->delete();
+            }
+        });
+
+        if ($request->expectsJson()) {
+            return response()->noContent();
+        }
+
+        return redirect($request->input('from', url()->previous()));
+    }
+}

--- a/app/Http/Controllers/QuestionVariantController.php
+++ b/app/Http/Controllers/QuestionVariantController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\QuestionVariant;
+use Illuminate\Http\Request;
+
+class QuestionVariantController extends Controller
+{
+    public function update(Request $request, QuestionVariant $questionVariant)
+    {
+        $data = $request->validate([
+            'text' => 'required|string',
+        ]);
+
+        $questionVariant->text = $data['text'];
+        $questionVariant->save();
+
+        if ($request->expectsJson()) {
+            return response()->noContent();
+        }
+
+        return redirect($request->input('from', url()->previous()));
+    }
+}

--- a/resources/views/engram/saved-test-tech.blade.php
+++ b/resources/views/engram/saved-test-tech.blade.php
@@ -5,9 +5,35 @@
 @section('content')
 <div class="max-w-6xl mx-auto px-4 py-6 space-y-6">
     <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-            <h1 class="text-2xl font-bold text-stone-900">{{ $test->name }}</h1>
-            <p class="text-sm text-stone-600 mt-1">Технічна інформація про тест · Питань: {{ $questions->count() }}</p>
+        <div x-data="{ editing: false }" class="flex-1 space-y-3">
+            <div x-show="!editing" class="space-y-2">
+                <div class="flex flex-wrap items-center gap-3">
+                    <h1 class="text-2xl font-bold text-stone-900">{{ $test->name }}</h1>
+                    <button type="button"
+                            class="inline-flex items-center gap-1 rounded-lg border border-stone-300 px-3 py-1.5 text-sm font-semibold text-stone-600 hover:bg-stone-100"
+                            @click="editing = true">
+                        <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m13.5 6.5-8 8-3 3 .5-3.5 8-8 2.5 2.5Zm0 0 2-2a1.586 1.586 0 0 1 2.243 0 1.586 1.586 0 0 1 0 2.243l-2 2M10 4h-6a2 2 0 0 0-2 2v10c0 1.105.895 2 2 2h10a2 2 0 0 0 2-2v-6" />
+                        </svg>
+                        <span>Редагувати назву</span>
+                    </button>
+                </div>
+                <p class="text-sm text-stone-600">Технічна інформація про тест · Питань: {{ $questions->count() }}</p>
+            </div>
+            <form x-show="editing" method="POST" action="{{ route('saved-tests.update', $test) }}" class="hidden rounded-2xl border border-stone-200 bg-stone-50 p-4 space-y-3">
+                @csrf
+                @method('put')
+                <input type="hidden" name="from" value="{{ request()->fullUrl() }}">
+                <div>
+                    <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Назва тесту</label>
+                    <input type="text" name="name" value="{{ $test->name }}" required
+                           class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    <button type="submit" class="inline-flex items-center rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white shadow hover:bg-emerald-700">Зберегти</button>
+                    <button type="button" class="inline-flex items-center rounded-lg border border-stone-300 px-3 py-1.5 text-sm font-semibold text-stone-700 hover:bg-stone-100" @click="editing = false">Скасувати</button>
+                </div>
+            </form>
         </div>
         <div class="flex flex-wrap gap-2">
             <a href="{{ route('saved-test.show', $test->slug) }}"
@@ -29,6 +55,7 @@
 
                     return [strtolower($answer->marker) => $value];
                 });
+
             $highlightSegments = function (string $text) use ($answersByMarker) {
                 $segments = preg_split('/(\{a\d+\})/i', $text, -1, PREG_SPLIT_DELIM_CAPTURE);
 
@@ -48,47 +75,109 @@
                     return e($segment);
                 })->implode('');
             };
+
             $filledQuestion = $highlightSegments($question->question);
-            $options = $question->options->pluck('option')->filter()->unique()->values();
-            foreach ($answersByMarker as $value) {
-                if ($value !== '' && ! $options->contains($value)) {
-                    $options->push($value);
-                }
-            }
-            $variantTexts = $question->relationLoaded('variants')
-                ? $question->variants->pluck('text')->filter()->unique()->values()
+
+            $optionItems = $question->options
+                ->map(function ($option) use ($question) {
+                    return (object) [
+                        'model' => $option,
+                        'text' => $option->option ?? '',
+                        'is_correct' => $question->answers->contains('option_id', $option->id),
+                        'editable' => true,
+                    ];
+                })
+                ->filter(fn ($item) => $item->text !== '')
+                ->values();
+
+            $answerOnlyOptions = $question->answers
+                ->filter(function ($answer) use ($question) {
+                    return $answer->option && ! $question->options->contains('id', $answer->option_id);
+                })
+                ->map(function ($answer) {
+                    return (object) [
+                        'model' => $answer->option,
+                        'text' => $answer->option->option ?? '',
+                        'is_correct' => true,
+                        'editable' => false,
+                    ];
+                })
+                ->filter(fn ($item) => $item->text !== '')
+                ->values();
+
+            $options = $optionItems->concat($answerOnlyOptions)->unique('text')->values();
+
+            $variantItems = $question->relationLoaded('variants')
+                ? $question->variants->filter(fn ($variant) => filled($variant->text))->values()
                 : collect();
-            $verbHints = $question->verbHints
+
+            $verbHintsByMarker = $question->verbHints
                 ->sortBy('marker')
                 ->mapWithKeys(function ($hint) {
-                    $value = $hint->option->option ?? '';
-
-                    return $value !== '' ? [strtolower($hint->marker) => $value] : [];
+                    return [strtolower($hint->marker) => $hint];
                 });
+
             $questionHints = $question->hints
                 ->sortBy(function ($hint) {
                     return $hint->provider . '|' . $hint->locale;
                 })
                 ->values();
+
             $explanations = collect($explanationsByQuestionId[$question->id] ?? []);
             $levelLabel = $question->level ?: 'N/A';
         @endphp
-        <article class="bg-white shadow rounded-2xl p-6 space-y-5 border border-stone-100">
-            <header class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                <div>
-                    <div class="flex items-baseline gap-3 text-sm text-stone-500">
-                        <span class="font-semibold uppercase tracking-wide">Питання {{ $loop->iteration }}</span>
-                        <span>ID: {{ $question->id }}</span>
+        <article x-data="{ editingQuestion: false }" class="bg-white shadow rounded-2xl p-6 space-y-5 border border-stone-100">
+            <header class="space-y-4">
+                <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div class="flex-1">
+                        <div class="flex items-baseline gap-3 text-sm text-stone-500">
+                            <span class="font-semibold uppercase tracking-wide">Питання {{ $loop->iteration }}</span>
+                            <span>ID: {{ $question->id }}</span>
+                        </div>
+                        <div x-show="!editingQuestion">
+                            <p class="mt-2 text-lg leading-relaxed text-stone-900">{!! $filledQuestion !!}</p>
+                        </div>
                     </div>
-                    <p class="mt-2 text-lg leading-relaxed text-stone-900">{!! $filledQuestion !!}</p>
+                    <div x-show="!editingQuestion" class="flex items-center gap-2">
+                        <span class="text-xs uppercase tracking-wide text-stone-500">Level</span>
+                        <span class="inline-flex items-center px-3 py-1 rounded-full bg-stone-900 text-white text-sm font-semibold">{{ $levelLabel }}</span>
+                    </div>
                 </div>
-                <div class="flex items-center gap-2">
-                    <span class="text-xs uppercase tracking-wide text-stone-500">Level</span>
-                    <span class="inline-flex items-center px-3 py-1 rounded-full bg-stone-900 text-white text-sm font-semibold">{{ $levelLabel }}</span>
+                <div x-show="!editingQuestion" class="flex justify-end">
+                    <button type="button" class="inline-flex items-center gap-1 rounded-lg border border-stone-300 px-3 py-1.5 text-sm font-semibold text-stone-700 hover:bg-stone-100" @click="editingQuestion = true">
+                        <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m13.5 6.5-8 8-3 3 .5-3.5 8-8 2.5 2.5Zm0 0 2-2a1.586 1.586 0 0 1 2.243 0 1.586 1.586 0 0 1 0 2.243l-2 2M10 4h-6a2 2 0 0 0-2 2v10c0 1.105.895 2 2 2h10a2 2 0 0 0 2-2v-6" />
+                        </svg>
+                        <span>Редагувати питання</span>
+                    </button>
                 </div>
+                <form x-show="editingQuestion" method="POST" action="{{ route('questions.update', $question) }}" class="hidden rounded-2xl border border-stone-200 bg-stone-50 p-4 space-y-4">
+                    @csrf
+                    @method('put')
+                    <input type="hidden" name="from" value="{{ request()->fullUrl() }}">
+                    <div>
+                        <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Текст питання</label>
+                        <textarea name="question" rows="4" class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">{{ $question->question }}</textarea>
+                    </div>
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Рівень</label>
+                            <select name="level" class="mt-1 w-40 rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                                <option value="" @selected(empty($question->level))>N/A</option>
+                                @foreach(['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as $levelOption)
+                                    <option value="{{ $levelOption }}" @selected($question->level === $levelOption)>{{ $levelOption }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="flex flex-wrap gap-2">
+                            <button type="submit" class="inline-flex items-center rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white shadow hover:bg-emerald-700">Зберегти</button>
+                            <button type="button" class="inline-flex items-center rounded-lg border border-stone-300 px-3 py-1.5 text-sm font-semibold text-stone-700 hover:bg-stone-100" @click="editingQuestion = false">Скасувати</button>
+                        </div>
+                    </div>
+                </form>
             </header>
 
-            @if($variantTexts->isNotEmpty())
+            @if($variantItems->isNotEmpty())
                 <details class="group">
                     <summary class="flex cursor-pointer select-none items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
                         <span>Варіанти запитання</span>
@@ -96,10 +185,30 @@
                         <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
                     </summary>
                     <ul class="mt-3 space-y-2 text-sm text-stone-800">
-                        @foreach($variantTexts as $variant)
-                            <li class="flex flex-col gap-1 rounded-lg border border-stone-200 bg-stone-50 px-3 py-2">
-                                <span class="font-mono text-[11px] uppercase text-stone-500">Варіант {{ $loop->iteration }}</span>
-                                <span>{!! $highlightSegments($variant) !!}</span>
+                        @foreach($variantItems as $variant)
+                            <li x-data="{ editing: false }" class="rounded-lg border border-stone-200 bg-stone-50 px-3 py-2">
+                                <div x-show="!editing" class="space-y-1">
+                                    <div class="flex items-center justify-between gap-2">
+                                        <span class="font-mono text-[11px] uppercase text-stone-500">Варіант {{ $loop->iteration }}</span>
+                                        <button type="button" class="inline-flex items-center gap-1 rounded border border-stone-300 px-2 py-1 text-xs font-semibold text-stone-600 hover:bg-stone-100" @click="editing = true">
+                                            <span>Редагувати</span>
+                                        </button>
+                                    </div>
+                                    <span>{!! $highlightSegments($variant->text) !!}</span>
+                                </div>
+                                <form x-show="editing" method="POST" action="{{ route('question-variants.update', $variant) }}" class="hidden space-y-2">
+                                    @csrf
+                                    @method('put')
+                                    <input type="hidden" name="from" value="{{ request()->fullUrl() }}">
+                                    <div>
+                                        <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Текст варіанту</label>
+                                        <textarea name="text" rows="3" class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">{{ $variant->text }}</textarea>
+                                    </div>
+                                    <div class="flex flex-wrap gap-2">
+                                        <button type="submit" class="inline-flex items-center rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-emerald-700">Зберегти</button>
+                                        <button type="button" class="inline-flex items-center rounded-lg border border-stone-300 px-3 py-1.5 text-xs font-semibold text-stone-700 hover:bg-stone-100" @click="editing = false">Скасувати</button>
+                                    </div>
+                                </form>
                             </li>
                         @endforeach
                     </ul>
@@ -112,22 +221,70 @@
                     <span class="text-[10px] font-normal text-stone-400 group-open:hidden">Показати ▼</span>
                     <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
                 </summary>
-                <ul class="mt-3 space-y-2 text-sm text-stone-800">
+                <ul class="mt-3 space-y-3 text-sm text-stone-800">
                     @foreach($question->answers as $answer)
                         @php
                             $marker = strtoupper($answer->marker);
                             $markerKey = strtolower($answer->marker);
                             $answerValue = $answersByMarker->get($markerKey, '');
-                            $verbHint = $verbHints->get($markerKey);
+                            $verbHintModel = $verbHintsByMarker->get($markerKey);
+                            $verbHintValue = $verbHintModel ? ($verbHintModel->option->option ?? '') : null;
                         @endphp
-                        <li class="flex flex-wrap items-center gap-2 rounded-lg border border-emerald-100 bg-emerald-50/70 px-3 py-2">
-                            <span class="font-mono text-xs uppercase text-emerald-500">{{ $marker }}</span>
-                            <span class="font-semibold text-emerald-900">{{ $answerValue }}</span>
-                            @if($verbHint)
-                                <span class="inline-flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-[11px] font-medium text-emerald-700">
-                                    <span class="font-semibold uppercase text-[10px] tracking-wide">Verb hint</span>
-                                    <span>{{ $verbHint }}</span>
-                                </span>
+                        <li class="rounded-lg border border-emerald-100 bg-emerald-50/70 px-3 py-3">
+                            <div x-data="{ editingAnswer: false }" class="space-y-2">
+                                <div x-show="!editingAnswer" class="flex flex-wrap items-center gap-2">
+                                    <span class="font-mono text-xs uppercase text-emerald-500">{{ $marker }}</span>
+                                    <span class="font-semibold text-emerald-900">{{ $answerValue }}</span>
+                                    <button type="button" class="inline-flex items-center gap-1 rounded border border-emerald-200 bg-white px-2 py-1 text-xs font-semibold text-emerald-700 hover:bg-emerald-100" @click="editingAnswer = true">
+                                        <span>Редагувати відповідь</span>
+                                    </button>
+                                </div>
+                                <form x-show="editingAnswer" method="POST" action="{{ route('question-answers.update', $answer) }}" class="hidden space-y-2">
+                                    @csrf
+                                    @method('put')
+                                    <input type="hidden" name="from" value="{{ request()->fullUrl() }}">
+                                    <div class="grid gap-3 sm:grid-cols-5">
+                                        <div class="sm:col-span-1">
+                                            <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Маркер</label>
+                                            <input type="text" name="marker" value="{{ $marker }}" required
+                                                   class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                                        </div>
+                                        <div class="sm:col-span-4">
+                                            <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Відповідь</label>
+                                            <input type="text" name="value" value="{{ $answerValue }}" required
+                                                   class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                                        </div>
+                                    </div>
+                                    <div class="flex flex-wrap gap-2">
+                                        <button type="submit" class="inline-flex items-center rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-emerald-700">Зберегти</button>
+                                        <button type="button" class="inline-flex items-center rounded-lg border border-stone-300 px-3 py-1.5 text-xs font-semibold text-stone-700 hover:bg-stone-100" @click="editingAnswer = false">Скасувати</button>
+                                    </div>
+                                </form>
+                            </div>
+                            @if($verbHintModel && $verbHintValue)
+                                <div x-data="{ editingHint: false }" class="mt-3 rounded-lg border border-emerald-200 bg-white px-3 py-2">
+                                    <div x-show="!editingHint" class="flex flex-wrap items-center gap-2">
+                                        <span class="font-semibold uppercase text-[10px] tracking-wide text-emerald-600">Verb hint</span>
+                                        <span class="text-sm text-emerald-800">{{ $verbHintValue }}</span>
+                                        <button type="button" class="inline-flex items-center gap-1 rounded border border-emerald-200 px-2 py-1 text-xs font-semibold text-emerald-700 hover:bg-emerald-50" @click="editingHint = true">
+                                            <span>Редагувати підказку</span>
+                                        </button>
+                                    </div>
+                                    <form x-show="editingHint" method="POST" action="{{ route('verb-hints.update', $verbHintModel) }}" class="hidden space-y-2">
+                                        @csrf
+                                        @method('put')
+                                        <input type="hidden" name="from" value="{{ request()->fullUrl() }}">
+                                        <div>
+                                            <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Підказка</label>
+                                            <input type="text" name="hint" value="{{ $verbHintValue }}" required
+                                                   class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                                        </div>
+                                        <div class="flex flex-wrap gap-2">
+                                            <button type="submit" class="inline-flex items-center rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-emerald-700">Зберегти</button>
+                                            <button type="button" class="inline-flex items-center rounded-lg border border-stone-300 px-3 py-1.5 text-xs font-semibold text-stone-700 hover:bg-stone-100" @click="editingHint = false">Скасувати</button>
+                                        </div>
+                                    </form>
+                                </div>
                             @endif
                         </li>
                     @endforeach
@@ -142,20 +299,43 @@
                         <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
                     </summary>
                     <div class="mt-3 flex flex-wrap gap-2">
-                        @foreach($options as $option)
-                            @php $isCorrectOption = $answersByMarker->contains(function ($value) use ($option) { return $value === $option; }); @endphp
-                            <span @class([
-                                'inline-flex items-center gap-1 rounded-full border px-3 py-1 text-sm',
-                                'border-emerald-200 bg-emerald-50 text-emerald-900 font-semibold shadow-sm' => $isCorrectOption,
-                                'border-stone-200 bg-stone-50 text-stone-800' => ! $isCorrectOption,
-                            ])>
-                                @if($isCorrectOption)
-                                    <svg class="h-3.5 w-3.5 text-emerald-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                        <path fill-rule="evenodd" d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.2 7.25a1 1 0 0 1-1.425.01L3.29 9.967a1 1 0 1 1 1.42-1.407l3.162 3.19 6.49-6.538a1 1 0 0 1 1.342-.088Z" clip-rule="evenodd" />
-                                    </svg>
+                        @foreach($options as $optionItem)
+                            <div x-data="{ editing: false }" class="inline-flex flex-col items-start gap-2">
+                                <div x-show="!editing" @class([
+                                    'inline-flex items-center gap-1 rounded-full border px-3 py-1 text-sm shadow-sm',
+                                    'border-emerald-200 bg-emerald-50 text-emerald-900 font-semibold' => $optionItem->is_correct,
+                                    'border-stone-200 bg-stone-50 text-stone-800' => ! $optionItem->is_correct,
+                                ])>
+                                    @if($optionItem->is_correct)
+                                        <svg class="h-3.5 w-3.5 text-emerald-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                            <path fill-rule="evenodd" d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.2 7.25a1 1 0 0 1-1.425-.01L3.29 9.967a1 1 0 1 1 1.42-1.407l3.162 3.19 6.49-6.538a1 1 0 0 1 1.342-.088Z" clip-rule="evenodd" />
+                                        </svg>
+                                    @endif
+                                    <span>{{ $optionItem->text }}</span>
+                                </div>
+                                @if($optionItem->editable && $optionItem->model)
+                                    <div class="flex flex-wrap gap-2">
+                                        <button x-show="!editing" type="button" class="inline-flex items-center gap-1 rounded border border-stone-300 px-2 py-1 text-xs font-semibold text-stone-600 hover:bg-stone-100" @click="editing = true">
+                                            <span>Редагувати</span>
+                                        </button>
+                                    </div>
+                                    <form x-show="editing" method="POST" action="{{ route('question-options.update', $optionItem->model) }}" class="hidden space-y-2 rounded-xl border border-stone-200 bg-white px-3 py-2">
+                                        @csrf
+                                        @method('put')
+                                        <input type="hidden" name="from" value="{{ request()->fullUrl() }}">
+                                        <input type="hidden" name="question_id" value="{{ $question->id }}">
+                                        <div>
+                                            <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Значення</label>
+                                            <input type="text" name="option" value="{{ $optionItem->text }}" required
+                                                   class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                                        </div>
+                                        <div class="flex flex-wrap gap-2">
+                                            <button type="submit" class="inline-flex items-center rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-emerald-700">Зберегти</button>
+                                            <button type="button" class="inline-flex items-center rounded-lg border border-stone-300 px-3 py-1.5 text-xs font-semibold text-stone-700 hover:bg-stone-100" @click="editing = false">Скасувати</button>
+                                        </div>
+                                    </form>
                                 @endif
-                                <span>{{ $option }}</span>
-                            </span>
+                            </div>
                         @endforeach
                     </div>
                 </details>
@@ -170,9 +350,43 @@
                     </summary>
                     <ul class="mt-3 space-y-3 text-sm text-stone-800">
                         @foreach($questionHints as $hint)
-                            <li class="rounded-lg border border-blue-100 bg-blue-50/60 px-3 py-2">
-                                <div class="text-xs font-semibold uppercase tracking-wide text-blue-700">{{ $hint->provider }} · {{ strtoupper($hint->locale) }}</div>
-                                <div class="mt-1 whitespace-pre-line text-stone-800">{{ $hint->hint }}</div>
+                            <li x-data="{ editing: false }" class="rounded-lg border border-blue-100 bg-blue-50/60 px-3 py-3">
+                                <div x-show="!editing" class="space-y-2">
+                                    <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-blue-700">
+                                        <span>{{ $hint->provider }}</span>
+                                        <span>·</span>
+                                        <span>{{ strtoupper($hint->locale) }}</span>
+                                        <button type="button" class="inline-flex items-center gap-1 rounded border border-blue-200 px-2 py-1 text-[11px] font-semibold text-blue-700 hover:bg-blue-100" @click="editing = true">
+                                            <span>Редагувати</span>
+                                        </button>
+                                    </div>
+                                    <div class="whitespace-pre-line text-stone-800">{{ $hint->hint }}</div>
+                                </div>
+                                <form x-show="editing" method="POST" action="{{ route('question-hints.update', $hint) }}" class="hidden space-y-3 rounded-xl border border-blue-200 bg-white px-3 py-3">
+                                    @csrf
+                                    @method('put')
+                                    <input type="hidden" name="from" value="{{ request()->fullUrl() }}">
+                                    <div class="grid gap-3 sm:grid-cols-2">
+                                        <div>
+                                            <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Провайдер</label>
+                                            <input type="text" name="provider" value="{{ $hint->provider }}" required
+                                                   class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Мова</label>
+                                            <input type="text" name="locale" value="{{ $hint->locale }}" maxlength="5" required
+                                                   class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Підказка</label>
+                                        <textarea name="hint" rows="3" class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">{{ $hint->hint }}</textarea>
+                                    </div>
+                                    <div class="flex flex-wrap gap-2">
+                                        <button type="submit" class="inline-flex items-center rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-emerald-700">Зберегти</button>
+                                        <button type="button" class="inline-flex items-center rounded-lg border border-stone-300 px-3 py-1.5 text-xs font-semibold text-stone-700 hover:bg-stone-100" @click="editing = false">Скасувати</button>
+                                    </div>
+                                </form>
                             </li>
                         @endforeach
                     </ul>
@@ -203,17 +417,60 @@
                                             return $value === $explanation->correct_answer;
                                         });
                                     @endphp
-                                    <tr class="border-t border-stone-200">
-                                        <td class="py-2 pr-4 font-semibold text-stone-600">{{ strtoupper($explanation->language) }}</td>
-                                        <td class="py-2 pr-4">{{ $explanation->wrong_answer ?: '—' }}</td>
-                                        <td @class([
+                                    <tr x-data="{ editing: false }" class="border-t border-stone-200">
+                                        <td x-show="!editing" class="py-2 pr-4 font-semibold text-stone-600">{{ strtoupper($explanation->language) }}</td>
+                                        <td x-show="!editing" class="py-2 pr-4">{{ $explanation->wrong_answer ?: '—' }}</td>
+                                        <td x-show="!editing" @class([
                                             'py-2 pr-4 font-semibold',
                                             'text-emerald-700' => $isStoredCorrect,
                                             'text-stone-800' => ! $isStoredCorrect,
                                         ])>
                                             {{ $explanation->correct_answer }}
                                         </td>
-                                        <td class="py-2">{{ $explanation->explanation }}</td>
+                                        <td x-show="!editing" class="py-2">
+                                            <div class="flex items-start justify-between gap-3">
+                                                <span class="flex-1">{{ $explanation->explanation }}</span>
+                                                <button type="button" class="inline-flex items-center gap-1 rounded border border-stone-300 px-2 py-1 text-xs font-semibold text-stone-600 hover:bg-stone-100" @click="editing = true">
+                                                    <span>Редагувати</span>
+                                                </button>
+                                            </div>
+                                        </td>
+                                        <td x-show="editing" colspan="4" class="hidden py-3">
+                                            <form method="POST" action="{{ route('chatgpt-explanations.update', $explanation) }}" class="space-y-3 rounded-2xl border border-stone-200 bg-white px-4 py-3">
+                                                @csrf
+                                                @method('put')
+                                                <input type="hidden" name="from" value="{{ request()->fullUrl() }}">
+                                                <div class="grid gap-3 sm:grid-cols-2">
+                                                    <div>
+                                                        <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Мова</label>
+                                                        <input type="text" name="language" value="{{ $explanation->language }}" maxlength="10" required
+                                                               class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                                                    </div>
+                                                    <div>
+                                                        <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Неправильна відповідь</label>
+                                                        <input type="text" name="wrong_answer" value="{{ $explanation->wrong_answer }}"
+                                                               class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                                                    </div>
+                                                    <div>
+                                                        <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Правильна відповідь</label>
+                                                        <input type="text" name="correct_answer" value="{{ $explanation->correct_answer }}" required
+                                                               class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">
+                                                    </div>
+                                                    <div>
+                                                        <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Текст питання</label>
+                                                        <textarea name="question" rows="2" class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">{{ $explanation->question }}</textarea>
+                                                    </div>
+                                                </div>
+                                                <div>
+                                                    <label class="block text-xs font-semibold uppercase tracking-wide text-stone-500">Пояснення</label>
+                                                    <textarea name="explanation" rows="3" class="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-500">{{ $explanation->explanation }}</textarea>
+                                                </div>
+                                                <div class="flex flex-wrap justify-end gap-2">
+                                                    <button type="submit" class="inline-flex items-center rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-emerald-700">Зберегти</button>
+                                                    <button type="button" class="inline-flex items-center rounded-lg border border-stone-300 px-3 py-1.5 text-xs font-semibold text-stone-700 hover:bg-stone-100" @click="editing = false">Скасувати</button>
+                                                </div>
+                                            </form>
+                                        </td>
                                     </tr>
                                 @endforeach
                             </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,11 @@ use App\Http\Controllers\QuestionHelpController;
 use App\Http\Controllers\TrainController;
 use App\Http\Controllers\WordSearchController;
 use App\Http\Controllers\SiteSearchController;
+use App\Http\Controllers\QuestionAnswerController;
+use App\Http\Controllers\QuestionHintController;
+use App\Http\Controllers\QuestionOptionController;
+use App\Http\Controllers\QuestionVariantController;
+use App\Http\Controllers\ChatGPTExplanationController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -91,6 +96,7 @@ Route::delete('/test/{slug}/step/remove-tag', [GrammarTestController::class, 're
 Route::delete('/test/{slug}/question/{question}', [GrammarTestController::class, 'deleteQuestion'])->name('saved-test.question.destroy');
 Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
 Route::delete('/tests/{test}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
+Route::put('/tests/{test}', [\App\Http\Controllers\GrammarTestController::class, 'update'])->name('saved-tests.update');
 Route::get('/tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('saved-tests.cards');
 Route::get('/catalog-tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('catalog-tests.cards');
 
@@ -132,6 +138,11 @@ Route::post('/verb-hints', [VerbHintController::class, 'store'])->name('verb-hin
 Route::put('/verb-hints/{verbHint}', [VerbHintController::class, 'update'])->name('verb-hints.update');
 Route::delete('/verb-hints/{verbHint}', [VerbHintController::class, 'destroy'])->name('verb-hints.destroy');
 Route::put('/questions/{question}', [QuestionController::class, 'update'])->name('questions.update');
+Route::put('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'update'])->name('question-answers.update');
+Route::put('/question-options/{questionOption}', [QuestionOptionController::class, 'update'])->name('question-options.update');
+Route::put('/question-variants/{questionVariant}', [QuestionVariantController::class, 'update'])->name('question-variants.update');
+Route::put('/question-hints/{questionHint}', [QuestionHintController::class, 'update'])->name('question-hints.update');
+Route::put('/chatgpt-explanations/{chatgptExplanation}', [ChatGPTExplanationController::class, 'update'])->name('chatgpt-explanations.update');
 
 Route::post('/question-hint', [QuestionHelpController::class, 'hint'])->name('question.hint');
 Route::post('/question-explain', [QuestionHelpController::class, 'explain'])->name('question.explain');

--- a/tests/Feature/QuestionAnswerControllerTest.php
+++ b/tests/Feature/QuestionAnswerControllerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Question;
+use App\Models\QuestionAnswer;
+use App\Models\QuestionOption;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class QuestionAnswerControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensureSchema();
+    }
+
+    /** @test */
+    public function it_updates_answer_value_and_reassigns_option(): void
+    {
+        $question = Question::create([
+            'uuid' => 'q-test',
+            'question' => 'I {a1} to school.',
+            'difficulty' => 1,
+        ]);
+
+        $oldOption = QuestionOption::create(['option' => 'goes']);
+        $question->options()->attach($oldOption->id, ['flag' => 0]);
+
+        $answer = QuestionAnswer::create([
+            'question_id' => $question->id,
+            'marker' => 'a1',
+            'option_id' => $oldOption->id,
+        ]);
+
+        $response = $this->from('/back')->put(route('question-answers.update', $answer), [
+            'marker' => 'A1',
+            'value' => 'go',
+            'from' => '/back',
+        ]);
+
+        $response->assertRedirect('/back');
+
+        $newOption = QuestionOption::where('option', 'go')->first();
+        $this->assertNotNull($newOption);
+
+        $this->assertDatabaseHas('question_answers', [
+            'id' => $answer->id,
+            'marker' => 'a1',
+            'option_id' => $newOption->id,
+        ]);
+
+        $this->assertDatabaseHas('question_option_question', [
+            'question_id' => $question->id,
+            'option_id' => $newOption->id,
+            'flag' => 0,
+        ]);
+
+        $this->assertDatabaseMissing('question_options', [
+            'id' => $oldOption->id,
+        ]);
+    }
+
+    private function ensureSchema(): void
+    {
+        if (! Schema::hasTable('questions')) {
+            Schema::create('questions', function (Blueprint $table) {
+                $table->id();
+                $table->uuid('uuid')->unique();
+                $table->text('question');
+                $table->unsignedTinyInteger('difficulty')->default(1);
+                $table->string('level', 2)->nullable();
+                $table->unsignedBigInteger('category_id')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('question_options')) {
+            Schema::create('question_options', function (Blueprint $table) {
+                $table->id();
+                $table->string('option')->unique();
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('question_option_question')) {
+            Schema::create('question_option_question', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->tinyInteger('flag')->nullable();
+                $table->unique(['question_id', 'option_id', 'flag'], 'qoq_question_option_flag_unique');
+            });
+        }
+
+        if (! Schema::hasTable('question_answers')) {
+            Schema::create('question_answers', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->string('marker');
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('verb_hints')) {
+            Schema::create('verb_hints', function (Blueprint $table) {
+                $table->id();
+                $table->string('marker');
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->timestamps();
+            });
+        }
+    }
+}

--- a/tests/Feature/QuestionOptionControllerTest.php
+++ b/tests/Feature/QuestionOptionControllerTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Question;
+use App\Models\QuestionAnswer;
+use App\Models\QuestionOption;
+use App\Models\VerbHint;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class QuestionOptionControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensureSchema();
+    }
+
+    /** @test */
+    public function it_creates_a_new_option_when_shared_between_questions(): void
+    {
+        $questionA = Question::create([
+            'uuid' => 'q-a',
+            'question' => 'They {a1} together.',
+            'difficulty' => 1,
+        ]);
+        $questionB = Question::create([
+            'uuid' => 'q-b',
+            'question' => 'He {a1} alone.',
+            'difficulty' => 1,
+        ]);
+
+        $sharedOption = QuestionOption::create(['option' => 'go']);
+
+        $questionA->options()->attach($sharedOption->id, ['flag' => 0]);
+        $questionB->options()->attach($sharedOption->id, ['flag' => 0]);
+
+        $answer = QuestionAnswer::create([
+            'question_id' => $questionA->id,
+            'marker' => 'a1',
+            'option_id' => $sharedOption->id,
+        ]);
+
+        $verbHint = VerbHint::create([
+            'question_id' => $questionA->id,
+            'marker' => 'a1',
+            'option_id' => $sharedOption->id,
+        ]);
+
+        $response = $this->from('/back')->put(route('question-options.update', $sharedOption), [
+            'question_id' => $questionA->id,
+            'option' => 'walk',
+            'from' => '/back',
+        ]);
+
+        $response->assertRedirect('/back');
+
+        $newOption = QuestionOption::where('option', 'walk')->first();
+        $this->assertNotNull($newOption);
+
+        $this->assertDatabaseHas('question_answers', [
+            'id' => $answer->id,
+            'option_id' => $newOption->id,
+        ]);
+
+        $this->assertDatabaseHas('verb_hints', [
+            'id' => $verbHint->id,
+            'option_id' => $newOption->id,
+        ]);
+
+        $this->assertDatabaseHas('question_option_question', [
+            'question_id' => $questionA->id,
+            'option_id' => $newOption->id,
+            'flag' => 0,
+        ]);
+
+        $this->assertDatabaseMissing('question_option_question', [
+            'question_id' => $questionA->id,
+            'option_id' => $sharedOption->id,
+            'flag' => 0,
+        ]);
+
+        $this->assertDatabaseHas('question_option_question', [
+            'question_id' => $questionB->id,
+            'option_id' => $sharedOption->id,
+            'flag' => 0,
+        ]);
+
+        $this->assertDatabaseHas('question_options', [
+            'id' => $sharedOption->id,
+            'option' => 'go',
+        ]);
+    }
+
+    private function ensureSchema(): void
+    {
+        if (! Schema::hasTable('questions')) {
+            Schema::create('questions', function (Blueprint $table) {
+                $table->id();
+                $table->uuid('uuid')->unique();
+                $table->text('question');
+                $table->unsignedTinyInteger('difficulty')->default(1);
+                $table->string('level', 2)->nullable();
+                $table->unsignedBigInteger('category_id')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('question_options')) {
+            Schema::create('question_options', function (Blueprint $table) {
+                $table->id();
+                $table->string('option')->unique();
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('question_option_question')) {
+            Schema::create('question_option_question', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->tinyInteger('flag')->nullable();
+                $table->unique(['question_id', 'option_id', 'flag'], 'qoq_question_option_flag_unique');
+            });
+        }
+
+        if (! Schema::hasTable('question_answers')) {
+            Schema::create('question_answers', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->string('marker');
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('verb_hints')) {
+            Schema::create('verb_hints', function (Blueprint $table) {
+                $table->id();
+                $table->string('marker');
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->timestamps();
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add update endpoints for tests, answers, options, variants, hints and explanations to support editing
- redesign the saved test technical view with inline Alpine-powered forms for every editable item
- cover the new answer and option flows with feature tests

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cdc06f88fc832ab7a5042c5b89f87c