### PR TITLE
Queue grammar test tech edits before applying

### DIFF
--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 use App\Models\Test;
 use App\Models\Tag;
 use App\Models\ChatGPTExplanation;
+use App\Services\PendingTestChangeRepository;
 use App\Services\QuestionVariantService;
 
 class GrammarTestController extends Controller
@@ -27,7 +28,10 @@ class GrammarTestController extends Controller
         'saved-test-js-select',
     ];
 
-    public function __construct(private QuestionVariantService $variantService)
+    public function __construct(
+        private QuestionVariantService $variantService,
+        private PendingTestChangeRepository $changeRepository
+    )
     {
     }
 
@@ -117,11 +121,14 @@ class GrammarTestController extends Controller
 
         [$questions, $explanationsByQuestionId] = $this->prepareSavedTestTechData($test);
 
+        $pendingChanges = collect($this->changeRepository->all($slug));
+
         return view('engram.saved-test-tech', [
             'test' => $test,
             'questions' => $questions,
             'explanationsByQuestionId' => $explanationsByQuestionId,
             'returnUrl' => route('saved-test.tech', $test->slug),
+            'pendingChanges' => $pendingChanges,
         ]);
     }
 

--- a/app/Http/Controllers/SavedTestChangeController.php
+++ b/app/Http/Controllers/SavedTestChangeController.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Question;
+use App\Models\Test;
+use App\Services\PendingTestChangeRepository;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class SavedTestChangeController extends Controller
+{
+    public function __construct(private PendingTestChangeRepository $repository)
+    {
+    }
+
+    public function index(Request $request, string $slug)
+    {
+        $test = Test::where('slug', $slug)->firstOrFail();
+        $changes = collect($this->repository->all($slug));
+
+        $html = view('engram.partials.saved-test-tech-change-list', [
+            'test' => $test,
+            'changes' => $changes,
+            'returnUrl' => route('saved-test.tech', $test->slug),
+        ])->render();
+
+        return response()->json([
+            'html' => $html,
+            'change_count' => $changes->count(),
+        ]);
+    }
+
+    public function store(Request $request, string $slug)
+    {
+        $test = Test::where('slug', $slug)->firstOrFail();
+
+        $data = $request->validate([
+            'route' => ['required', 'string'],
+            'route_params' => ['nullable', 'array'],
+            'method' => ['required', 'string', Rule::in(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])],
+            'payload' => ['nullable', 'array'],
+            'change_type' => ['nullable', 'string', 'max:100'],
+            'summary' => ['nullable', 'string', 'max:255'],
+            'question_id' => ['nullable', 'integer'],
+        ]);
+
+        $payload = collect($data['payload'] ?? [])
+            ->reject(fn ($value, $key) => in_array($key, ['_token', '_method', 'from'], true))
+            ->all();
+
+        $change = [
+            'route' => $data['route'],
+            'route_params' => $this->normalizeRouteParams($data['route_params'] ?? []),
+            'method' => strtoupper($data['method']),
+            'payload' => $payload,
+            'change_type' => $data['change_type'] ?? 'generic',
+            'summary' => $data['summary'] ?? null,
+            'question_id' => $data['question_id'] ?? null,
+        ];
+
+        if ($change['question_id']) {
+            $question = Question::find($change['question_id']);
+            if ($question) {
+                $change['question_preview'] = Str::limit(trim(strip_tags($question->question ?? '')), 200);
+            }
+        }
+
+        $stored = $this->repository->add($slug, $change);
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'change' => $stored,
+                'change_count' => collect($this->repository->all($slug))->count(),
+            ], 201);
+        }
+
+        return redirect()->route('saved-test.tech', [$test->slug]);
+    }
+
+    public function apply(Request $request, string $slug, string $changeId)
+    {
+        $test = Test::where('slug', $slug)->firstOrFail();
+
+        $change = $this->repository->find($slug, $changeId);
+
+        if (! $change) {
+            abort(404, 'Change not found.');
+        }
+
+        try {
+            $this->executeChange($change);
+        } catch (ValidationException $exception) {
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'message' => $exception->getMessage(),
+                    'errors' => $exception->errors(),
+                ], 422);
+            }
+
+            throw $exception;
+        } catch (\Throwable $exception) {
+            if ($request->expectsJson()) {
+                $message = $exception->getMessage() ?: 'Не вдалося застосувати зміну.';
+
+                return response()->json([
+                    'message' => $message,
+                ], 500);
+            }
+
+            throw $exception;
+        }
+
+        $this->repository->remove($slug, $changeId);
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'status' => 'applied',
+                'change_id' => $changeId,
+            ]);
+        }
+
+        return redirect()->route('saved-test.tech', [$test->slug]);
+    }
+
+    public function destroy(Request $request, string $slug, string $changeId)
+    {
+        $test = Test::where('slug', $slug)->firstOrFail();
+
+        $change = $this->repository->find($slug, $changeId);
+
+        if (! $change) {
+            abort(404, 'Change not found.');
+        }
+
+        $this->repository->remove($slug, $changeId);
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'status' => 'deleted',
+                'change_id' => $changeId,
+            ]);
+        }
+
+        return redirect()->route('saved-test.tech', [$test->slug]);
+    }
+
+    private function normalizeRouteParams(array $params): array
+    {
+        return collect($params)
+            ->map(fn ($value) => is_numeric($value) ? (int) $value : $value)
+            ->all();
+    }
+
+    private function executeChange(array $change)
+    {
+        $routeName = Arr::get($change, 'route');
+        $routeParams = Arr::get($change, 'route_params', []);
+        $method = Arr::get($change, 'method', 'POST');
+        $payload = Arr::get($change, 'payload', []);
+
+        if (! $routeName) {
+            throw new \RuntimeException('Route name is missing for queued change.');
+        }
+
+        $url = route($routeName, $routeParams);
+        $fakeRequest = Request::create($url, $method, $payload);
+        $fakeRequest->headers->set('Accept', 'application/json');
+        $fakeRequest->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        $router = app('router');
+        $route = $router->getRoutes()->match($fakeRequest);
+        $route->setContainer(app());
+        $route->bind($fakeRequest);
+
+        $currentRequest = request();
+        app()->instance('request', $fakeRequest);
+
+        try {
+            return app()->call($route->getAction(), array_merge($route->parameters(), [
+                'request' => $fakeRequest,
+            ]));
+        } finally {
+            app()->instance('request', $currentRequest);
+        }
+    }
+}

--- a/app/Services/PendingTestChangeRepository.php
+++ b/app/Services/PendingTestChangeRepository.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class PendingTestChangeRepository
+{
+    private const DIRECTORY = 'test-changes';
+
+    public function all(string $slug): array
+    {
+        return $this->read($slug);
+    }
+
+    public function add(string $slug, array $change): array
+    {
+        $changes = $this->read($slug);
+
+        $change['id'] = $change['id'] ?? (string) Str::uuid();
+        $change['created_at'] = $change['created_at'] ?? now()->toIso8601String();
+
+        $changes[] = $change;
+
+        $this->write($slug, $changes);
+
+        return $change;
+    }
+
+    public function find(string $slug, string $changeId): ?array
+    {
+        return collect($this->read($slug))->firstWhere('id', $changeId);
+    }
+
+    public function remove(string $slug, string $changeId): void
+    {
+        $filtered = collect($this->read($slug))
+            ->reject(fn ($change) => ($change['id'] ?? null) === $changeId)
+            ->values()
+            ->all();
+
+        $this->write($slug, $filtered);
+    }
+
+    public function replace(string $slug, array $changes): void
+    {
+        $this->write($slug, $changes);
+    }
+
+    private function read(string $slug): array
+    {
+        $path = $this->path($slug);
+
+        if (! Storage::disk('local')->exists($path)) {
+            return [];
+        }
+
+        $contents = Storage::disk('local')->get($path);
+        $data = json_decode($contents, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    private function write(string $slug, array $changes): void
+    {
+        $path = $this->path($slug);
+
+        Storage::disk('local')->makeDirectory(self::DIRECTORY);
+
+        Storage::disk('local')->put(
+            $path,
+            json_encode($changes, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+        );
+    }
+
+    private function path(string $slug): string
+    {
+        return self::DIRECTORY . '/' . $slug . '.json';
+    }
+}

--- a/resources/views/engram/partials/saved-test-tech-change-list.blade.php
+++ b/resources/views/engram/partials/saved-test-tech-change-list.blade.php
@@ -1,0 +1,89 @@
+@php
+    use Illuminate\Support\Arr;
+    use Illuminate\Support\Carbon;
+@endphp
+
+@if($changes->isEmpty())
+    <div class="rounded-2xl border border-dashed border-stone-200 bg-white p-6 text-center text-sm text-stone-500">
+        Змін наразі немає. Внесіть правки на вкладці «Питання», щоб додати їх до черги.
+    </div>
+@else
+    @foreach($changes as $change)
+        @php
+            $changeId = Arr::get($change, 'id');
+            $summary = Arr::get($change, 'summary') ?: 'Зміна без опису';
+            $type = Arr::get($change, 'change_type', 'generic');
+            $questionId = Arr::get($change, 'question_id');
+            $questionPreview = Arr::get($change, 'question_preview');
+            $payload = Arr::get($change, 'payload', []);
+            $createdAt = Arr::get($change, 'created_at');
+            $createdForHumans = $createdAt ? Carbon::parse($createdAt)->diffForHumans(null, true) : null;
+        @endphp
+        <article class="space-y-4 rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+            <header class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div class="space-y-1">
+                    <p class="text-sm font-semibold uppercase tracking-wide text-stone-500">{{ strtoupper($type) }}</p>
+                    <h3 class="text-lg font-bold text-stone-900">{{ $summary }}</h3>
+                    <dl class="flex flex-wrap gap-3 text-xs text-stone-500">
+                        @if($questionId)
+                            <div class="flex items-center gap-1">
+                                <dt class="font-semibold uppercase tracking-wide">Питання</dt>
+                                <dd class="rounded-full bg-stone-900 px-2 py-0.5 text-white">ID {{ $questionId }}</dd>
+                            </div>
+                        @endif
+                        @if($createdForHumans)
+                            <div class="flex items-center gap-1">
+                                <dt class="font-semibold uppercase tracking-wide">Додано</dt>
+                                <dd>{{ $createdForHumans }} тому</dd>
+                            </div>
+                        @endif
+                    </dl>
+                    @if($questionPreview)
+                        <p class="rounded-lg bg-stone-100 px-3 py-2 text-sm text-stone-700">
+                            <span class="font-semibold text-stone-600">Поточне питання:</span>
+                            <span class="ml-2">{{ $questionPreview }}</span>
+                        </p>
+                    @endif
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    <form method="POST"
+                          action="{{ route('saved-test.tech.changes.apply', [$test->slug, $changeId]) }}"
+                          data-refresh-questions="true"
+                          data-refresh-changes="true">
+                        @csrf
+                        <button type="submit"
+                                class="inline-flex items-center gap-1 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white shadow hover:bg-emerald-700">
+                            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="m7 10 2 2 4-4m4 2a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z" />
+                            </svg>
+                            <span>Застосувати</span>
+                        </button>
+                    </form>
+                    <form method="POST"
+                          action="{{ route('saved-test.tech.changes.destroy', [$test->slug, $changeId]) }}"
+                          data-confirm="Видалити цю зміну з черги?"
+                          data-refresh-questions="false"
+                          data-refresh-changes="true">
+                        @csrf
+                        @method('delete')
+                        <button type="submit"
+                                class="inline-flex items-center gap-1 rounded-lg border border-stone-300 px-3 py-1.5 text-sm font-semibold text-stone-600 hover:bg-stone-100">
+                            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="m6 6 8 8m0-8-8 8m9-3v2a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h2" />
+                            </svg>
+                            <span>Скасувати</span>
+                        </button>
+                    </form>
+                </div>
+            </header>
+            <details class="group rounded-xl border border-stone-200 bg-stone-50 px-4 py-3 text-sm text-stone-700">
+                <summary class="flex cursor-pointer items-center justify-between text-xs font-semibold uppercase tracking-wide text-stone-500">
+                    <span>Дані зміни</span>
+                    <span class="text-[10px] font-normal text-stone-400 group-open:hidden">Показати ▼</span>
+                    <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
+                </summary>
+                <pre class="mt-3 overflow-auto whitespace-pre-wrap rounded-lg bg-white px-4 py-3 text-[13px] text-stone-800">{{ json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) }}</pre>
+            </details>
+        </article>
+    @endforeach
+@endif

--- a/resources/views/engram/partials/saved-test-tech-question.blade.php
+++ b/resources/views/engram/partials/saved-test-tech-question.blade.php
@@ -94,7 +94,15 @@
             </div>
         </div>
         <div x-show="!editingQuestion" class="flex flex-wrap justify-end gap-2">
-            <form method="POST" action="{{ route('saved-test.question.destroy', [$test->slug, $question]) }}" data-confirm="Видалити це питання з тесту?">
+            <form method="POST"
+                  action="{{ route('saved-test.question.destroy', [$test->slug, $question]) }}"
+                  data-confirm="Видалити це питання з тесту?"
+                  data-queue-change="true"
+                  data-change-type="question.delete"
+                  data-change-summary="Видалити питання"
+                  data-question-id="{{ $question->id }}"
+                  data-route-name="saved-test.question.destroy"
+                  data-route-params="@js(['slug' => $test->slug, 'question' => $question->id])">
                 @csrf
                 @method('delete')
                 <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -116,7 +124,13 @@
                 <span>Редагувати питання</span>
             </button>
         </div>
-        <form x-show="editingQuestion" x-cloak x-ref="form" method="POST" action="{{ route('questions.update', $question) }}" class="rounded-2xl border border-stone-200 bg-stone-50 p-4 space-y-4">
+        <form x-show="editingQuestion" x-cloak x-ref="form" method="POST" action="{{ route('questions.update', $question) }}" class="rounded-2xl border border-stone-200 bg-stone-50 p-4 space-y-4"
+              data-queue-change="true"
+              data-change-type="question.update"
+              data-change-summary="Оновити питання"
+              data-question-id="{{ $question->id }}"
+              data-route-name="questions.update"
+              data-route-params="@js(['question' => $question->id])">
             @csrf
             @method('put')
             <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -155,7 +169,15 @@
                         <div class="flex items-center justify-between gap-2">
                             <span class="font-mono text-[11px] uppercase text-stone-500">Варіант {{ $loop->iteration }}</span>
                             <div class="flex items-center gap-2">
-                                <form method="POST" action="{{ route('question-variants.destroy', $variant) }}" data-confirm="Видалити цей варіант?">
+                                <form method="POST"
+                                      action="{{ route('question-variants.destroy', $variant) }}"
+                                      data-confirm="Видалити цей варіант?"
+                                      data-queue-change="true"
+                                      data-change-type="variant.delete"
+                                      data-change-summary="Видалити варіант питання"
+                                      data-question-id="{{ $question->id }}"
+                                      data-route-name="question-variants.destroy"
+                                      data-route-params="@js(['questionVariant' => $variant->id])">
                                     @csrf
                                     @method('delete')
                                     <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -174,7 +196,13 @@
                         </div>
                         <span>{!! $highlightSegments($variant->text) !!}</span>
                     </div>
-                    <form x-show="editing" x-cloak x-ref="form" method="POST" action="{{ route('question-variants.update', $variant) }}" class="space-y-2">
+                    <form x-show="editing" x-cloak x-ref="form" method="POST" action="{{ route('question-variants.update', $variant) }}" class="space-y-2"
+                          data-queue-change="true"
+                          data-change-type="variant.update"
+                          data-change-summary="Оновити варіант питання"
+                          data-question-id="{{ $question->id }}"
+                          data-route-name="question-variants.update"
+                          data-route-params="@js(['questionVariant' => $variant->id])">
                         @csrf
                         @method('put')
                         <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -198,7 +226,13 @@
                         <span>Створити</span>
                     </button>
                 </div>
-                <form x-show="adding" x-cloak x-ref="form" method="POST" action="{{ route('question-variants.store') }}" class="mt-3 space-y-2">
+                <form x-show="adding" x-cloak x-ref="form" method="POST" action="{{ route('question-variants.store') }}" class="mt-3 space-y-2"
+                      data-queue-change="true"
+                      data-change-type="variant.create"
+                      data-change-summary="Додати варіант питання"
+                      data-question-id="{{ $question->id }}"
+                      data-route-name="question-variants.store"
+                      data-route-params="@js([])">
                     @csrf
                     <input type="hidden" name="from" value="{{ $returnUrl }}">
                     <input type="hidden" name="question_id" value="{{ $question->id }}">
@@ -235,7 +269,15 @@
                         <div x-show="!editingAnswer" x-ref="display" class="flex flex-wrap items-center gap-2">
                             <span class="font-mono text-xs uppercase text-emerald-500">{{ $marker }}</span>
                             <span class="font-semibold text-emerald-900">{{ $answerValue }}</span>
-                            <form method="POST" action="{{ route('question-answers.destroy', $answer) }}" data-confirm="Видалити цю відповідь?">
+                            <form method="POST"
+                                  action="{{ route('question-answers.destroy', $answer) }}"
+                                  data-confirm="Видалити цю відповідь?"
+                                  data-queue-change="true"
+                                  data-change-type="answer.delete"
+                                  data-change-summary="Видалити правильну відповідь"
+                                  data-question-id="{{ $question->id }}"
+                                  data-route-name="question-answers.destroy"
+                                  data-route-params="@js(['questionAnswer' => $answer->id])">
                                 @csrf
                                 @method('delete')
                                 <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -251,7 +293,13 @@
                                 <span>Редагувати відповідь</span>
                             </button>
                         </div>
-                        <form x-show="editingAnswer" x-cloak x-ref="form" method="POST" action="{{ route('question-answers.update', $answer) }}" class="space-y-2">
+                        <form x-show="editingAnswer" x-cloak x-ref="form" method="POST" action="{{ route('question-answers.update', $answer) }}" class="space-y-2"
+                              data-queue-change="true"
+                              data-change-type="answer.update"
+                              data-change-summary="Оновити правильну відповідь"
+                              data-question-id="{{ $question->id }}"
+                              data-route-name="question-answers.update"
+                              data-route-params="@js(['questionAnswer' => $answer->id])">
                             @csrf
                             @method('put')
                             <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -278,7 +326,15 @@
                             <div x-show="!editingHint" x-ref="display" class="flex flex-wrap items-center gap-2">
                                 <span class="font-semibold uppercase text-[10px] tracking-wide text-emerald-600">Verb hint</span>
                                 <span class="text-sm text-emerald-800">{{ $verbHintValue }}</span>
-                                <form method="POST" action="{{ route('verb-hints.destroy', $verbHintModel) }}" data-confirm="Видалити цю підказку?">
+                                <form method="POST"
+                                      action="{{ route('verb-hints.destroy', $verbHintModel) }}"
+                                      data-confirm="Видалити цю підказку?"
+                                      data-queue-change="true"
+                                      data-change-type="verb-hint.delete"
+                                      data-change-summary="Видалити verb hint"
+                                      data-question-id="{{ $question->id }}"
+                                      data-route-name="verb-hints.destroy"
+                                      data-route-params="@js(['verbHint' => $verbHintModel->id])">
                                     @csrf
                                     @method('delete')
                                     <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -292,7 +348,13 @@
                                     <span>Редагувати підказку</span>
                                 </button>
                             </div>
-                            <form x-show="editingHint" x-cloak x-ref="form" method="POST" action="{{ route('verb-hints.update', $verbHintModel) }}" class="space-y-2">
+                            <form x-show="editingHint" x-cloak x-ref="form" method="POST" action="{{ route('verb-hints.update', $verbHintModel) }}" class="space-y-2"
+                                  data-queue-change="true"
+                                  data-change-type="verb-hint.update"
+                                  data-change-summary="Оновити verb hint"
+                                  data-question-id="{{ $question->id }}"
+                                  data-route-name="verb-hints.update"
+                                  data-route-params="@js(['verbHint' => $verbHintModel->id])">
                                 @csrf
                                 @method('put')
                                 <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -315,7 +377,13 @@
                                     <span>Додати</span>
                                 </button>
                             </div>
-                            <form x-show="addingHint" x-cloak x-ref="form" method="POST" action="{{ route('verb-hints.store') }}" class="mt-2 space-y-2">
+                            <form x-show="addingHint" x-cloak x-ref="form" method="POST" action="{{ route('verb-hints.store') }}" class="mt-2 space-y-2"
+                                  data-queue-change="true"
+                                  data-change-type="verb-hint.create"
+                                  data-change-summary="Додати verb hint"
+                                  data-question-id="{{ $question->id }}"
+                                  data-route-name="verb-hints.store"
+                                  data-route-params="@js([])">
                                 @csrf
                                 <input type="hidden" name="from" value="{{ $returnUrl }}">
                                 <input type="hidden" name="question_id" value="{{ $question->id }}">
@@ -340,7 +408,13 @@
                         <span>Створити</span>
                     </button>
                 </div>
-                <form x-show="addingAnswer" x-cloak x-ref="form" method="POST" action="{{ route('question-answers.store') }}" class="mt-3 space-y-2">
+                <form x-show="addingAnswer" x-cloak x-ref="form" method="POST" action="{{ route('question-answers.store') }}" class="mt-3 space-y-2"
+                      data-queue-change="true"
+                      data-change-type="answer.create"
+                      data-change-summary="Додати правильну відповідь"
+                      data-question-id="{{ $question->id }}"
+                      data-route-name="question-answers.store"
+                      data-route-params="@js([])">
                     @csrf
                     <input type="hidden" name="from" value="{{ $returnUrl }}">
                     <input type="hidden" name="question_id" value="{{ $question->id }}">
@@ -394,7 +468,15 @@
                                 <span>Редагувати</span>
                             </button>
                             @if(! $optionItem->is_correct)
-                                <form method="POST" action="{{ route('question-options.destroy', $optionItem->model) }}" data-confirm="Видалити цей варіант відповіді?">
+                                <form method="POST"
+                                      action="{{ route('question-options.destroy', $optionItem->model) }}"
+                                      data-confirm="Видалити цей варіант відповіді?"
+                                      data-queue-change="true"
+                                      data-change-type="option.delete"
+                                      data-change-summary="Видалити варіант відповіді"
+                                      data-question-id="{{ $question->id }}"
+                                      data-route-name="question-options.destroy"
+                                      data-route-params="@js(['questionOption' => $optionItem->model->id])">
                                     @csrf
                                     @method('delete')
                                     <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -403,7 +485,13 @@
                                 </form>
                             @endif
                         </div>
-                        <form x-show="editing" x-cloak x-ref="form" method="POST" action="{{ route('question-options.update', $optionItem->model) }}" class="space-y-2 rounded-xl border border-stone-200 bg-white px-3 py-2">
+                        <form x-show="editing" x-cloak x-ref="form" method="POST" action="{{ route('question-options.update', $optionItem->model) }}" class="space-y-2 rounded-xl border border-stone-200 bg-white px-3 py-2"
+                              data-queue-change="true"
+                              data-change-type="option.update"
+                              data-change-summary="Оновити варіант відповіді"
+                              data-question-id="{{ $question->id }}"
+                              data-route-name="question-options.update"
+                              data-route-params="@js(['questionOption' => $optionItem->model->id])">
                             @csrf
                             @method('put')
                             <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -430,7 +518,13 @@
                         <span>Створити</span>
                     </button>
                 </div>
-                <form x-show="addingOption" x-cloak x-ref="form" method="POST" action="{{ route('question-options.store') }}" class="space-y-2">
+                <form x-show="addingOption" x-cloak x-ref="form" method="POST" action="{{ route('question-options.store') }}" class="space-y-2"
+                      data-queue-change="true"
+                      data-change-type="option.create"
+                      data-change-summary="Додати варіант відповіді"
+                      data-question-id="{{ $question->id }}"
+                      data-route-name="question-options.store"
+                      data-route-params="@js([])">
                     @csrf
                     <input type="hidden" name="from" value="{{ $returnUrl }}">
                     <input type="hidden" name="question_id" value="{{ $question->id }}">
@@ -461,7 +555,15 @@
                             <span>{{ $hint->provider }}</span>
                             <span>·</span>
                             <span>{{ strtoupper($hint->locale) }}</span>
-                            <form method="POST" action="{{ route('question-hints.destroy', $hint) }}" data-confirm="Видалити цю підказку?">
+                            <form method="POST"
+                                  action="{{ route('question-hints.destroy', $hint) }}"
+                                  data-confirm="Видалити цю підказку?"
+                                  data-queue-change="true"
+                                  data-change-type="question-hint.delete"
+                                  data-change-summary="Видалити question hint"
+                                  data-question-id="{{ $question->id }}"
+                                  data-route-name="question-hints.destroy"
+                                  data-route-params="@js(['questionHint' => $hint->id])">
                                 @csrf
                                 @method('delete')
                                 <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -477,7 +579,13 @@
                         </div>
                         <div class="whitespace-pre-line text-stone-800">{{ $hint->hint }}</div>
                     </div>
-                    <form x-show="editing" x-cloak x-ref="form" method="POST" action="{{ route('question-hints.update', $hint) }}" class="space-y-3 rounded-xl border border-blue-200 bg-white px-3 py-3">
+                    <form x-show="editing" x-cloak x-ref="form" method="POST" action="{{ route('question-hints.update', $hint) }}" class="space-y-3 rounded-xl border border-blue-200 bg-white px-3 py-3"
+                          data-queue-change="true"
+                          data-change-type="question-hint.update"
+                          data-change-summary="Оновити question hint"
+                          data-question-id="{{ $question->id }}"
+                          data-route-name="question-hints.update"
+                          data-route-params="@js(['questionHint' => $hint->id])">
                         @csrf
                         @method('put')
                         <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -513,7 +621,13 @@
                         <span>Створити</span>
                     </button>
                 </div>
-                <form x-show="addingHint" x-cloak x-ref="form" method="POST" action="{{ route('question-hints.store') }}" class="mt-3 space-y-2">
+                <form x-show="addingHint" x-cloak x-ref="form" method="POST" action="{{ route('question-hints.store') }}" class="mt-3 space-y-2"
+                      data-queue-change="true"
+                      data-change-type="question-hint.create"
+                      data-change-summary="Додати question hint"
+                      data-question-id="{{ $question->id }}"
+                      data-route-name="question-hints.store"
+                      data-route-params="@js([])">
                     @csrf
                     <input type="hidden" name="from" value="{{ $returnUrl }}">
                     <input type="hidden" name="question_id" value="{{ $question->id }}">
@@ -577,7 +691,15 @@
                             <div class="flex items-start justify-between gap-3">
                                     <span class="flex-1">{{ $explanation->explanation }}</span>
                                     <div class="flex items-center gap-2">
-                                        <form method="POST" action="{{ route('chatgpt-explanations.destroy', $explanation) }}" data-confirm="Видалити це пояснення?">
+                                        <form method="POST"
+                                              action="{{ route('chatgpt-explanations.destroy', $explanation) }}"
+                                              data-confirm="Видалити це пояснення?"
+                                              data-queue-change="true"
+                                              data-change-type="explanation.delete"
+                                              data-change-summary="Видалити пояснення"
+                                              data-question-id="{{ $question->id }}"
+                                              data-route-name="chatgpt-explanations.destroy"
+                                              data-route-params="@js(['chatgptExplanation' => $explanation->id])">
                                             @csrf
                                             @method('delete')
                                             <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -594,7 +716,13 @@
                                 </div>
                             </td>
                             <td x-show="editing" x-cloak colspan="4" class="py-3">
-                                <form x-ref="form" method="POST" action="{{ route('chatgpt-explanations.update', $explanation) }}" class="space-y-3 rounded-2xl border border-stone-200 bg-white px-4 py-3">
+                                <form x-ref="form" method="POST" action="{{ route('chatgpt-explanations.update', $explanation) }}" class="space-y-3 rounded-2xl border border-stone-200 bg-white px-4 py-3"
+                                      data-queue-change="true"
+                                      data-change-type="explanation.update"
+                                      data-change-summary="Оновити пояснення"
+                                      data-question-id="{{ $question->id }}"
+                                      data-route-name="chatgpt-explanations.update"
+                                      data-route-params="@js(['chatgptExplanation' => $explanation->id])">
                                     @csrf
                                     @method('put')
                                     <input type="hidden" name="from" value="{{ $returnUrl }}">
@@ -643,7 +771,13 @@
                                     <span>Створити</span>
                                 </button>
                             </div>
-                            <form x-show="addingExplanation" x-cloak x-ref="form" method="POST" action="{{ route('chatgpt-explanations.store') }}" class="mt-3 space-y-3 rounded-2xl border border-stone-200 bg-white px-4 py-3">
+                            <form x-show="addingExplanation" x-cloak x-ref="form" method="POST" action="{{ route('chatgpt-explanations.store') }}" class="mt-3 space-y-3 rounded-2xl border border-stone-200 bg-white px-4 py-3"
+                                  data-queue-change="true"
+                                  data-change-type="explanation.create"
+                                  data-change-summary="Додати пояснення"
+                                  data-question-id="{{ $question->id }}"
+                                  data-route-name="chatgpt-explanations.store"
+                                  data-route-params="@js([])">
                                 @csrf
                                 <input type="hidden" name="from" value="{{ $returnUrl }}">
                                 <input type="hidden" name="question_id" value="{{ $question->id }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,6 +80,10 @@ Route::get('/test/{slug}/js/step/select', [GrammarTestController::class, 'showSa
 Route::get('/test/{slug}/js/select', [GrammarTestController::class, 'showSavedTestJsSelect'])->name('saved-test.js.select');
 Route::get('/test/{slug}/tech', [GrammarTestController::class, 'showSavedTestTech'])->name('saved-test.tech');
 Route::get('/test/{slug}/tech/questions', [GrammarTestController::class, 'fetchSavedTestTechQuestions'])->name('saved-test.tech.questions');
+Route::get('/test/{slug}/tech/changes', [SavedTestChangeController::class, 'index'])->name('saved-test.tech.changes.index');
+Route::post('/test/{slug}/tech/changes', [SavedTestChangeController::class, 'store'])->name('saved-test.tech.changes.store');
+Route::post('/test/{slug}/tech/changes/{change}/apply', [SavedTestChangeController::class, 'apply'])->name('saved-test.tech.changes.apply');
+Route::delete('/test/{slug}/tech/changes/{change}', [SavedTestChangeController::class, 'destroy'])->name('saved-test.tech.changes.destroy');
 Route::post('/test/{slug}/questions', [GrammarTestController::class, 'storeSavedTestQuestion'])->name('saved-test.questions.store');
 Route::get('/test/{slug}', [GrammarTestController::class, 'showSavedTest'])->name('saved-test.show');
 Route::get('/test/{slug}/random', [GrammarTestController::class, 'showSavedTestRandom'])->name('saved-test.random');
@@ -133,6 +137,7 @@ Route::get('/question-review/{question}', [QuestionReviewController::class, 'edi
 use App\Http\Controllers\QuestionController;
 use App\Http\Controllers\QuestionReviewResultController;
 use App\Http\Controllers\VerbHintController;
+use App\Http\Controllers\SavedTestChangeController;
 
 Route::get('/question-review-results', [QuestionReviewResultController::class, 'index'])->name('question-review-results.index');
 


### PR DESCRIPTION
## Summary
- add a pending-change repository that records test question edits to JSON
- add a controller and routes for reviewing, applying, or discarding queued changes and surface them on the tech page
- update the tech UI so form submissions queue into JSON, provide a change-review tab, and refresh counts via new JS helpers

## Testing
- ⚠️ `./vendor/bin/phpunit` *(fails: No such file or directory — dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cea178300c832abcbedad14ec81b56