### PR TITLE
Add AJAX question editor with JSON drafts

### DIFF
--- a/app/Http/Controllers/GrammarTestController.php
+++ b/app/Http/Controllers/GrammarTestController.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 use App\Models\Test;
 use App\Models\Tag;
 use App\Models\ChatGPTExplanation;
+use App\Services\QuestionTechDraftService;
 use App\Services\QuestionVariantService;
 
 class GrammarTestController extends Controller
@@ -27,7 +28,10 @@ class GrammarTestController extends Controller
         'saved-test-js-select',
     ];
 
-    public function __construct(private QuestionVariantService $variantService)
+    public function __construct(
+        private QuestionVariantService $variantService,
+        private QuestionTechDraftService $draftService,
+    )
     {
     }
 
@@ -150,10 +154,15 @@ class GrammarTestController extends Controller
             }
         }
 
+        $drafts = $questions->mapWithKeys(function (Question $question) {
+            return [$question->id => $this->draftService->getDraft($question)];
+        });
+
         return view('engram.saved-test-tech', [
             'test' => $test,
             'questions' => $questions,
             'explanationsByQuestionId' => $explanationsByQuestionId,
+            'drafts' => $drafts,
         ]);
     }
 

--- a/app/Http/Controllers/TechQuestionDraftController.php
+++ b/app/Http/Controllers/TechQuestionDraftController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Question;
+use App\Models\Test;
+use App\Services\QuestionTechDraftService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TechQuestionDraftController extends Controller
+{
+    public function __construct(private QuestionTechDraftService $draftService)
+    {
+    }
+
+    public function show(string $slug, Question $question): JsonResponse
+    {
+        $this->ensureQuestionBelongsToTest($slug, $question);
+
+        $dump = $this->draftService->getDraft($question);
+
+        return response()->json($dump);
+    }
+
+    public function update(Request $request, string $slug, Question $question): JsonResponse
+    {
+        $this->ensureQuestionBelongsToTest($slug, $question);
+
+        $validated = $request->validate([
+            'question' => 'required|array',
+            'question.question' => 'nullable|string',
+            'question.difficulty' => 'nullable',
+            'question.level' => 'nullable',
+            'question.flag' => 'nullable',
+            'question.category_id' => 'nullable',
+            'question.source_id' => 'nullable',
+            'question.options' => 'array',
+            'question.answers' => 'array',
+            'question.verb_hints' => 'array',
+            'question.variants' => 'array',
+            'question.hints' => 'array',
+            'question.tags' => 'array',
+        ]);
+
+        $draft = $this->draftService->storeDraftFromArray(
+            $question,
+            $validated['question'],
+            $slug
+        );
+
+        return response()->json([
+            'status' => 'saved',
+            'draft' => $draft,
+        ]);
+    }
+
+    public function apply(string $slug, Question $question): JsonResponse
+    {
+        $this->ensureQuestionBelongsToTest($slug, $question);
+
+        $draft = $this->draftService->applyDraft($question);
+
+        return response()->json([
+            'status' => 'applied',
+            'draft' => $draft,
+        ]);
+    }
+
+    private function ensureQuestionBelongsToTest(string $slug, Question $question): void
+    {
+        $test = Test::where('slug', $slug)->firstOrFail();
+
+        if (! in_array($question->id, $test->questions ?? [], true)) {
+            abort(404);
+        }
+    }
+}

--- a/app/Services/QuestionTechDraftService.php
+++ b/app/Services/QuestionTechDraftService.php
@@ -1,0 +1,598 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Question;
+use App\Models\QuestionAnswer;
+use App\Models\QuestionHint;
+use App\Models\QuestionOption;
+use App\Models\QuestionVariant;
+use App\Models\VerbHint;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class QuestionTechDraftService
+{
+    private const DIRECTORY = 'storage/question-dumps';
+
+    /**
+     * Returns the current draft for the question. If the draft file exists it will
+     * be used, otherwise the data is built from the database.
+     */
+    public function getDraft(Question $question): array
+    {
+        $question = $this->ensureUuid($question);
+        $path = $this->getDumpPath($question);
+
+        if (File::exists($path)) {
+            $decoded = json_decode(File::get($path), true);
+
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        $dump = $this->makeDumpFromModel($question);
+
+        return $dump + ['meta' => [
+            'source' => 'database',
+            'exported_at' => now()->toIso8601String(),
+        ]];
+    }
+
+    /**
+     * Persists the provided payload as a draft and returns the stored data.
+     */
+    public function storeDraftFromArray(Question $question, array $payload, ?string $testSlug = null): array
+    {
+        $question = $this->ensureUuid($question);
+
+        $normalized = $this->normalizePayload($question, $payload);
+
+        $data = [
+            'question' => $normalized,
+            'meta' => [
+                'source' => 'draft',
+                'exported_at' => now()->toIso8601String(),
+                'test_slug' => $testSlug,
+            ],
+        ];
+
+        $this->writeDump($question, $data);
+
+        return $data;
+    }
+
+    /**
+     * Applies the stored draft to the database and updates the draft file to the
+     * latest database state.
+     */
+    public function applyDraft(Question $question): array
+    {
+        $question = $this->ensureUuid($question);
+        $path = $this->getDumpPath($question);
+
+        if (! File::exists($path)) {
+            // Nothing to apply, just regenerate dump from database state.
+            $dump = $this->makeDumpFromModel($question);
+            $data = $dump + ['meta' => [
+                'source' => 'database',
+                'exported_at' => now()->toIso8601String(),
+            ]];
+            $this->writeDump($question, $data);
+
+            return $data;
+        }
+
+        $contents = json_decode(File::get($path), true);
+        $questionData = Arr::get($contents, 'question', []);
+
+        DB::transaction(function () use ($question, $questionData) {
+            $this->applyQuestionAttributes($question, $questionData);
+            $optionMap = $this->applyOptions($question, $questionData);
+            $this->applyAnswers($question, $questionData, $optionMap);
+            $this->applyVerbHints($question, $questionData, $optionMap);
+            $this->applyVariants($question, $questionData);
+            $this->applyHints($question, $questionData);
+        });
+
+        $question->refresh()->load([
+            'answers.option',
+            'options',
+            'verbHints.option',
+            'hints',
+            'variants',
+        ]);
+
+        $dump = $this->makeDumpFromModel($question);
+        $data = $dump + ['meta' => [
+            'source' => 'database',
+            'exported_at' => now()->toIso8601String(),
+        ]];
+
+        $this->writeDump($question, $data);
+
+        return $data;
+    }
+
+    /**
+     * Builds a dump from the current database state.
+     */
+    public function makeDumpFromModel(Question $question): array
+    {
+        $relations = [
+            'answers.option',
+            'options',
+            'verbHints.option',
+            'hints',
+            'variants',
+        ];
+
+        if (Schema::hasTable('tags')) {
+            $relations[] = 'tags';
+        }
+
+        $question->loadMissing($relations);
+
+        $options = $question->options->map(function (QuestionOption $option) {
+            return [
+                'id' => $option->id,
+                'option' => $option->option,
+            ];
+        })->values();
+
+        $optionTexts = $options->pluck('option')->map(fn ($value) => trim((string) $value))->filter()->all();
+
+        $answers = $question->answers->map(function (QuestionAnswer $answer) use (&$options, &$optionTexts) {
+            $optionText = optional($answer->option)->option;
+
+            if ($optionText !== null && ! in_array($optionText, $optionTexts, true)) {
+                $options->push([
+                    'id' => optional($answer->option)->id,
+                    'option' => $optionText,
+                ]);
+                $optionTexts[] = $optionText;
+            }
+
+            return [
+                'id' => $answer->id,
+                'marker' => $answer->marker,
+                'option' => $optionText,
+            ];
+        })->values();
+
+        $verbHints = $question->verbHints->map(function (VerbHint $hint) use (&$options, &$optionTexts) {
+            $optionText = optional($hint->option)->option;
+
+            if ($optionText !== null && ! in_array($optionText, $optionTexts, true)) {
+                $options->push([
+                    'id' => optional($hint->option)->id,
+                    'option' => $optionText,
+                ]);
+                $optionTexts[] = $optionText;
+            }
+
+            return [
+                'id' => $hint->id,
+                'marker' => $hint->marker,
+                'option' => $optionText,
+            ];
+        })->values();
+
+        $variants = $question->variants->map(function (QuestionVariant $variant) {
+            return [
+                'id' => $variant->id,
+                'text' => $variant->text,
+            ];
+        })->values();
+
+        $hints = $question->hints->map(function (QuestionHint $hint) {
+            return [
+                'id' => $hint->id,
+                'provider' => $hint->provider,
+                'locale' => $hint->locale,
+                'hint' => $hint->hint,
+            ];
+        })->values();
+
+        return [
+            'question' => [
+                'id' => $question->id,
+                'uuid' => $question->uuid,
+                'question' => $question->question,
+                'difficulty' => $question->difficulty,
+                'level' => $question->level,
+                'flag' => $question->flag,
+                'category_id' => $question->category_id,
+                'source_id' => $question->source_id,
+                'options' => $options->unique('option')->values()->all(),
+                'answers' => $answers->all(),
+                'verb_hints' => $verbHints->all(),
+                'variants' => $variants->all(),
+                'hints' => $hints->all(),
+                'tags' => $question->relationLoaded('tags')
+                    ? $question->tags->map(fn ($tag) => [
+                        'id' => $tag->id,
+                        'name' => $tag->name,
+                    ])->values()->all()
+                    : [],
+            ],
+        ];
+    }
+
+    /**
+     * Ensures the storage directory exists and writes the dump to the disk.
+     */
+    private function writeDump(Question $question, array $payload): void
+    {
+        $path = $this->getDumpPath($question);
+
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+    }
+
+    private function getDumpPath(Question $question): string
+    {
+        return base_path(self::DIRECTORY . '/' . $question->uuid . '.json');
+    }
+
+    private function ensureUuid(Question $question): Question
+    {
+        if (! $question->uuid) {
+            $question->uuid = (string) Str::uuid();
+            $question->save();
+        }
+
+        return $question;
+    }
+
+    private function normalizePayload(Question $question, array $payload): array
+    {
+        $options = collect(Arr::get($payload, 'options', []))
+            ->map(function ($item) {
+                $text = trim((string) ($item['option'] ?? ''));
+
+                return [
+                    'id' => isset($item['id']) ? (int) $item['id'] : null,
+                    'option' => $text,
+                ];
+            })
+            ->filter(fn ($item) => $item['option'] !== '')
+            ->unique('option')
+            ->values()
+            ->all();
+
+        $answers = collect(Arr::get($payload, 'answers', []))
+            ->map(function ($item) {
+                $marker = trim((string) ($item['marker'] ?? ''));
+                $option = trim((string) ($item['option'] ?? ''));
+
+                return [
+                    'id' => isset($item['id']) ? (int) $item['id'] : null,
+                    'marker' => $marker,
+                    'option' => $option,
+                ];
+            })
+            ->filter(fn ($item) => $item['marker'] !== '' && $item['option'] !== '')
+            ->values()
+            ->all();
+
+        $verbHints = collect(Arr::get($payload, 'verb_hints', []))
+            ->map(function ($item) {
+                $marker = trim((string) ($item['marker'] ?? ''));
+                $option = trim((string) ($item['option'] ?? ''));
+
+                return [
+                    'id' => isset($item['id']) ? (int) $item['id'] : null,
+                    'marker' => $marker,
+                    'option' => $option,
+                ];
+            })
+            ->filter(fn ($item) => $item['marker'] !== '' && $item['option'] !== '')
+            ->values()
+            ->all();
+
+        $variants = collect(Arr::get($payload, 'variants', []))
+            ->map(function ($item) {
+                $text = trim((string) ($item['text'] ?? ''));
+
+                return [
+                    'id' => isset($item['id']) ? (int) $item['id'] : null,
+                    'text' => $text,
+                ];
+            })
+            ->filter(fn ($item) => $item['text'] !== '')
+            ->values()
+            ->all();
+
+        $hints = collect(Arr::get($payload, 'hints', []))
+            ->map(function ($item) {
+                $provider = trim((string) ($item['provider'] ?? ''));
+                $locale = trim((string) ($item['locale'] ?? ''));
+                $hint = trim((string) ($item['hint'] ?? ''));
+
+                return [
+                    'id' => isset($item['id']) ? (int) $item['id'] : null,
+                    'provider' => $provider,
+                    'locale' => $locale,
+                    'hint' => $hint,
+                ];
+            })
+            ->filter(fn ($item) => $item['provider'] !== '' && $item['locale'] !== '' && $item['hint'] !== '')
+            ->values()
+            ->all();
+
+        return [
+            'id' => $question->id,
+            'uuid' => $question->uuid,
+            'question' => (string) Arr::get($payload, 'question', ''),
+            'difficulty' => $this->nullableValue(Arr::get($payload, 'difficulty')),
+            'level' => $this->nullableValue(Arr::get($payload, 'level')),
+            'flag' => $this->nullableInteger(Arr::get($payload, 'flag')),
+            'category_id' => $this->nullableInteger(Arr::get($payload, 'category_id')),
+            'source_id' => $this->nullableInteger(Arr::get($payload, 'source_id')),
+            'options' => $options,
+            'answers' => $answers,
+            'verb_hints' => $verbHints,
+            'variants' => $variants,
+            'hints' => $hints,
+            'tags' => collect(Arr::get($payload, 'tags', []))
+                ->map(fn ($tag) => [
+                    'id' => isset($tag['id']) ? (int) $tag['id'] : null,
+                    'name' => (string) ($tag['name'] ?? ''),
+                ])
+                ->filter(fn ($tag) => $tag['id'] !== null || $tag['name'] !== '')
+                ->values()
+                ->all(),
+        ];
+    }
+
+    private function applyQuestionAttributes(Question $question, array $payload): void
+    {
+        $question->fill([
+            'question' => (string) Arr::get($payload, 'question', $question->question),
+            'difficulty' => $this->nullableValue(Arr::get($payload, 'difficulty')),
+            'level' => $this->nullableValue(Arr::get($payload, 'level')),
+            'flag' => $this->nullableInteger(Arr::get($payload, 'flag')),
+            'category_id' => $this->nullableInteger(Arr::get($payload, 'category_id')),
+            'source_id' => $this->nullableInteger(Arr::get($payload, 'source_id')),
+        ]);
+
+        $question->save();
+    }
+
+    /**
+     * Returns a map of option text to the QuestionOption model instance.
+     *
+     * @return array<string, QuestionOption>
+     */
+    private function applyOptions(Question $question, array $payload): array
+    {
+        $options = collect(Arr::get($payload, 'options', []))
+            ->map(fn ($item) => trim((string) ($item['option'] ?? '')))
+            ->filter()
+            ->unique()
+            ->values();
+
+        $answerOptions = collect(Arr::get($payload, 'answers', []))
+            ->map(fn ($item) => trim((string) ($item['option'] ?? '')))
+            ->filter();
+
+        $verbHintOptions = collect(Arr::get($payload, 'verb_hints', []))
+            ->map(fn ($item) => trim((string) ($item['option'] ?? '')))
+            ->filter();
+
+        $allOptions = $options
+            ->merge($answerOptions)
+            ->merge($verbHintOptions)
+            ->filter()
+            ->unique()
+            ->values();
+
+        $optionMap = [];
+        $optionIds = [];
+
+        foreach ($allOptions as $text) {
+            /** @var QuestionOption $model */
+            $model = QuestionOption::firstOrCreate(['option' => $text]);
+            $optionMap[$text] = $model;
+            $optionIds[$model->id] = ['flag' => 0];
+        }
+
+        if (! empty($optionIds)) {
+            $question->options()->sync($optionIds);
+        } else {
+            $question->options()->detach();
+        }
+
+        return $optionMap;
+    }
+
+    private function applyAnswers(Question $question, array $payload, array $optionMap): void
+    {
+        $answers = collect(Arr::get($payload, 'answers', []));
+
+        $keptIds = [];
+
+        foreach ($answers as $item) {
+            $marker = trim((string) ($item['marker'] ?? ''));
+            $option = trim((string) ($item['option'] ?? ''));
+
+            if ($marker === '' || $option === '' || ! isset($optionMap[$option])) {
+                continue;
+            }
+
+            $attributes = [
+                'marker' => $marker,
+                'option_id' => $optionMap[$option]->id,
+            ];
+
+            if (! empty($item['id'])) {
+                $answer = QuestionAnswer::where('id', $item['id'])->where('question_id', $question->id)->first();
+
+                if ($answer) {
+                    $answer->fill($attributes);
+                    $answer->save();
+                    $keptIds[] = $answer->id;
+
+                    continue;
+                }
+            }
+
+            $answer = $question->answers()->create($attributes);
+            $keptIds[] = $answer->id;
+        }
+
+        if (! empty($keptIds)) {
+            $question->answers()->whereNotIn('id', $keptIds)->delete();
+        } else {
+            $question->answers()->delete();
+        }
+    }
+
+    private function applyVerbHints(Question $question, array $payload, array $optionMap): void
+    {
+        $verbHints = collect(Arr::get($payload, 'verb_hints', []));
+        $keptIds = [];
+
+        foreach ($verbHints as $item) {
+            $marker = trim((string) ($item['marker'] ?? ''));
+            $option = trim((string) ($item['option'] ?? ''));
+
+            if ($marker === '' || $option === '' || ! isset($optionMap[$option])) {
+                continue;
+            }
+
+            $attributes = [
+                'marker' => $marker,
+                'option_id' => $optionMap[$option]->id,
+            ];
+
+            if (! empty($item['id'])) {
+                $verbHint = VerbHint::where('id', $item['id'])->where('question_id', $question->id)->first();
+
+                if ($verbHint) {
+                    $verbHint->fill($attributes);
+                    $verbHint->save();
+                    $keptIds[] = $verbHint->id;
+
+                    continue;
+                }
+            }
+
+            $verbHint = $question->verbHints()->create($attributes);
+            $keptIds[] = $verbHint->id;
+        }
+
+        if (! empty($keptIds)) {
+            $question->verbHints()->whereNotIn('id', $keptIds)->delete();
+        } else {
+            $question->verbHints()->delete();
+        }
+    }
+
+    private function applyVariants(Question $question, array $payload): void
+    {
+        $variants = collect(Arr::get($payload, 'variants', []));
+        $keptIds = [];
+
+        foreach ($variants as $item) {
+            $text = trim((string) ($item['text'] ?? ''));
+
+            if ($text === '') {
+                continue;
+            }
+
+            if (! empty($item['id'])) {
+                $variant = QuestionVariant::where('id', $item['id'])->where('question_id', $question->id)->first();
+
+                if ($variant) {
+                    $variant->text = $text;
+                    $variant->save();
+                    $keptIds[] = $variant->id;
+
+                    continue;
+                }
+            }
+
+            $variant = $question->variants()->create(['text' => $text]);
+            $keptIds[] = $variant->id;
+        }
+
+        if (! empty($keptIds)) {
+            $question->variants()->whereNotIn('id', $keptIds)->delete();
+        } else {
+            $question->variants()->delete();
+        }
+    }
+
+    private function applyHints(Question $question, array $payload): void
+    {
+        $hints = collect(Arr::get($payload, 'hints', []));
+        $keptIds = [];
+
+        foreach ($hints as $item) {
+            $provider = trim((string) ($item['provider'] ?? ''));
+            $locale = trim((string) ($item['locale'] ?? ''));
+            $hintText = trim((string) ($item['hint'] ?? ''));
+
+            if ($provider === '' || $locale === '' || $hintText === '') {
+                continue;
+            }
+
+            $attributes = [
+                'provider' => $provider,
+                'locale' => $locale,
+                'hint' => $hintText,
+            ];
+
+            if (! empty($item['id'])) {
+                $hint = QuestionHint::where('id', $item['id'])->where('question_id', $question->id)->first();
+
+                if ($hint) {
+                    $hint->fill($attributes);
+                    $hint->save();
+                    $keptIds[] = $hint->id;
+
+                    continue;
+                }
+            }
+
+            $hint = $question->hints()->create($attributes);
+            $keptIds[] = $hint->id;
+        }
+
+        if (! empty($keptIds)) {
+            $question->hints()->whereNotIn('id', $keptIds)->delete();
+        } else {
+            $question->hints()->delete();
+        }
+    }
+
+    private function nullableValue(mixed $value): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+
+    private function nullableInteger(mixed $value): ?int
+    {
+        if ($value === '' || $value === null) {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+}

--- a/public/js/tech-editor.js
+++ b/public/js/tech-editor.js
@@ -1,0 +1,738 @@
+(function () {
+    const csrfTokenElement = document.querySelector('meta[name="csrf-token"]');
+    const csrfToken = csrfTokenElement ? csrfTokenElement.getAttribute('content') || '' : '';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('[data-tech-editor]').forEach(function (root) {
+            TechQuestionEditor(root, csrfToken);
+        });
+    });
+
+    function TechQuestionEditor(root, csrf) {
+        const saveUrl = root.dataset.saveUrl || null;
+        const applyUrl = root.dataset.applyUrl || null;
+        const dumpUrl = root.dataset.dumpUrl || null;
+        const statusEl = root.querySelector('[data-role="status"]');
+        const dumpViewer = root.querySelector('[data-role="dump-viewer"]');
+
+        let saveTimer = null;
+        let saving = false;
+        let changeQueued = false;
+        let applyRequested = false;
+        let lastSaveFailed = false;
+
+        bindBaseInputs();
+        bindExistingRows();
+        bindActions();
+        refreshOptionChoices();
+        ensureAllPlaceholders();
+
+        function bindBaseInputs() {
+            const baseFields = ['question', 'difficulty', 'level', 'flag', 'category_id', 'source_id'];
+            baseFields.forEach(function (field) {
+                const element = root.querySelector('[data-field="' + field + '"]');
+                if (!element) {
+                    return;
+                }
+                const eventName = element.tagName === 'SELECT' ? 'change' : 'input';
+                element.addEventListener(eventName, queueSave);
+            });
+        }
+
+        function bindExistingRows() {
+            root.querySelectorAll('[data-collection="options"] [data-role="option"]').forEach(bindOptionRow);
+            root.querySelectorAll('[data-collection="answers"] [data-role="answer"]').forEach(bindAnswerRow);
+            root.querySelectorAll('[data-collection="verb-hints"] [data-role="verb-hint"]').forEach(bindVerbHintRow);
+            root.querySelectorAll('[data-collection="variants"] [data-role="variant"]').forEach(bindVariantRow);
+            root.querySelectorAll('[data-collection="hints"] [data-role="hint"]').forEach(bindHintRow);
+
+            root.querySelectorAll('[data-collection]').forEach(function (container) {
+                if (container.querySelector('[data-role]')) {
+                    removePlaceholder(container);
+                }
+            });
+        }
+
+        function bindActions() {
+            const addOptionButton = root.querySelector('[data-action="add-option"]');
+            const addAnswerButton = root.querySelector('[data-action="add-answer"]');
+            const addVerbHintButton = root.querySelector('[data-action="add-verb-hint"]');
+            const addVariantButton = root.querySelector('[data-action="add-variant"]');
+            const addHintButton = root.querySelector('[data-action="add-hint"]');
+            const applyButton = root.querySelector('[data-action="apply"]');
+            const refreshDumpButton = root.querySelector('[data-action="refresh-dump"]');
+
+            if (addOptionButton) {
+                addOptionButton.addEventListener('click', function () {
+                    const container = root.querySelector('[data-collection="options"]');
+                    const row = cloneTemplate('option');
+                    if (!container || !row) {
+                        return;
+                    }
+                    removePlaceholder(container);
+                    container.appendChild(row);
+                    bindOptionRow(row);
+                    refreshOptionChoices();
+                    queueSave();
+                    const optionInput = row.querySelector('[data-field="option-text"]');
+                    if (optionInput) {
+                        optionInput.focus();
+                    }
+                });
+            }
+
+            if (addAnswerButton) {
+                addAnswerButton.addEventListener('click', function () {
+                    const container = root.querySelector('[data-collection="answers"]');
+                    const row = cloneTemplate('answer');
+                    if (!container || !row) {
+                        return;
+                    }
+                    removePlaceholder(container);
+                    container.appendChild(row);
+                    bindAnswerRow(row);
+                    refreshOptionChoices();
+                    queueSave();
+                    const markerInput = row.querySelector('[data-field="answer-marker"]');
+                    if (markerInput) {
+                        markerInput.focus();
+                    }
+                });
+            }
+
+            if (addVerbHintButton) {
+                addVerbHintButton.addEventListener('click', function () {
+                    const container = root.querySelector('[data-collection="verb-hints"]');
+                    const row = cloneTemplate('verb-hint');
+                    if (!container || !row) {
+                        return;
+                    }
+                    removePlaceholder(container);
+                    container.appendChild(row);
+                    bindVerbHintRow(row);
+                    refreshOptionChoices();
+                    queueSave();
+                    const markerInput = row.querySelector('[data-field="verb-marker"]');
+                    if (markerInput) {
+                        markerInput.focus();
+                    }
+                });
+            }
+
+            if (addVariantButton) {
+                addVariantButton.addEventListener('click', function () {
+                    const container = root.querySelector('[data-collection="variants"]');
+                    const row = cloneTemplate('variant');
+                    if (!container || !row) {
+                        return;
+                    }
+                    removePlaceholder(container);
+                    container.appendChild(row);
+                    bindVariantRow(row);
+                    queueSave();
+                    const textarea = row.querySelector('textarea');
+                    if (textarea) {
+                        textarea.focus();
+                    }
+                });
+            }
+
+            if (addHintButton) {
+                addHintButton.addEventListener('click', function () {
+                    const container = root.querySelector('[data-collection="hints"]');
+                    const row = cloneTemplate('hint');
+                    if (!container || !row) {
+                        return;
+                    }
+                    removePlaceholder(container);
+                    container.appendChild(row);
+                    bindHintRow(row);
+                    queueSave();
+                    const providerInput = row.querySelector('[data-field="hint-provider"]');
+                    if (providerInput) {
+                        providerInput.focus();
+                    }
+                });
+            }
+
+            if (applyButton) {
+                applyButton.addEventListener('click', function () {
+                    if (!applyUrl) {
+                        return;
+                    }
+
+                    if (saveTimer) {
+                        window.clearTimeout(saveTimer);
+                        saveTimer = null;
+                    }
+
+                    if (saving) {
+                        applyRequested = true;
+                        setStatus('Очікуємо завершення збереження...', 'info');
+                        return;
+                    }
+
+                    if (changeQueued) {
+                        applyRequested = true;
+                        triggerSave();
+                    } else {
+                        applyChanges();
+                    }
+                });
+            }
+
+            if (refreshDumpButton) {
+                refreshDumpButton.addEventListener('click', function () {
+                    if (!dumpUrl) {
+                        return;
+                    }
+                    setStatus('Оновлення дампу...', 'info');
+                    fetch(dumpUrl, {
+                        headers: { 'Accept': 'application/json' },
+                    })
+                        .then(function (response) {
+                            if (!response.ok) {
+                                throw new Error('failed');
+                            }
+                            return response.json();
+                        })
+                        .then(function (data) {
+                            updateDump(data);
+                            setStatus('Дамп оновлено', 'success');
+                        })
+                        .catch(function (error) {
+                            console.error(error);
+                            setStatus('Не вдалося завантажити дамп', 'error');
+                        });
+                });
+            }
+        }
+
+        function queueSave() {
+            changeQueued = true;
+            if (saveTimer) {
+                window.clearTimeout(saveTimer);
+            }
+            saveTimer = window.setTimeout(function () {
+                saveTimer = null;
+                if (!saving) {
+                    triggerSave();
+                }
+            }, 600);
+        }
+
+        function triggerSave() {
+            if (!saveUrl) {
+                return;
+            }
+
+            if (saveTimer) {
+                window.clearTimeout(saveTimer);
+                saveTimer = null;
+            }
+
+            const payload = { question: collectData() };
+            changeQueued = false;
+            saving = true;
+            lastSaveFailed = false;
+            setStatus('Збереження...', 'info');
+
+            fetch(saveUrl, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-CSRF-TOKEN': csrf,
+                },
+                body: JSON.stringify(payload),
+            })
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('failed');
+                    }
+                    return response.json();
+                })
+                .then(function (data) {
+                    setStatus('Чернетку збережено', 'success');
+                    updateDump(data.draft || null);
+                    updateRowIds(data.draft && data.draft.question ? data.draft.question : null);
+                })
+                .catch(function (error) {
+                    console.error(error);
+                    lastSaveFailed = true;
+                    changeQueued = true;
+                    setStatus('Не вдалося зберегти зміни', 'error');
+                })
+                .finally(function () {
+                    saving = false;
+
+                    if (changeQueued && !lastSaveFailed) {
+                        triggerSave();
+                        return;
+                    }
+
+                    if (applyRequested) {
+                        const shouldApply = !lastSaveFailed;
+                        applyRequested = false;
+                        if (shouldApply) {
+                            applyChanges();
+                        }
+                    }
+                });
+        }
+
+        function collectData() {
+            const data = {
+                id: root.dataset.questionId ? Number(root.dataset.questionId) : null,
+                uuid: root.dataset.questionUuid || null,
+                question: valueOf('[data-field="question"]'),
+                difficulty: valueOf('[data-field="difficulty"]'),
+                level: valueOf('[data-field="level"]'),
+                flag: valueOf('[data-field="flag"]'),
+                category_id: valueOf('[data-field="category_id"]'),
+                source_id: valueOf('[data-field="source_id"]'),
+                options: [],
+                answers: [],
+                verb_hints: [],
+                variants: [],
+                hints: [],
+            };
+
+            root.querySelectorAll('[data-collection="options"] [data-role="option"]').forEach(function (row) {
+                const optionInput = row.querySelector('[data-field="option-text"]');
+                data.options.push({
+                    id: row.dataset.id ? Number(row.dataset.id) : null,
+                    option: optionInput ? optionInput.value : '',
+                });
+            });
+
+            root.querySelectorAll('[data-collection="answers"] [data-role="answer"]').forEach(function (row) {
+                data.answers.push({
+                    id: row.dataset.id ? Number(row.dataset.id) : null,
+                    marker: valueFrom(row, '[data-field="answer-marker"]'),
+                    option: valueFrom(row, '[data-field="answer-option"]'),
+                });
+            });
+
+            root.querySelectorAll('[data-collection="verb-hints"] [data-role="verb-hint"]').forEach(function (row) {
+                data.verb_hints.push({
+                    id: row.dataset.id ? Number(row.dataset.id) : null,
+                    marker: valueFrom(row, '[data-field="verb-marker"]'),
+                    option: valueFrom(row, '[data-field="verb-option"]'),
+                });
+            });
+
+            root.querySelectorAll('[data-collection="variants"] [data-role="variant"]').forEach(function (row) {
+                data.variants.push({
+                    id: row.dataset.id ? Number(row.dataset.id) : null,
+                    text: valueFrom(row, '[data-field="variant-text"]'),
+                });
+            });
+
+            root.querySelectorAll('[data-collection="hints"] [data-role="hint"]').forEach(function (row) {
+                data.hints.push({
+                    id: row.dataset.id ? Number(row.dataset.id) : null,
+                    provider: valueFrom(row, '[data-field="hint-provider"]'),
+                    locale: valueFrom(row, '[data-field="hint-locale"]'),
+                    hint: valueFrom(row, '[data-field="hint-text"]'),
+                });
+            });
+
+            return data;
+        }
+
+        function valueOf(selector) {
+            const element = root.querySelector(selector);
+            return element ? element.value : '';
+        }
+
+        function valueFrom(parent, selector) {
+            const element = parent.querySelector(selector);
+            return element ? element.value : '';
+        }
+
+        function setStatus(message, type) {
+            if (!statusEl) {
+                return;
+            }
+
+            statusEl.textContent = message;
+            statusEl.classList.remove('text-emerald-600', 'text-red-600', 'text-stone-500');
+
+            switch (type) {
+                case 'success':
+                    statusEl.classList.add('text-emerald-600');
+                    break;
+                case 'error':
+                    statusEl.classList.add('text-red-600');
+                    break;
+                default:
+                    statusEl.classList.add('text-stone-500');
+                    break;
+            }
+        }
+
+        function updateDump(draft) {
+            if (!dumpViewer || !draft) {
+                return;
+            }
+
+            try {
+                dumpViewer.textContent = JSON.stringify(draft, null, 2);
+            } catch (error) {
+                console.error(error);
+            }
+        }
+
+        function updateRowIds(questionData) {
+            if (!questionData) {
+                return;
+            }
+
+            assignIds('options', questionData.options || []);
+            assignIds('answers', questionData.answers || []);
+            assignIds('verb-hints', questionData.verb_hints || []);
+            assignIds('variants', questionData.variants || []);
+            assignIds('hints', questionData.hints || []);
+            refreshOptionChoices();
+            restoreSelections('answers');
+            restoreSelections('verb-hints');
+        }
+
+        function assignIds(collectionName, items) {
+            const container = root.querySelector('[data-collection="' + collectionName + '"]');
+            if (!container) {
+                return;
+            }
+            const rows = Array.from(container.querySelectorAll('[data-role]'));
+            rows.forEach(function (row, index) {
+                const item = items[index];
+                row.dataset.id = item && item.id ? item.id : '';
+                if (collectionName === 'answers' || collectionName === 'verb-hints') {
+                    row.dataset.selectedOption = item && item.option ? item.option : '';
+                }
+            });
+        }
+
+        function refreshOptionChoices() {
+            const values = Array.from(root.querySelectorAll('[data-collection="options"] [data-field="option-text"]'))
+                .map(function (input) { return input.value || ''; })
+                .filter(function (text) { return text.trim() !== ''; });
+            const uniqueValues = Array.from(new Set(values));
+
+            root.querySelectorAll('select[data-field="answer-option"], select[data-field="verb-option"]').forEach(function (select) {
+                const current = select.value;
+                select.innerHTML = '';
+                const emptyOption = document.createElement('option');
+                emptyOption.value = '';
+                select.appendChild(emptyOption);
+
+                uniqueValues.forEach(function (text) {
+                    const option = document.createElement('option');
+                    option.value = text;
+                    option.textContent = text;
+                    select.appendChild(option);
+                });
+
+                if (current && uniqueValues.includes(current)) {
+                    select.value = current;
+                }
+            });
+        }
+
+        function bindOptionRow(row) {
+            const input = row.querySelector('[data-field="option-text"]');
+            const removeButton = row.querySelector('[data-action="remove-option"]');
+
+            if (input) {
+                input.addEventListener('input', function () {
+                    refreshOptionChoices();
+                    queueSave();
+                });
+            }
+
+            if (removeButton) {
+                removeButton.addEventListener('click', function () {
+                    const container = row.closest('[data-collection]');
+                    row.remove();
+                    refreshOptionChoices();
+                    ensurePlaceholder(container);
+                    queueSave();
+                });
+            }
+        }
+
+        function bindAnswerRow(row) {
+            const marker = row.querySelector('[data-field="answer-marker"]');
+            const option = row.querySelector('[data-field="answer-option"]');
+            const removeButton = row.querySelector('[data-action="remove-answer"]');
+
+            if (marker) {
+                marker.addEventListener('input', queueSave);
+            }
+            if (option) {
+                option.addEventListener('change', queueSave);
+            }
+            if (removeButton) {
+                removeButton.addEventListener('click', function () {
+                    const container = row.closest('[data-collection]');
+                    row.remove();
+                    ensurePlaceholder(container);
+                    queueSave();
+                });
+            }
+        }
+
+        function bindVerbHintRow(row) {
+            const marker = row.querySelector('[data-field="verb-marker"]');
+            const option = row.querySelector('[data-field="verb-option"]');
+            const removeButton = row.querySelector('[data-action="remove-verb-hint"]');
+
+            if (marker) {
+                marker.addEventListener('input', queueSave);
+            }
+            if (option) {
+                option.addEventListener('change', queueSave);
+            }
+            if (removeButton) {
+                removeButton.addEventListener('click', function () {
+                    const container = row.closest('[data-collection]');
+                    row.remove();
+                    ensurePlaceholder(container);
+                    queueSave();
+                });
+            }
+        }
+
+        function bindVariantRow(row) {
+            const textarea = row.querySelector('[data-field="variant-text"]');
+            const removeButton = row.querySelector('[data-action="remove-variant"]');
+
+            if (textarea) {
+                textarea.addEventListener('input', queueSave);
+            }
+            if (removeButton) {
+                removeButton.addEventListener('click', function () {
+                    const container = row.closest('[data-collection]');
+                    row.remove();
+                    ensurePlaceholder(container);
+                    queueSave();
+                });
+            }
+        }
+
+        function bindHintRow(row) {
+            const provider = row.querySelector('[data-field="hint-provider"]');
+            const locale = row.querySelector('[data-field="hint-locale"]');
+            const hint = row.querySelector('[data-field="hint-text"]');
+            const removeButton = row.querySelector('[data-action="remove-hint"]');
+
+            if (provider) {
+                provider.addEventListener('input', queueSave);
+            }
+            if (locale) {
+                locale.addEventListener('input', queueSave);
+            }
+            if (hint) {
+                hint.addEventListener('input', queueSave);
+            }
+            if (removeButton) {
+                removeButton.addEventListener('click', function () {
+                    const container = row.closest('[data-collection]');
+                    row.remove();
+                    ensurePlaceholder(container);
+                    queueSave();
+                });
+            }
+        }
+
+        function cloneTemplate(name) {
+            const template = root.querySelector('template[data-template="' + name + '"]');
+            if (!template || !template.content || !template.content.firstElementChild) {
+                return null;
+            }
+            return template.content.firstElementChild.cloneNode(true);
+        }
+
+        function applyChanges() {
+            if (!applyUrl) {
+                return;
+            }
+            setStatus('Застосування...', 'info');
+            fetch(applyUrl, {
+                method: 'POST',
+                headers: {
+                    'Accept': 'application/json',
+                    'X-CSRF-TOKEN': csrf,
+                },
+            })
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('failed');
+                    }
+                    return response.json();
+                })
+                .then(function (data) {
+                    const questionData = data.draft && data.draft.question ? data.draft.question : null;
+                    if (questionData) {
+                        renderFromData(questionData);
+                    }
+                    updateDump(data.draft || null);
+                    changeQueued = false;
+                    setStatus('Зміни застосовано', 'success');
+                })
+                .catch(function (error) {
+                    console.error(error);
+                    setStatus('Не вдалося застосувати зміни', 'error');
+                });
+        }
+
+        function renderFromData(questionData) {
+            if (!questionData) {
+                return;
+            }
+
+            ['question', 'difficulty', 'level', 'flag', 'category_id', 'source_id'].forEach(function (field) {
+                const element = root.querySelector('[data-field="' + field + '"]');
+                if (element) {
+                    element.value = questionData[field] || '';
+                }
+            });
+
+            rebuildCollection('options', questionData.options || []);
+            rebuildCollection('answers', questionData.answers || []);
+            rebuildCollection('verb-hints', questionData.verb_hints || []);
+            rebuildCollection('variants', questionData.variants || []);
+            rebuildCollection('hints', questionData.hints || []);
+
+            refreshOptionChoices();
+            restoreSelections('answers');
+            restoreSelections('verb-hints');
+            ensureAllPlaceholders();
+        }
+
+        function rebuildCollection(name, items) {
+            const container = root.querySelector('[data-collection="' + name + '"]');
+            if (!container) {
+                return;
+            }
+
+            container.innerHTML = '';
+
+            if (!Array.isArray(items) || items.length === 0) {
+                ensurePlaceholder(container);
+                return;
+            }
+
+            const templateNameMap = {
+                options: 'option',
+                answers: 'answer',
+                'verb-hints': 'verb-hint',
+                variants: 'variant',
+                hints: 'hint',
+            };
+
+            const templateName = templateNameMap[name];
+
+            items.forEach(function (item) {
+                const row = cloneTemplate(templateName);
+                if (!row) {
+                    return;
+                }
+
+                row.dataset.id = item && item.id ? item.id : '';
+
+                if (name === 'options') {
+                    const input = row.querySelector('[data-field="option-text"]');
+                    if (input) {
+                        input.value = item && item.option ? item.option : '';
+                    }
+                    bindOptionRow(row);
+                } else if (name === 'answers') {
+                    const marker = row.querySelector('[data-field="answer-marker"]');
+                    if (marker) {
+                        marker.value = item && item.marker ? item.marker : '';
+                    }
+                    row.dataset.selectedOption = item && item.option ? item.option : '';
+                    bindAnswerRow(row);
+                } else if (name === 'verb-hints') {
+                    const marker = row.querySelector('[data-field="verb-marker"]');
+                    if (marker) {
+                        marker.value = item && item.marker ? item.marker : '';
+                    }
+                    row.dataset.selectedOption = item && item.option ? item.option : '';
+                    bindVerbHintRow(row);
+                } else if (name === 'variants') {
+                    const textarea = row.querySelector('[data-field="variant-text"]');
+                    if (textarea) {
+                        textarea.value = item && item.text ? item.text : '';
+                    }
+                    bindVariantRow(row);
+                } else if (name === 'hints') {
+                    const provider = row.querySelector('[data-field="hint-provider"]');
+                    const locale = row.querySelector('[data-field="hint-locale"]');
+                    const hint = row.querySelector('[data-field="hint-text"]');
+                    if (provider) {
+                        provider.value = item && item.provider ? item.provider : '';
+                    }
+                    if (locale) {
+                        locale.value = item && item.locale ? item.locale : '';
+                    }
+                    if (hint) {
+                        hint.value = item && item.hint ? item.hint : '';
+                    }
+                    bindHintRow(row);
+                }
+
+                container.appendChild(row);
+            });
+        }
+
+        function restoreSelections(collectionName) {
+            const selector = collectionName === 'answers' ? '[data-field="answer-option"]' : '[data-field="verb-option"]';
+            root.querySelectorAll('[data-collection="' + collectionName + '"] [data-role]').forEach(function (row) {
+                const select = row.querySelector(selector);
+                const value = row.dataset.selectedOption || '';
+                if (select) {
+                    select.value = value;
+                }
+                delete row.dataset.selectedOption;
+            });
+        }
+
+        function ensurePlaceholder(container) {
+            if (!container) {
+                return;
+            }
+            removePlaceholder(container);
+            const hasRows = container.querySelector('[data-role]');
+            if (hasRows) {
+                return;
+            }
+            const text = container.dataset.emptyText || '';
+            if (!text) {
+                return;
+            }
+            const placeholder = document.createElement('p');
+            placeholder.dataset.role = 'empty-message';
+            placeholder.className = 'text-sm text-stone-500';
+            placeholder.textContent = text;
+            container.appendChild(placeholder);
+        }
+
+        function removePlaceholder(container) {
+            if (!container) {
+                return;
+            }
+            container.querySelectorAll('[data-role="empty-message"]').forEach(function (element) {
+                element.remove();
+            });
+        }
+
+        function ensureAllPlaceholders() {
+            root.querySelectorAll('[data-collection]').forEach(function (container) {
+                ensurePlaceholder(container);
+            });
+        }
+    }
+})();

--- a/resources/views/engram/saved-test-tech.blade.php
+++ b/resources/views/engram/saved-test-tech.blade.php
@@ -72,6 +72,14 @@
                 ->values();
             $explanations = collect($explanationsByQuestionId[$question->id] ?? []);
             $levelLabel = $question->level ?: 'N/A';
+            $draft = $drafts->get($question->id) ?? [];
+            $draftQuestion = $draft['question'] ?? [];
+            $draftMeta = $draft['meta'] ?? [];
+            $draftOptions = collect($draftQuestion['options'] ?? []);
+            $draftAnswers = collect($draftQuestion['answers'] ?? []);
+            $draftVerbHints = collect($draftQuestion['verb_hints'] ?? []);
+            $draftVariants = collect($draftQuestion['variants'] ?? []);
+            $draftHints = collect($draftQuestion['hints'] ?? []);
         @endphp
         <article class="bg-white shadow rounded-2xl p-6 space-y-5 border border-stone-100">
             <header class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -221,7 +229,413 @@
                     </div>
                 </details>
             @endif
+
+            <section class="mt-6 border-t border-dashed border-stone-200 pt-6">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                    <h3 class="text-lg font-semibold text-stone-900">Редагування питання</h3>
+                    <div class="flex flex-wrap items-center gap-2 text-xs text-stone-500 sm:text-sm">
+                        @if(($draftMeta['source'] ?? '') === 'draft')
+                            <span class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-3 py-1 text-amber-800">
+                                Незастосовані зміни
+                            </span>
+                        @else
+                            <span class="inline-flex items-center gap-1 rounded-full bg-stone-200 px-3 py-1 text-stone-700">
+                                Дані з бази
+                            </span>
+                        @endif
+                        @if(!empty($draftMeta['exported_at']))
+                            <span class="font-medium text-stone-500">
+                                Оновлено: {{ $draftMeta['exported_at'] }}
+                            </span>
+                        @endif
+                    </div>
+                </div>
+
+                <div
+                    class="mt-4 space-y-6 rounded-2xl border border-stone-200 bg-white/80 p-4 shadow-sm"
+                    data-tech-editor
+                    data-question-id="{{ $question->id }}"
+                    data-question-uuid="{{ $question->uuid }}"
+                    data-save-url="{{ route('saved-test.tech.question.draft.update', [$test->slug, $question]) }}"
+                    data-apply-url="{{ route('saved-test.tech.question.apply', [$test->slug, $question]) }}"
+                    data-dump-url="{{ route('saved-test.tech.question.dump', [$test->slug, $question]) }}"
+                    data-draft-source="{{ $draftMeta['source'] ?? 'database' }}"
+                >
+                    <div class="space-y-4">
+                        <div>
+                            <label class="block text-sm font-semibold text-stone-700">Текст питання</label>
+                            <textarea
+                                rows="3"
+                                data-field="question"
+                                class="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200">{{ $draftQuestion['question'] ?? $question->question }}</textarea>
+                        </div>
+                        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                            <div>
+                                <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Складність</label>
+                                <input
+                                    type="text"
+                                    data-field="difficulty"
+                                    value="{{ $draftQuestion['difficulty'] ?? '' }}"
+                                    class="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                >
+                            </div>
+                            <div>
+                                <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Рівень</label>
+                                <input
+                                    type="text"
+                                    data-field="level"
+                                    value="{{ $draftQuestion['level'] ?? '' }}"
+                                    class="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                >
+                            </div>
+                            <div>
+                                <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Прапорець</label>
+                                <input
+                                    type="number"
+                                    data-field="flag"
+                                    value="{{ $draftQuestion['flag'] ?? '' }}"
+                                    class="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                >
+                            </div>
+                            <div>
+                                <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Категорія ID</label>
+                                <input
+                                    type="number"
+                                    data-field="category_id"
+                                    value="{{ $draftQuestion['category_id'] ?? '' }}"
+                                    class="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                >
+                            </div>
+                            <div>
+                                <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Джерело ID</label>
+                                <input
+                                    type="number"
+                                    data-field="source_id"
+                                    value="{{ $draftQuestion['source_id'] ?? '' }}"
+                                    class="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                >
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="space-y-3">
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                            <h4 class="text-sm font-semibold uppercase tracking-wide text-stone-500">Варіанти відповіді</h4>
+                            <button
+                                type="button"
+                                class="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700 hover:bg-blue-100"
+                                data-action="add-option"
+                            >
+                                Додати варіант
+                            </button>
+                        </div>
+                        <div class="space-y-2" data-collection="options" data-empty-text="Варіанти поки не додані.">
+                            @forelse($draftOptions as $option)
+                                <div
+                                    class="flex flex-wrap items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 py-2 shadow-sm"
+                                    data-role="option"
+                                    data-id="{{ $option['id'] ?? '' }}"
+                                >
+                                    <input
+                                        type="text"
+                                        data-field="option-text"
+                                        value="{{ $option['option'] ?? '' }}"
+                                        class="min-w-[120px] flex-1 rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                    >
+                                    <button
+                                        type="button"
+                                        class="inline-flex items-center rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 hover:bg-stone-200"
+                                        data-action="remove-option"
+                                    >
+                                        Видалити
+                                    </button>
+                                </div>
+                            @empty
+                                <p class="text-sm text-stone-500" data-role="empty-message">Варіанти поки не додані.</p>
+                            @endforelse
+                        </div>
+                    </div>
+
+                    <div class="space-y-3">
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                            <h4 class="text-sm font-semibold uppercase tracking-wide text-stone-500">Правильні відповіді</h4>
+                            <button
+                                type="button"
+                                class="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700 hover:bg-blue-100"
+                                data-action="add-answer"
+                            >
+                                Додати відповідь
+                            </button>
+                        </div>
+                        <div class="space-y-2" data-collection="answers" data-empty-text="Немає відповідей.">
+                            @forelse($draftAnswers as $answer)
+                                <div
+                                    class="grid gap-2 sm:grid-cols-[100px,1fr,auto]"
+                                    data-role="answer"
+                                    data-id="{{ $answer['id'] ?? '' }}"
+                                >
+                                    <input
+                                        type="text"
+                                        placeholder="A1"
+                                        data-field="answer-marker"
+                                        value="{{ $answer['marker'] ?? '' }}"
+                                        class="rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                    >
+                                    <select
+                                        data-field="answer-option"
+                                        class="rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                    >
+                                        <option value=""></option>
+                                        @foreach($draftOptions as $option)
+                                            @php $optionText = $option['option'] ?? ''; @endphp
+                                            <option value="{{ $optionText }}" @selected($optionText === ($answer['option'] ?? ''))>{{ $optionText }}</option>
+                                        @endforeach
+                                    </select>
+                                    <button
+                                        type="button"
+                                        class="inline-flex items-center justify-center rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 hover:bg-stone-200"
+                                        data-action="remove-answer"
+                                    >
+                                        Видалити
+                                    </button>
+                                </div>
+                            @empty
+                                <p class="text-sm text-stone-500" data-role="empty-message">Немає відповідей.</p>
+                            @endforelse
+                        </div>
+                    </div>
+
+                    <div class="space-y-3">
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                            <h4 class="text-sm font-semibold uppercase tracking-wide text-stone-500">Verb hints</h4>
+                            <button
+                                type="button"
+                                class="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700 hover:bg-blue-100"
+                                data-action="add-verb-hint"
+                            >
+                                Додати hint
+                            </button>
+                        </div>
+                        <div class="space-y-2" data-collection="verb-hints" data-empty-text="Verb hints відсутні.">
+                            @forelse($draftVerbHints as $hint)
+                                <div
+                                    class="grid gap-2 sm:grid-cols-[100px,1fr,auto]"
+                                    data-role="verb-hint"
+                                    data-id="{{ $hint['id'] ?? '' }}"
+                                >
+                                    <input
+                                        type="text"
+                                        placeholder="A1"
+                                        data-field="verb-marker"
+                                        value="{{ $hint['marker'] ?? '' }}"
+                                        class="rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                    >
+                                    <select
+                                        data-field="verb-option"
+                                        class="rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                    >
+                                        <option value=""></option>
+                                        @foreach($draftOptions as $option)
+                                            @php $optionText = $option['option'] ?? ''; @endphp
+                                            <option value="{{ $optionText }}" @selected($optionText === ($hint['option'] ?? ''))>{{ $optionText }}</option>
+                                        @endforeach
+                                    </select>
+                                    <button
+                                        type="button"
+                                        class="inline-flex items-center justify-center rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 hover:bg-stone-200"
+                                        data-action="remove-verb-hint"
+                                    >
+                                        Видалити
+                                    </button>
+                                </div>
+                            @empty
+                                <p class="text-sm text-stone-500" data-role="empty-message">Verb hints відсутні.</p>
+                            @endforelse
+                        </div>
+                    </div>
+
+                    <div class="space-y-3">
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                            <h4 class="text-sm font-semibold uppercase tracking-wide text-stone-500">Варіанти запитання</h4>
+                            <button
+                                type="button"
+                                class="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700 hover:bg-blue-100"
+                                data-action="add-variant"
+                            >
+                                Додати варіант
+                            </button>
+                        </div>
+                        <div class="space-y-2" data-collection="variants" data-empty-text="Варіанти запитання відсутні.">
+                            @forelse($draftVariants as $variant)
+                                <div
+                                    class="rounded-lg border border-stone-200 bg-white p-3 shadow-sm"
+                                    data-role="variant"
+                                    data-id="{{ $variant['id'] ?? '' }}"
+                                >
+                                    <textarea
+                                        rows="2"
+                                        data-field="variant-text"
+                                        class="w-full rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200">{{ $variant['text'] ?? '' }}</textarea>
+                                    <div class="mt-2 flex justify-end">
+                                        <button
+                                            type="button"
+                                            class="inline-flex items-center rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 hover:bg-stone-200"
+                                            data-action="remove-variant"
+                                        >
+                                            Видалити
+                                        </button>
+                                    </div>
+                                </div>
+                            @empty
+                                <p class="text-sm text-stone-500" data-role="empty-message">Варіанти запитання відсутні.</p>
+                            @endforelse
+                        </div>
+                    </div>
+
+                    <div class="space-y-3">
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                            <h4 class="text-sm font-semibold uppercase tracking-wide text-stone-500">Підказки</h4>
+                            <button
+                                type="button"
+                                class="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700 hover:bg-blue-100"
+                                data-action="add-hint"
+                            >
+                                Додати підказку
+                            </button>
+                        </div>
+                        <div class="space-y-3" data-collection="hints" data-empty-text="Підказки відсутні.">
+                            @forelse($draftHints as $hint)
+                                <div
+                                    class="rounded-lg border border-stone-200 bg-white p-3 shadow-sm"
+                                    data-role="hint"
+                                    data-id="{{ $hint['id'] ?? '' }}"
+                                >
+                                    <div class="grid gap-2 sm:grid-cols-2">
+                                        <div>
+                                            <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Провайдер</label>
+                                            <input
+                                                type="text"
+                                                data-field="hint-provider"
+                                                value="{{ $hint['provider'] ?? '' }}"
+                                                class="mt-1 w-full rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                            >
+                                        </div>
+                                        <div>
+                                            <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Мова</label>
+                                            <input
+                                                type="text"
+                                                data-field="hint-locale"
+                                                value="{{ $hint['locale'] ?? '' }}"
+                                                class="mt-1 w-full rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                            >
+                                        </div>
+                                    </div>
+                                    <div class="mt-2">
+                                        <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Текст підказки</label>
+                                        <textarea
+                                            rows="2"
+                                            data-field="hint-text"
+                                            class="mt-1 w-full rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200">{{ $hint['hint'] ?? '' }}</textarea>
+                                    </div>
+                                    <div class="mt-2 flex justify-end">
+                                        <button
+                                            type="button"
+                                            class="inline-flex items-center rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 hover:bg-stone-200"
+                                            data-action="remove-hint"
+                                        >
+                                            Видалити
+                                        </button>
+                                    </div>
+                                </div>
+                            @empty
+                                <p class="text-sm text-stone-500" data-role="empty-message">Підказки відсутні.</p>
+                            @endforelse
+                        </div>
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-3 border-t border-stone-200 pt-4">
+                        <button
+                            type="button"
+                            class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-300"
+                            data-action="apply"
+                        >
+                            Застосувати зміни
+                        </button>
+                        <button
+                            type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-700 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                            data-action="refresh-dump"
+                        >
+                            Оновити дамп
+                        </button>
+                        <span class="text-sm text-stone-500" data-role="status"></span>
+                    </div>
+
+                    <details class="group rounded-xl border border-stone-200 bg-white/90 p-4">
+                        <summary class="flex cursor-pointer select-none items-center justify-between text-xs font-semibold uppercase tracking-wide text-stone-500">
+                            <span>JSON дамп</span>
+                            <span class="text-[10px] font-normal text-stone-400 group-open:hidden">Показати ▼</span>
+                            <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
+                        </summary>
+                        <pre class="mt-3 max-h-80 overflow-auto rounded-lg bg-stone-900/90 p-4 text-xs leading-relaxed text-emerald-100" data-role="dump-viewer">{{ json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) }}</pre>
+                    </details>
+
+                    <template data-template="option">
+                        <div class="flex flex-wrap items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 py-2 shadow-sm" data-role="option">
+                            <input type="text" data-field="option-text" class="min-w-[120px] flex-1 rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200">
+                            <button type="button" class="inline-flex items-center rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 hover:bg-stone-200" data-action="remove-option">Видалити</button>
+                        </div>
+                    </template>
+                    <template data-template="answer">
+                        <div class="grid gap-2 sm:grid-cols-[100px,1fr,auto]" data-role="answer">
+                            <input type="text" placeholder="A1" data-field="answer-marker" class="rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200">
+                            <select data-field="answer-option" class="rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"></select>
+                            <button type="button" class="inline-flex items-center justify-center rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 hover:bg-stone-200" data-action="remove-answer">Видалити</button>
+                        </div>
+                    </template>
+                    <template data-template="verb-hint">
+                        <div class="grid gap-2 sm:grid-cols-[100px,1fr,auto]" data-role="verb-hint">
+                            <input type="text" placeholder="A1" data-field="verb-marker" class="rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200">
+                            <select data-field="verb-option" class="rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"></select>
+                            <button type="button" class="inline-flex items-center justify-center rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 hover:bg-stone-200" data-action="remove-verb-hint">Видалити</button>
+                        </div>
+                    </template>
+                    <template data-template="variant">
+                        <div class="rounded-lg border border-stone-200 bg-white p-3 shadow-sm" data-role="variant">
+                            <textarea rows="2" data-field="variant-text" class="w-full rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"></textarea>
+                            <div class="mt-2 flex justify-end">
+                                <button type="button" class="inline-flex items-center rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 hover:bg-stone-200" data-action="remove-variant">Видалити</button>
+                            </div>
+                        </div>
+                    </template>
+                    <template data-template="hint">
+                        <div class="rounded-lg border border-stone-200 bg-white p-3 shadow-sm" data-role="hint">
+                            <div class="grid gap-2 sm:grid-cols-2">
+                                <div>
+                                    <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Провайдер</label>
+                                    <input type="text" data-field="hint-provider" class="mt-1 w-full rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200">
+                                </div>
+                                <div>
+                                    <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Мова</label>
+                                    <input type="text" data-field="hint-locale" class="mt-1 w-full rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200">
+                                </div>
+                            </div>
+                            <div class="mt-2">
+                                <label class="text-xs font-semibold uppercase tracking-wide text-stone-500">Текст підказки</label>
+                                <textarea rows="2" data-field="hint-text" class="mt-1 w-full rounded border border-stone-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"></textarea>
+                            </div>
+                            <div class="mt-2 flex justify-end">
+                                <button type="button" class="inline-flex items-center rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 hover:bg-stone-200" data-action="remove-hint">Видалити</button>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </section>
         </article>
     @endforeach
 </div>
+
+@push('scripts')
+    <script src="{{ asset('js/tech-editor.js') }}" defer></script>
+@endpush
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,6 +2,7 @@
 <html lang="uk">
 <head>
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>@yield('title', 'English App')</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -117,5 +118,6 @@
     <footer class="bg-white border-t mt-8 py-4 text-center text-sm text-gray-400">
         &copy; {{ date('Y') }} English Test Hub. All rights reserved.
     </footer>
+    @stack('scripts')
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\QuestionHelpController;
 use App\Http\Controllers\TrainController;
 use App\Http\Controllers\WordSearchController;
 use App\Http\Controllers\SiteSearchController;
+use App\Http\Controllers\TechQuestionDraftController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -74,6 +75,13 @@ Route::get('/test/{slug}/js/input', [GrammarTestController::class, 'showSavedTes
 Route::get('/test/{slug}/js/step/select', [GrammarTestController::class, 'showSavedTestJsStepSelect'])->name('saved-test.js.step-select');
 Route::get('/test/{slug}/js/select', [GrammarTestController::class, 'showSavedTestJsSelect'])->name('saved-test.js.select');
 Route::get('/test/{slug}/tech', [GrammarTestController::class, 'showSavedTestTech'])->name('saved-test.tech');
+Route::prefix('/test/{slug}/tech/question/{question}')
+    ->name('saved-test.tech.question.')
+    ->group(function () {
+        Route::get('/dump', [TechQuestionDraftController::class, 'show'])->name('dump');
+        Route::put('/draft', [TechQuestionDraftController::class, 'update'])->name('draft.update');
+        Route::post('/apply', [TechQuestionDraftController::class, 'apply'])->name('apply');
+    });
 Route::get('/test/{slug}', [GrammarTestController::class, 'showSavedTest'])->name('saved-test.show');
 Route::get('/test/{slug}/random', [GrammarTestController::class, 'showSavedTestRandom'])->name('saved-test.random');
 Route::get('/test/{slug}/step', [GrammarTestController::class, 'showSavedTestStep'])->name('saved-test.step');


### PR DESCRIPTION
## Summary
- add a dedicated service that stores, normalizes, and applies question drafts as JSON dumps tied to each question
- expose tech page AJAX endpoints for saving, viewing, and applying drafts and wire them into the existing controller and routes
- build an interactive editor on the tech page with reusable templates and a new front-end module that syncs changes without reloads
- expose CSRF metadata and script stacking so the new tooling can issue authenticated requests

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cf18013308832a851c85f06414abdb