### PR TITLE
Add editing controls for technical test page questions

### DIFF
--- a/app/Http/Controllers/QuestionAnswerController.php
+++ b/app/Http/Controllers/QuestionAnswerController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\QuestionAnswer;
+use App\Models\QuestionOption;
+use App\Models\VerbHint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class QuestionAnswerController extends Controller
+{
+    public function update(Request $request, QuestionAnswer $questionAnswer)
+    {
+        $data = $request->validate([
+            'value' => 'required|string|max:255',
+        ]);
+
+        $value = trim($data['value']);
+
+        $question = $questionAnswer->question;
+        $currentOption = $questionAnswer->relationLoaded('option')
+            ? $questionAnswer->option
+            : $questionAnswer->option()->first();
+
+        $supportsOptionReference = Schema::hasColumn('question_answers', 'option_id');
+
+        if (! $supportsOptionReference) {
+            if ($questionAnswer->answer === $value) {
+                return $this->response($request);
+            }
+
+            $questionAnswer->answer = $value;
+            $questionAnswer->save();
+
+            return $this->response($request);
+        }
+
+        if ($currentOption && $currentOption->option === $value) {
+            return $this->response($request);
+        }
+
+        DB::transaction(function () use ($questionAnswer, $question, $currentOption, $value) {
+            $newOption = QuestionOption::firstOrCreate(['option' => $value]);
+
+            $pivotQuery = DB::table('question_option_question')
+                ->where('question_id', $question->id)
+                ->where('option_id', $newOption->id);
+
+            if (Schema::hasColumn('question_option_question', 'flag')) {
+                $pivotQuery->where(function ($query) {
+                    $query->whereNull('flag')->orWhere('flag', 0);
+                });
+            }
+
+            if (! $pivotQuery->exists()) {
+                $question->options()->attach($newOption->id);
+            }
+
+            $questionAnswer->option()->associate($newOption);
+            $questionAnswer->save();
+
+            if ($currentOption && $currentOption->isNot($newOption)) {
+                $otherAnswersExist = QuestionAnswer::query()
+                    ->where('question_id', $question->id)
+                    ->where('id', '!=', $questionAnswer->id)
+                    ->where('option_id', $currentOption->id)
+                    ->exists();
+
+                if (! $otherAnswersExist) {
+                    $cleanupQuery = DB::table('question_option_question')
+                        ->where('question_id', $question->id)
+                        ->where('option_id', $currentOption->id);
+
+                    if (Schema::hasColumn('question_option_question', 'flag')) {
+                        $cleanupQuery->where(function ($query) {
+                            $query->whereNull('flag')->orWhere('flag', 0);
+                        });
+                    }
+
+                    $cleanupQuery->delete();
+                }
+
+                $stillUsed = QuestionAnswer::query()
+                    ->where('option_id', $currentOption->id)
+                    ->exists()
+                    || VerbHint::query()->where('option_id', $currentOption->id)->exists()
+                    || DB::table('question_option_question')
+                        ->where('option_id', $currentOption->id)
+                        ->exists();
+
+                if (! $stillUsed) {
+                    $currentOption->delete();
+                }
+            }
+        });
+
+        return $this->response($request);
+    }
+
+    private function response(Request $request)
+    {
+        if ($request->wantsJson()) {
+            return response()->noContent();
+        }
+
+        return redirect($request->input('from', url()->previous()));
+    }
+}

--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -10,11 +10,17 @@ class QuestionController extends Controller
     public function update(Request $request, Question $question)
     {
         $data = $request->validate([
-            'question' => 'required|string',
+            'question' => 'sometimes|required|string',
+            'level' => 'sometimes|nullable|string|max:10',
         ]);
 
-        $question->question = $data['question'];
-        $question->save();
+        if (! empty($data)) {
+            $question->fill($data);
+
+            if ($question->isDirty()) {
+                $question->save();
+            }
+        }
 
         if ($request->wantsJson()) {
             return response()->noContent();

--- a/app/Http/Controllers/QuestionHintController.php
+++ b/app/Http/Controllers/QuestionHintController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\QuestionHint;
+use Illuminate\Http\Request;
+
+class QuestionHintController extends Controller
+{
+    public function update(Request $request, QuestionHint $questionHint)
+    {
+        $data = $request->validate([
+            'hint' => 'required|string',
+        ]);
+
+        $questionHint->hint = $data['hint'];
+        $questionHint->save();
+
+        if ($request->wantsJson()) {
+            return response()->noContent();
+        }
+
+        return redirect($request->input('from', url()->previous()));
+    }
+}

--- a/app/Http/Controllers/QuestionOptionController.php
+++ b/app/Http/Controllers/QuestionOptionController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Question;
+use App\Models\QuestionAnswer;
+use App\Models\QuestionOption;
+use App\Models\VerbHint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class QuestionOptionController extends Controller
+{
+    public function update(Request $request, Question $question, QuestionOption $option)
+    {
+        $data = $request->validate([
+            'value' => 'required|string|max:255',
+        ]);
+
+        $value = trim($data['value']);
+
+        $pivotQuery = DB::table('question_option_question')
+            ->where('question_id', $question->id)
+            ->where('option_id', $option->id);
+
+        if (Schema::hasColumn('question_option_question', 'flag')) {
+            $pivotQuery->where(function ($query) {
+                $query->whereNull('flag')->orWhere('flag', 0);
+            });
+        }
+
+        if (! $pivotQuery->exists()) {
+            abort(404);
+        }
+
+        if ($option->option === $value) {
+            return $this->response($request);
+        }
+
+        DB::transaction(function () use ($question, $option, $value) {
+            $newOption = QuestionOption::firstOrCreate(['option' => $value]);
+
+            $attachQuery = DB::table('question_option_question')
+                ->where('question_id', $question->id)
+                ->where('option_id', $newOption->id);
+
+            if (Schema::hasColumn('question_option_question', 'flag')) {
+                $attachQuery->where(function ($query) {
+                    $query->whereNull('flag')->orWhere('flag', 0);
+                });
+            }
+
+            if (! $attachQuery->exists()) {
+                $question->options()->attach($newOption->id);
+            }
+
+            $hasOptionColumn = Schema::hasColumn('question_answers', 'option_id');
+
+            if ($hasOptionColumn) {
+                QuestionAnswer::query()
+                    ->where('question_id', $question->id)
+                    ->where('option_id', $option->id)
+                    ->update(['option_id' => $newOption->id]);
+            }
+
+            DB::table('question_option_question')
+                ->where('question_id', $question->id)
+                ->where('option_id', $option->id)
+                ->when(Schema::hasColumn('question_option_question', 'flag'), function ($query) {
+                    $query->where(function ($inner) {
+                        $inner->whereNull('flag')->orWhere('flag', 0);
+                    });
+                })
+                ->delete();
+
+            $stillUsed = QuestionAnswer::query()->where('option_id', $option->id)->exists()
+                || VerbHint::query()->where('option_id', $option->id)->exists()
+                || DB::table('question_option_question')->where('option_id', $option->id)->exists();
+
+            if (! $stillUsed) {
+                $option->delete();
+            }
+        });
+
+        return $this->response($request);
+    }
+
+    private function response(Request $request)
+    {
+        if ($request->wantsJson()) {
+            return response()->noContent();
+        }
+
+        return redirect($request->input('from', url()->previous()));
+    }
+}

--- a/app/Http/Controllers/QuestionVariantController.php
+++ b/app/Http/Controllers/QuestionVariantController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\QuestionVariant;
+use Illuminate\Http\Request;
+
+class QuestionVariantController extends Controller
+{
+    public function update(Request $request, QuestionVariant $questionVariant)
+    {
+        $data = $request->validate([
+            'text' => 'required|string',
+        ]);
+
+        $questionVariant->text = $data['text'];
+        $questionVariant->save();
+
+        if ($request->wantsJson()) {
+            return response()->noContent();
+        }
+
+        return redirect($request->input('from', url()->previous()));
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,10 @@ use App\Http\Controllers\GrammarTestController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\PageController;
 use App\Http\Controllers\QuestionHelpController;
+use App\Http\Controllers\QuestionAnswerController;
+use App\Http\Controllers\QuestionHintController;
+use App\Http\Controllers\QuestionOptionController;
+use App\Http\Controllers\QuestionVariantController;
 use App\Http\Controllers\TrainController;
 use App\Http\Controllers\WordSearchController;
 use App\Http\Controllers\SiteSearchController;
@@ -132,6 +136,10 @@ Route::post('/verb-hints', [VerbHintController::class, 'store'])->name('verb-hin
 Route::put('/verb-hints/{verbHint}', [VerbHintController::class, 'update'])->name('verb-hints.update');
 Route::delete('/verb-hints/{verbHint}', [VerbHintController::class, 'destroy'])->name('verb-hints.destroy');
 Route::put('/questions/{question}', [QuestionController::class, 'update'])->name('questions.update');
+Route::put('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'update'])->name('question-answers.update');
+Route::put('/questions/{question}/options/{option}', [QuestionOptionController::class, 'update'])->name('questions.options.update');
+Route::put('/question-variants/{questionVariant}', [QuestionVariantController::class, 'update'])->name('question-variants.update');
+Route::put('/question-hints/{questionHint}', [QuestionHintController::class, 'update'])->name('question-hints.update');
 
 Route::post('/question-hint', [QuestionHelpController::class, 'hint'])->name('question.hint');
 Route::post('/question-explain', [QuestionHelpController::class, 'explain'])->name('question.explain');

--- a/tests/Feature/Concerns/EnsuresQuestionSchema.php
+++ b/tests/Feature/Concerns/EnsuresQuestionSchema.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\Concerns;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+trait EnsuresQuestionSchema
+{
+    protected function ensureQuestionSchema(): void
+    {
+        if (! Schema::hasTable('categories')) {
+            Schema::create('categories', function (Blueprint $table) {
+                $table->id();
+                $table->string('name');
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('questions')) {
+            Schema::create('questions', function (Blueprint $table) {
+                $table->id();
+                $table->uuid('uuid')->unique();
+                $table->text('question');
+                $table->unsignedTinyInteger('difficulty')->default(1);
+                $table->string('level', 2)->nullable();
+                $table->unsignedBigInteger('category_id')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('question_options')) {
+            Schema::create('question_options', function (Blueprint $table) {
+                $table->id();
+                $table->string('option')->unique();
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('question_option_question')) {
+            Schema::create('question_option_question', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->tinyInteger('flag')->nullable();
+                $table->unique(['question_id', 'option_id', 'flag'], 'qoq_question_option_flag_unique');
+            });
+        }
+
+        if (! Schema::hasTable('question_answers')) {
+            Schema::create('question_answers', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->string('marker');
+                $table->timestamps();
+                $table->unique(['question_id', 'marker', 'option_id'], 'question_marker_option_unique');
+            });
+        }
+
+        if (! Schema::hasTable('verb_hints')) {
+            Schema::create('verb_hints', function (Blueprint $table) {
+                $table->id();
+                $table->string('marker');
+                $table->unsignedBigInteger('question_id');
+                $table->unsignedBigInteger('option_id');
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('question_hints')) {
+            Schema::create('question_hints', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->string('provider');
+                $table->string('locale', 5);
+                $table->text('hint');
+                $table->timestamps();
+                $table->unique(['question_id', 'provider', 'locale']);
+            });
+        }
+
+        if (! Schema::hasTable('question_variants')) {
+            Schema::create('question_variants', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('question_id');
+                $table->text('text');
+                $table->timestamps();
+            });
+        }
+    }
+}

--- a/tests/Feature/QuestionAnswerUpdateTest.php
+++ b/tests/Feature/QuestionAnswerUpdateTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Question;
+use App\Models\QuestionAnswer;
+use App\Models\QuestionOption;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Feature\Concerns\EnsuresQuestionSchema;
+use Tests\TestCase;
+
+class QuestionAnswerUpdateTest extends TestCase
+{
+    use EnsuresQuestionSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensureQuestionSchema();
+        $this->resetQuestionData();
+    }
+
+    /** @test */
+    public function answer_value_can_be_updated_via_route(): void
+    {
+        $category = Category::create(['name' => 'Grammar']);
+
+        $question = Question::create([
+            'uuid' => 'question-1',
+            'question' => 'I {a1} to school.',
+            'difficulty' => 1,
+            'category_id' => $category->id,
+        ]);
+
+        $optionGo = QuestionOption::create(['option' => 'go']);
+        $question->options()->attach($optionGo->id);
+
+        $answer = QuestionAnswer::create([
+            'question_id' => $question->id,
+            'marker' => 'a1',
+            'option_id' => $optionGo->id,
+        ]);
+
+        $response = $this->putJson(route('question-answers.update', $answer->id), [
+            'value' => 'goes',
+        ]);
+
+        $response->assertNoContent();
+
+        $newOption = QuestionOption::where('option', 'goes')->first();
+        $this->assertNotNull($newOption);
+
+        $this->assertDatabaseHas('question_answers', [
+            'id' => $answer->id,
+            'option_id' => $newOption->id,
+        ]);
+
+        $this->assertDatabaseHas('question_option_question', [
+            'question_id' => $question->id,
+            'option_id' => $newOption->id,
+        ]);
+
+        $this->assertDatabaseMissing('question_option_question', [
+            'question_id' => $question->id,
+            'option_id' => $optionGo->id,
+        ]);
+    }
+
+    private function resetQuestionData(): void
+    {
+        foreach ([
+            'verb_hints',
+            'question_answers',
+            'question_option_question',
+            'question_options',
+            'questions',
+            'categories',
+        ] as $table) {
+            if (Schema::hasTable($table)) {
+                DB::table($table)->delete();
+            }
+        }
+    }
+}

--- a/tests/Feature/QuestionHintUpdateTest.php
+++ b/tests/Feature/QuestionHintUpdateTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Question;
+use App\Models\QuestionHint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Feature\Concerns\EnsuresQuestionSchema;
+use Tests\TestCase;
+
+class QuestionHintUpdateTest extends TestCase
+{
+    use EnsuresQuestionSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensureQuestionSchema();
+        $this->resetQuestionData();
+    }
+
+    /** @test */
+    public function hint_text_can_be_updated(): void
+    {
+        $category = Category::create(['name' => 'Grammar']);
+
+        $question = Question::create([
+            'uuid' => 'question-1',
+            'question' => 'I {a1} to school.',
+            'difficulty' => 1,
+            'category_id' => $category->id,
+        ]);
+
+        $hint = QuestionHint::create([
+            'question_id' => $question->id,
+            'provider' => 'chatgpt',
+            'locale' => 'uk',
+            'hint' => 'Почніть із дієслова go.',
+        ]);
+
+        $response = $this->putJson(route('question-hints.update', $hint->id), [
+            'hint' => 'Використовуйте форму go.',
+        ]);
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseHas('question_hints', [
+            'id' => $hint->id,
+            'hint' => 'Використовуйте форму go.',
+        ]);
+    }
+
+    private function resetQuestionData(): void
+    {
+        foreach ([
+            'question_hints',
+            'questions',
+            'categories',
+        ] as $table) {
+            if (Schema::hasTable($table)) {
+                DB::table($table)->delete();
+            }
+        }
+    }
+}

--- a/tests/Feature/QuestionOptionUpdateTest.php
+++ b/tests/Feature/QuestionOptionUpdateTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Question;
+use App\Models\QuestionAnswer;
+use App\Models\QuestionOption;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Feature\Concerns\EnsuresQuestionSchema;
+use Tests\TestCase;
+
+class QuestionOptionUpdateTest extends TestCase
+{
+    use EnsuresQuestionSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensureQuestionSchema();
+        $this->resetQuestionData();
+    }
+
+    /** @test */
+    public function option_value_update_relinks_answers_and_replaces_option(): void
+    {
+        $category = Category::create(['name' => 'Grammar']);
+
+        $question = Question::create([
+            'uuid' => 'question-1',
+            'question' => 'She {a1} every day.',
+            'difficulty' => 1,
+            'category_id' => $category->id,
+        ]);
+
+        $optionGo = QuestionOption::create(['option' => 'go']);
+        $question->options()->attach($optionGo->id);
+
+        $answer = QuestionAnswer::create([
+            'question_id' => $question->id,
+            'marker' => 'a1',
+            'option_id' => $optionGo->id,
+        ]);
+
+        $response = $this->putJson(route('questions.options.update', [$question->id, $optionGo->id]), [
+            'value' => 'goes',
+        ]);
+
+        $response->assertNoContent();
+
+        $newOption = QuestionOption::where('option', 'goes')->first();
+        $this->assertNotNull($newOption);
+
+        $this->assertDatabaseHas('question_answers', [
+            'id' => $answer->id,
+            'option_id' => $newOption->id,
+        ]);
+
+        $this->assertDatabaseHas('question_option_question', [
+            'question_id' => $question->id,
+            'option_id' => $newOption->id,
+        ]);
+
+        $this->assertDatabaseMissing('question_option_question', [
+            'question_id' => $question->id,
+            'option_id' => $optionGo->id,
+        ]);
+
+        $this->assertDatabaseMissing('question_options', [
+            'id' => $optionGo->id,
+        ]);
+    }
+
+    private function resetQuestionData(): void
+    {
+        foreach ([
+            'verb_hints',
+            'question_answers',
+            'question_option_question',
+            'question_options',
+            'questions',
+            'categories',
+        ] as $table) {
+            if (Schema::hasTable($table)) {
+                DB::table($table)->delete();
+            }
+        }
+    }
+}

--- a/tests/Feature/QuestionUpdateTest.php
+++ b/tests/Feature/QuestionUpdateTest.php
@@ -41,4 +41,48 @@ class QuestionUpdateTest extends TestCase
             'question' => 'Updated {a1}',
         ]);
     }
+
+    /** @test */
+    public function question_level_can_be_updated_via_route(): void
+    {
+        $migrations = [
+            '2025_07_20_143201_create_categories_table.php',
+            '2025_07_20_143210_create_quastion_table.php',
+            '2025_07_20_180521_add_flag_to_question_table.php',
+            '2025_07_20_193626_add_source_to_qustion_table.php',
+            '2025_07_31_000002_add_uuid_to_questions_table.php',
+            '2025_07_31_000003_add_level_to_questions_table.php',
+        ];
+        foreach ($migrations as $file) {
+            Artisan::call('migrate', ['--path' => 'database/migrations/' . $file]);
+        }
+
+        $category = Category::create(['name' => 'test']);
+        $question = Question::create([
+            'uuid' => 'q1',
+            'question' => 'Original {a1}',
+            'difficulty' => 1,
+            'category_id' => $category->id,
+        ]);
+
+        $response = $this->putJson(route('questions.update', $question->id), [
+            'level' => 'B1',
+        ]);
+
+        $response->assertNoContent();
+        $this->assertDatabaseHas('questions', [
+            'id' => $question->id,
+            'level' => 'B1',
+        ]);
+
+        $response = $this->putJson(route('questions.update', $question->id), [
+            'level' => null,
+        ]);
+
+        $response->assertNoContent();
+        $this->assertDatabaseHas('questions', [
+            'id' => $question->id,
+            'level' => null,
+        ]);
+    }
 }

--- a/tests/Feature/QuestionVariantUpdateTest.php
+++ b/tests/Feature/QuestionVariantUpdateTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Question;
+use App\Models\QuestionVariant;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Feature\Concerns\EnsuresQuestionSchema;
+use Tests\TestCase;
+
+class QuestionVariantUpdateTest extends TestCase
+{
+    use EnsuresQuestionSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensureQuestionSchema();
+        $this->resetQuestionData();
+    }
+
+    /** @test */
+    public function variant_text_can_be_updated(): void
+    {
+        $category = Category::create(['name' => 'Grammar']);
+
+        $question = Question::create([
+            'uuid' => 'question-1',
+            'question' => 'They {a1} together.',
+            'difficulty' => 1,
+            'category_id' => $category->id,
+        ]);
+
+        $variant = QuestionVariant::create([
+            'question_id' => $question->id,
+            'text' => 'We {a1} as well.',
+        ]);
+
+        $response = $this->putJson(route('question-variants.update', $variant->id), [
+            'text' => 'We also {a1}.',
+        ]);
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseHas('question_variants', [
+            'id' => $variant->id,
+            'text' => 'We also {a1}.',
+        ]);
+    }
+
+    private function resetQuestionData(): void
+    {
+        foreach ([
+            'question_variants',
+            'questions',
+            'categories',
+        ] as $table) {
+            if (Schema::hasTable($table)) {
+                DB::table($table)->delete();
+            }
+        }
+    }
+}

--- a/tests/Feature/SavedTestTechnicalPageTest.php
+++ b/tests/Feature/SavedTestTechnicalPageTest.php
@@ -117,6 +117,75 @@ class SavedTestTechnicalPageTest extends TestCase
         }
     }
 
+    /** @test */
+    public function it_shows_edit_actions_for_question_elements(): void
+    {
+        $category = Category::create(['name' => 'Present Simple']);
+
+        $question = Question::create([
+            'uuid' => (string) Str::uuid(),
+            'question' => 'I {a1} to school every day.',
+            'difficulty' => 1,
+            'level' => 'A1',
+            'category_id' => $category->id,
+        ]);
+
+        $optionGo = QuestionOption::create(['option' => 'go']);
+        $optionGoes = QuestionOption::create(['option' => 'goes']);
+        $optionWent = QuestionOption::create(['option' => 'went']);
+
+        $question->options()->attach([$optionGo->id, $optionGoes->id, $optionWent->id]);
+
+        $answer = QuestionAnswer::create([
+            'question_id' => $question->id,
+            'marker' => 'a1',
+            'option_id' => $optionGo->id,
+        ]);
+
+        $verbHint = VerbHint::create([
+            'question_id' => $question->id,
+            'marker' => 'a1',
+            'option_id' => $optionGo->id,
+        ]);
+
+        $hint = QuestionHint::create([
+            'question_id' => $question->id,
+            'provider' => 'chatgpt',
+            'locale' => 'uk',
+            'hint' => 'Використовуйте базову форму дієслова.',
+        ]);
+
+        $variant = null;
+        if (Schema::hasTable('question_variants')) {
+            $variant = QuestionVariant::create([
+                'question_id' => $question->id,
+                'text' => 'They {a1} to school together.',
+            ]);
+        }
+
+        $test = Test::create([
+            'name' => 'Simple test',
+            'slug' => 'simple-test',
+            'filters' => [],
+            'questions' => [$question->id],
+        ]);
+
+        $response = $this->get(route('saved-test.tech', $test->slug));
+
+        $response->assertOk();
+        $response->assertSee('Редагувати питання');
+        $response->assertSee('Змінити');
+        $response->assertSee('Редагувати відповідь');
+        $response->assertSee("editAnswer({$answer->id}", false);
+        $response->assertSee("editOption({$question->id}, {$optionGo->id}", false);
+        $response->assertSee("editQuestionHint({$hint->id}", false);
+        $response->assertSee("editVerbHintValue({$verbHint->id}", false);
+
+        if ($variant) {
+            $response->assertSee("editVariant({$variant->id}", false);
+        }
+    }
+
     private function ensureSchema(): void
     {
         if (! Schema::hasTable('categories')) {


### PR DESCRIPTION
## Summary
- add dedicated controllers and routes to update question answers, options, variants and hints while keeping option usage consistent
- extend the technical saved test view with inline edit buttons and JavaScript helpers for updating question content
- introduce reusable schema setup helpers and new feature tests covering the update endpoints alongside refreshed technical page assertions

## Testing
- `php artisan test` *(warnings: some feature tests report missing .env during execution)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1e24c444832aa3d8106b6bd916cf