### PR TITLE
Add management for test questions and elements on tech page

### DIFF
--- a/app/Http/Controllers/QuestionAnswerController.php
+++ b/app/Http/Controllers/QuestionAnswerController.php
@@ -3,16 +3,77 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Concerns\ReturnsTechnicalQuestionResource;
+use App\Models\Question;
 use App\Models\QuestionAnswer;
 use App\Models\QuestionOption;
 use App\Models\VerbHint;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\ValidationException;
 
 class QuestionAnswerController extends Controller
 {
     use ReturnsTechnicalQuestionResource;
+
+    public function store(Request $request, Question $question)
+    {
+        $data = $request->validate([
+            'marker' => 'required|string|max:10',
+            'value' => 'required|string|max:255',
+        ]);
+
+        $marker = strtoupper(trim($data['marker']));
+        $value = trim($data['value']);
+
+        $supportsOptionReference = Schema::hasColumn('question_answers', 'option_id');
+
+        DB::transaction(function () use ($question, $marker, $value, $supportsOptionReference) {
+            $answer = new QuestionAnswer([
+                'marker' => $marker,
+            ]);
+
+            $answer->question()->associate($question);
+
+            if ($supportsOptionReference) {
+                $option = QuestionOption::firstOrCreate(['option' => $value]);
+
+                $exists = QuestionAnswer::query()
+                    ->where('question_id', $question->id)
+                    ->where('marker', $marker)
+                    ->where('option_id', $option->id)
+                    ->exists();
+
+                if ($exists) {
+                    throw ValidationException::withMessages([
+                        'value' => 'Така відповідь вже існує.',
+                    ]);
+                }
+
+                $pivotQuery = DB::table('question_option_question')
+                    ->where('question_id', $question->id)
+                    ->where('option_id', $option->id);
+
+                if (Schema::hasColumn('question_option_question', 'flag')) {
+                    $pivotQuery->where(function ($query) {
+                        $query->whereNull('flag')->orWhere('flag', 0);
+                    });
+                }
+
+                if (! $pivotQuery->exists()) {
+                    $question->options()->attach($option->id);
+                }
+
+                $answer->option()->associate($option);
+            } else {
+                $answer->answer = $value;
+            }
+
+            $answer->save();
+        });
+
+        return $this->respondWithQuestion($request, $question);
+    }
 
     public function update(Request $request, QuestionAnswer $questionAnswer)
     {
@@ -95,6 +156,47 @@ class QuestionAnswerController extends Controller
 
                 if (! $stillUsed) {
                     $currentOption->delete();
+                }
+            }
+        });
+
+        return $this->respondWithQuestion($request, $question);
+    }
+
+    public function destroy(Request $request, QuestionAnswer $questionAnswer)
+    {
+        $question = $questionAnswer->question;
+        $option = $questionAnswer->relationLoaded('option')
+            ? $questionAnswer->option
+            : $questionAnswer->option()->first();
+
+        DB::transaction(function () use ($questionAnswer, $question, $option) {
+            $questionAnswer->delete();
+
+            if ($option) {
+                $otherAnswersExist = QuestionAnswer::query()
+                    ->where('question_id', $question->id)
+                    ->where('option_id', $option->id)
+                    ->exists();
+
+                if (! $otherAnswersExist) {
+                    DB::table('question_option_question')
+                        ->where('question_id', $question->id)
+                        ->where('option_id', $option->id)
+                        ->when(Schema::hasColumn('question_option_question', 'flag'), function ($query) {
+                            $query->where(function ($inner) {
+                                $inner->whereNull('flag')->orWhere('flag', 0);
+                            });
+                        })
+                        ->delete();
+                }
+
+                $stillUsed = QuestionAnswer::query()->where('option_id', $option->id)->exists()
+                    || VerbHint::query()->where('option_id', $option->id)->exists()
+                    || DB::table('question_option_question')->where('option_id', $option->id)->exists();
+
+                if (! $stillUsed) {
+                    $option->delete();
                 }
             }
         });

--- a/app/Http/Controllers/QuestionHintController.php
+++ b/app/Http/Controllers/QuestionHintController.php
@@ -3,12 +3,38 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Concerns\ReturnsTechnicalQuestionResource;
+use App\Models\Question;
 use App\Models\QuestionHint;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 
 class QuestionHintController extends Controller
 {
     use ReturnsTechnicalQuestionResource;
+
+    public function store(Request $request, Question $question)
+    {
+        $data = $request->validate([
+            'provider' => 'required|string|max:255',
+            'locale' => 'required|string|max:10',
+            'hint' => 'required|string',
+        ]);
+
+        $exists = $question->hints()
+            ->where('provider', $data['provider'])
+            ->where('locale', $data['locale'])
+            ->exists();
+
+        if ($exists) {
+            throw ValidationException::withMessages([
+                'provider' => 'Підказка з таким провайдером та мовою вже існує.',
+            ]);
+        }
+
+        $question->hints()->create($data);
+
+        return $this->respondWithQuestion($request, $question);
+    }
 
     public function update(Request $request, QuestionHint $questionHint)
     {
@@ -20,5 +46,13 @@ class QuestionHintController extends Controller
         $questionHint->save();
 
         return $this->respondWithQuestion($request, $questionHint->question);
+    }
+
+    public function destroy(Request $request, QuestionHint $questionHint)
+    {
+        $question = $questionHint->question;
+        $questionHint->delete();
+
+        return $this->respondWithQuestion($request, $question);
     }
 }

--- a/app/Http/Controllers/QuestionOptionController.php
+++ b/app/Http/Controllers/QuestionOptionController.php
@@ -10,10 +10,40 @@ use App\Models\VerbHint;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\ValidationException;
 
 class QuestionOptionController extends Controller
 {
     use ReturnsTechnicalQuestionResource;
+
+    public function store(Request $request, Question $question)
+    {
+        $data = $request->validate([
+            'value' => 'required|string|max:255',
+        ]);
+
+        $value = trim($data['value']);
+
+        DB::transaction(function () use ($question, $value) {
+            $option = QuestionOption::firstOrCreate(['option' => $value]);
+
+            $pivotQuery = DB::table('question_option_question')
+                ->where('question_id', $question->id)
+                ->where('option_id', $option->id);
+
+            if (Schema::hasColumn('question_option_question', 'flag')) {
+                $pivotQuery->where(function ($query) {
+                    $query->whereNull('flag')->orWhere('flag', 0);
+                });
+            }
+
+            if (! $pivotQuery->exists()) {
+                $question->options()->attach($option->id);
+            }
+        });
+
+        return $this->respondWithQuestion($request, $question);
+    }
 
     public function update(Request $request, Question $question, QuestionOption $option)
     {
@@ -67,6 +97,67 @@ class QuestionOptionController extends Controller
                     ->update(['option_id' => $newOption->id]);
             }
 
+            DB::table('question_option_question')
+                ->where('question_id', $question->id)
+                ->where('option_id', $option->id)
+                ->when(Schema::hasColumn('question_option_question', 'flag'), function ($query) {
+                    $query->where(function ($inner) {
+                        $inner->whereNull('flag')->orWhere('flag', 0);
+                    });
+                })
+                ->delete();
+
+            $stillUsed = QuestionAnswer::query()->where('option_id', $option->id)->exists()
+                || VerbHint::query()->where('option_id', $option->id)->exists()
+                || DB::table('question_option_question')->where('option_id', $option->id)->exists();
+
+            if (! $stillUsed) {
+                $option->delete();
+            }
+        });
+
+        return $this->respondWithQuestion($request, $question);
+    }
+
+    public function destroy(Request $request, Question $question, QuestionOption $option)
+    {
+        $pivotQuery = DB::table('question_option_question')
+            ->where('question_id', $question->id)
+            ->where('option_id', $option->id);
+
+        if (Schema::hasColumn('question_option_question', 'flag')) {
+            $pivotQuery->where(function ($query) {
+                $query->whereNull('flag')->orWhere('flag', 0);
+            });
+        }
+
+        if (! $pivotQuery->exists()) {
+            abort(404);
+        }
+
+        $isAnswerOption = QuestionAnswer::query()
+            ->where('question_id', $question->id)
+            ->where('option_id', $option->id)
+            ->exists();
+
+        if ($isAnswerOption) {
+            throw ValidationException::withMessages([
+                'value' => 'Неможливо видалити опцію, що використовується у відповіді.',
+            ]);
+        }
+
+        $hasVerbHint = VerbHint::query()
+            ->where('question_id', $question->id)
+            ->where('option_id', $option->id)
+            ->exists();
+
+        if ($hasVerbHint) {
+            throw ValidationException::withMessages([
+                'value' => 'Неможливо видалити опцію, що використовується у verb hint.',
+            ]);
+        }
+
+        DB::transaction(function () use ($question, $option) {
             DB::table('question_option_question')
                 ->where('question_id', $question->id)
                 ->where('option_id', $option->id)

--- a/app/Http/Controllers/QuestionVariantController.php
+++ b/app/Http/Controllers/QuestionVariantController.php
@@ -3,12 +3,28 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Concerns\ReturnsTechnicalQuestionResource;
+use App\Models\Question;
 use App\Models\QuestionVariant;
 use Illuminate\Http\Request;
 
 class QuestionVariantController extends Controller
 {
     use ReturnsTechnicalQuestionResource;
+
+    public function store(Request $request, Question $question)
+    {
+        $data = $request->validate([
+            'text' => 'required|string',
+        ]);
+
+        $variant = new QuestionVariant([
+            'text' => $data['text'],
+        ]);
+        $variant->question()->associate($question);
+        $variant->save();
+
+        return $this->respondWithQuestion($request, $question);
+    }
 
     public function update(Request $request, QuestionVariant $questionVariant)
     {
@@ -20,5 +36,13 @@ class QuestionVariantController extends Controller
         $questionVariant->save();
 
         return $this->respondWithQuestion($request, $questionVariant->question);
+    }
+
+    public function destroy(Request $request, QuestionVariant $questionVariant)
+    {
+        $question = $questionVariant->question;
+        $questionVariant->delete();
+
+        return $this->respondWithQuestion($request, $question);
     }
 }

--- a/app/Http/Controllers/VerbHintController.php
+++ b/app/Http/Controllers/VerbHintController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Concerns\ReturnsTechnicalQuestionResource;
+use App\Http\Resources\TechnicalQuestionResource;
 use App\Models\{VerbHint, QuestionOption, Question};
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -37,8 +38,11 @@ class VerbHintController extends Controller
             'option_id' => $option->id,
         ]);
 
-        if ($request->expectsJson()) {
-            return response()->json(['id' => $verbHint->id], 201);
+        if ($request->wantsJson()) {
+            return response()->json([
+                'id' => $verbHint->id,
+                'question' => TechnicalQuestionResource::make($question->refresh())->toArray($request),
+            ], 201);
         }
 
         $redirectTo = $request->input('from', url()->previous());
@@ -125,8 +129,10 @@ class VerbHintController extends Controller
             $option->delete();
         }
 
-        if ($request->expectsJson()) {
-            return response()->noContent();
+        if ($request->wantsJson()) {
+            return response()->json([
+                'question' => TechnicalQuestionResource::make($question->refresh())->toArray($request),
+            ]);
         }
 
         $redirectTo = $request->input('from', url()->previous());

--- a/resources/views/engram/saved-test-tech.blade.php
+++ b/resources/views/engram/saved-test-tech.blade.php
@@ -10,6 +10,11 @@
             <p class="text-sm text-stone-600 mt-1">Технічна інформація про тест · Питань: {{ $questions->count() }}</p>
         </div>
         <div class="flex flex-wrap gap-2">
+            <button type="button"
+                    class="px-3 py-1.5 rounded-2xl bg-blue-600 text-white text-sm font-semibold shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                    onclick="techEditor.addQuestion()">
+                + Додати питання
+            </button>
             <a href="{{ route('saved-test.show', $test->slug) }}"
                class="px-3 py-1.5 rounded-2xl border border-stone-200 bg-white shadow-sm text-sm font-semibold text-stone-700 hover:bg-stone-50">
                 ← Основна сторінка
@@ -169,7 +174,7 @@
                         <span>ID: {{ $question->id }}</span>
                     </div>
                     <p class="mt-2 text-lg leading-relaxed text-stone-900" data-question-text>{!! $filledQuestion !!}</p>
-                    <div class="mt-2 flex flex-wrap gap-2 text-xs font-semibold text-blue-600">
+                    <div class="mt-2 flex flex-wrap gap-2 text-xs font-semibold">
                         <button type="button"
                                 class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-blue-700 hover:bg-blue-100"
                                 onclick="techEditor.editQuestion({{ $question->id }})">
@@ -177,6 +182,14 @@
                                 <path d="M15.728 2.272a2.625 2.625 0 0 1 0 3.712l-8.1 8.1a3.5 3.5 0 0 1-1.563.888l-2.82.705a.625.625 0 0 1-.757-.757l.706-2.82a3.5 3.5 0 0 1 .888-1.564l8.1-8.1a2.625 2.625 0 0 1 3.712 0Zm-2.65 1.062-8.1 8.1a2.25 2.25 0 0 0-.57 1.006l-.46 1.838 1.838-.46a2.25 2.25 0 0 0 1.006-.57l8.1-8.1a1.375 1.375 0 1 0-1.94-1.94Z" />
                             </svg>
                             <span>Редагувати питання</span>
+                        </button>
+                        <button type="button"
+                                class="inline-flex items-center gap-1 rounded-full bg-red-50 px-3 py-1 text-red-600 hover:bg-red-100"
+                                onclick="techEditor.deleteQuestion({{ $question->id }})">
+                            <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                <path d="M6.5 5.75a.75.75 0 0 1 .75-.75h5a.75.75 0 0 1 .75.75v.75h2.25a.75.75 0 0 1 0 1.5H15l-.55 8.247A2.25 2.25 0 0 1 12.205 18H7.795a2.25 2.25 0 0 1-2.245-2.503L5 8H3.5a.75.75 0 0 1 0-1.5H5.75V5.75Zm2.25.75v.75h2.5V6.5h-2.5Zm-.75 2.25a.75.75 0 0 0-1.5 0l.25 7.5a.75.75 0 0 0 1.5-.05l-.25-7.45Zm4.5 0a.75.75 0 0 1 1.5 0l-.25 7.5a.75.75 0 1 1-1.5-.05l.25-7.45Z" />
+                            </svg>
+                            <span>Видалити питання</span>
                         </button>
                     </div>
                 </div>
@@ -191,28 +204,41 @@
                 </div>
             </header>
 
-            @if($variants->isNotEmpty())
-                <details class="group">
-                    <summary class="flex cursor-pointer select-none items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
-                        <span>Варіанти запитання</span>
-                        <span class="text-[10px] font-normal text-stone-400 group-open:hidden">Показати ▼</span>
-                        <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
-                    </summary>
-                    <ul class="mt-3 space-y-2 text-sm text-stone-800">
-                        @foreach($variants as $variant)
+            <details class="group">
+                <summary class="flex cursor-pointer select-none items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
+                    <span>Варіанти запитання</span>
+                    <span class="text-[10px] font-normal text-stone-400 group-open:hidden">Показати ▼</span>
+                    <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
+                </summary>
+                <div class="mt-3 space-y-3">
+                    <ul class="space-y-2 text-sm text-stone-800" data-variants-container>
+                        @forelse($variants as $variant)
                             <li class="flex flex-col gap-1 rounded-lg border border-stone-200 bg-stone-50 px-3 py-2"
                                 data-variant-id="{{ $variant->id }}">
                                 <div class="flex items-center justify-between gap-2">
                                     <span class="font-mono text-[11px] uppercase text-stone-500">Варіант {{ $loop->iteration }}</span>
-                                    <button type="button" class="text-[11px] font-semibold text-blue-600 underline hover:text-blue-800"
-                                            onclick="techEditor.editVariant({{ $question->id }}, {{ $variant->id }})">Редагувати</button>
+                                    <div class="flex items-center gap-2">
+                                        <button type="button" class="text-[11px] font-semibold text-blue-600 underline hover:text-blue-800"
+                                                onclick="techEditor.editVariant({{ $question->id }}, {{ $variant->id }})">Редагувати</button>
+                                        <button type="button" class="text-[11px] font-semibold text-red-600 underline hover:text-red-700"
+                                                onclick="techEditor.deleteVariant({{ $question->id }}, {{ $variant->id }})">Видалити</button>
+                                    </div>
                                 </div>
                                 <span data-variant-text>{!! $highlightSegments($variant->text) !!}</span>
                             </li>
-                        @endforeach
+                        @empty
+                            <li class="rounded-lg border border-dashed border-stone-300 px-3 py-2 text-sm text-stone-500" data-empty>
+                                Варіанти відсутні.
+                            </li>
+                        @endforelse
                     </ul>
-                </details>
-            @endif
+                    <button type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-dashed border-blue-300 px-3 py-1.5 text-xs font-semibold text-blue-600 transition hover:bg-blue-50"
+                            onclick="techEditor.addVariant({{ $question->id }})">
+                        <span>+ Додати варіант</span>
+                    </button>
+                </div>
+            </details>
 
             <details class="group">
                 <summary class="flex cursor-pointer select-none items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
@@ -220,93 +246,142 @@
                     <span class="text-[10px] font-normal text-stone-400 group-open:hidden">Показати ▼</span>
                     <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
                 </summary>
-                <ul class="mt-3 space-y-2 text-sm text-stone-800">
-                    @foreach($question->answers as $answer)
-                        @php
-                            $marker = strtoupper($answer->marker);
-                            $markerKey = strtolower($answer->marker);
-                            $answerValue = $answersByMarker->get($markerKey, '');
-                            $verbHintModel = $verbHintsByMarker->get($markerKey);
-                            $verbHintValue = $verbHintModel?->option?->option;
-                        @endphp
-                        <li class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-emerald-100 bg-emerald-50/70 px-3 py-2"
-                            data-answer-id="{{ $answer->id }}">
-                            <div class="flex flex-wrap items-center gap-2 text-sm">
-                                <span class="font-mono text-xs uppercase text-emerald-500">{{ $marker }}</span>
-                                <span class="font-semibold text-emerald-900" data-answer-value>{{ $answerValue }}</span>
-                                @if($verbHintValue)
-                                    <span class="inline-flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-[11px] font-medium text-emerald-700"
-                                        data-verb-hint @if($verbHintModel) data-verb-hint-id="{{ $verbHintModel->id }}" @endif>
-                                        <span class="font-semibold uppercase text-[10px] tracking-wide">Verb hint</span>
-                                        <span data-verb-hint-value>{{ $verbHintValue }}</span>
-                                        @if($verbHintModel)
-                                            <button type="button" class="text-[10px] font-semibold text-blue-600 underline hover:text-blue-800"
-                                                    onclick="techEditor.editVerbHint({{ $question->id }}, {{ $verbHintModel->id }})">Редагувати</button>
-                                        @endif
-                                    </span>
-                                @endif
-                            </div>
-                            <button type="button" class="text-xs font-semibold text-blue-600 underline hover:text-blue-800"
-                                    onclick="techEditor.editAnswer({{ $question->id }}, {{ $answer->id }})">Редагувати відповідь</button>
-                        </li>
-                    @endforeach
-                </ul>
+                <div class="mt-3 space-y-3">
+                    <ul class="space-y-2 text-sm text-stone-800" data-answers-container>
+                        @forelse($question->answers as $answer)
+                            @php
+                                $marker = strtoupper($answer->marker);
+                                $markerKey = strtolower($answer->marker);
+                                $answerValue = $answersByMarker->get($markerKey, '');
+                                $verbHintModel = $verbHintsByMarker->get($markerKey);
+                                $verbHintValue = $verbHintModel?->option?->option;
+                            @endphp
+                            <li class="flex flex-col gap-2 rounded-lg border border-emerald-100 bg-emerald-50/70 px-3 py-2"
+                                data-answer-id="{{ $answer->id }}">
+                                <div class="flex flex-wrap items-center gap-2 text-sm">
+                                    <span class="font-mono text-xs uppercase text-emerald-500">{{ $marker }}</span>
+                                    <span class="font-semibold text-emerald-900" data-answer-value>{{ $answerValue }}</span>
+                                    @if($verbHintValue && $verbHintModel)
+                                        <span class="inline-flex flex-wrap items-center gap-2 rounded-full bg-white px-2 py-0.5 text-[11px] font-medium text-emerald-700"
+                                              data-verb-hint data-verb-hint-id="{{ $verbHintModel->id }}">
+                                            <span class="font-semibold uppercase text-[10px] tracking-wide">Verb hint</span>
+                                            <span data-verb-hint-value>{{ $verbHintValue }}</span>
+                                            <div class="flex items-center gap-2">
+                                                <button type="button" class="text-[10px] font-semibold text-blue-600 underline hover:text-blue-800"
+                                                        onclick="techEditor.editVerbHint({{ $question->id }}, {{ $verbHintModel->id }})">Редагувати</button>
+                                                <button type="button" class="text-[10px] font-semibold text-red-600 underline hover:text-red-700"
+                                                        onclick="techEditor.deleteVerbHint({{ $question->id }}, {{ $verbHintModel->id }})">Видалити</button>
+                                            </div>
+                                        </span>
+                                    @else
+                                        <button type="button"
+                                                class="inline-flex items-center gap-1 rounded-full border border-dashed border-emerald-300 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 hover:bg-emerald-50"
+                                                onclick="techEditor.addVerbHint({{ $question->id }}, {{ json_encode($marker) }})">
+                                            Додати verb hint
+                                        </button>
+                                    @endif
+                                </div>
+                                <div class="flex flex-wrap gap-3 text-xs font-semibold">
+                                    <button type="button" class="text-blue-600 underline hover:text-blue-800"
+                                            onclick="techEditor.editAnswer({{ $question->id }}, {{ $answer->id }})">Редагувати відповідь</button>
+                                    <button type="button" class="text-red-600 underline hover:text-red-700"
+                                            onclick="techEditor.deleteAnswer({{ $question->id }}, {{ $answer->id }})">Видалити</button>
+                                </div>
+                            </li>
+                        @empty
+                            <li class="rounded-lg border border-dashed border-stone-300 px-3 py-2 text-sm text-stone-500" data-empty>
+                                Відповіді відсутні.
+                            </li>
+                        @endforelse
+                    </ul>
+                    <button type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-dashed border-emerald-300 px-3 py-1.5 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50"
+                            onclick="techEditor.addAnswer({{ $question->id }})">
+                        <span>+ Додати відповідь</span>
+                    </button>
+                </div>
             </details>
 
-            @if($options->isNotEmpty())
-                <details class="group">
-                    <summary class="flex cursor-pointer select-none items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
-                        <span>Варіанти відповіді</span>
-                        <span class="text-[10px] font-normal text-stone-400 group-open:hidden">Показати ▼</span>
-                        <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
-                    </summary>
-                    <div class="mt-3 flex flex-wrap gap-2" data-options-container>
-                        @foreach($options as $option)
+            <details class="group">
+                <summary class="flex cursor-pointer select-none items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
+                    <span>Варіанти відповіді</span>
+                    <span class="text-[10px] font-normal text-stone-400 group-open:hidden">Показати ▼</span>
+                    <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
+                </summary>
+                <div class="mt-3 space-y-3">
+                    <div class="flex flex-wrap gap-2" data-options-container>
+                        @forelse($options as $option)
                             @php $isCorrectOption = (bool) ($option['is_correct'] ?? false); @endphp
                             <div @class([
                                 'inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm',
                                 'border-emerald-200 bg-emerald-50 text-emerald-900 font-semibold shadow-sm' => $isCorrectOption,
                                 'border-stone-200 bg-stone-50 text-stone-800' => ! $isCorrectOption,
                             ])
-                            data-option-id="{{ $option['id'] ?? '' }}">
+                                data-option-id="{{ $option['id'] ?? '' }}">
                                 @if($isCorrectOption)
                                     <svg class="h-3.5 w-3.5 text-emerald-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                        <path fill-rule="evenodd" d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.2 7.25a1 1 0 0 1-1.425.01L3.29 9.967a1 1 0 1 1 1.42-1.407l3.162 3.19 6.49-6.538a1 1 0 0 1 1.342-.088Z" clip-rule="evenodd" />
+                                        <path fill-rule="evenodd" d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.2 7.25a1 1 0 0 1-1.425-.01L3.29 9.967a1 1 0 1 1 1.42-1.407l3.162 3.19 6.49-6.538a1 1 0 0 1 1.342-.088Z" clip-rule="evenodd" />
                                     </svg>
                                 @endif
                                 <span>{{ $option['label'] }}</span>
                                 @if(! empty($option['id']))
-                                    <button type="button" class="text-xs font-semibold text-blue-600 underline hover:text-blue-800"
-                                            onclick="techEditor.editOption({{ $question->id }}, {{ $option['id'] }})">Редагувати</button>
+                                    <div class="flex items-center gap-2">
+                                        <button type="button" class="text-xs font-semibold text-blue-600 underline hover:text-blue-800"
+                                                onclick="techEditor.editOption({{ $question->id }}, {{ $option['id'] }})">Редагувати</button>
+                                        @if(! $isCorrectOption)
+                                            <button type="button" class="text-xs font-semibold text-red-600 underline hover:text-red-700"
+                                                    onclick="techEditor.deleteOption({{ $question->id }}, {{ $option['id'] }})">Видалити</button>
+                                        @endif
+                                    </div>
                                 @endif
                             </div>
-                        @endforeach
+                        @empty
+                            <p class="text-sm text-stone-500" data-empty>Варіанти відсутні.</p>
+                        @endforelse
                     </div>
-                </details>
-            @endif
+                    <button type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-dashed border-stone-300 px-3 py-1.5 text-xs font-semibold text-stone-700 transition hover:bg-stone-50"
+                            onclick="techEditor.addOption({{ $question->id }})">
+                        <span>+ Додати варіант відповіді</span>
+                    </button>
+                </div>
+            </details>
 
-            @if($questionHints->isNotEmpty())
-                <details class="group">
-                    <summary class="flex cursor-pointer select-none items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
-                        <span>Question hints</span>
-                        <span class="text-[10px] font-normal text-stone-400 group-open:hidden">Показати ▼</span>
-                        <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
-                    </summary>
-                    <ul class="mt-3 space-y-3 text-sm text-stone-800">
-                        @foreach($questionHints as $hint)
+            <details class="group">
+                <summary class="flex cursor-pointer select-none items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
+                    <span>Question hints</span>
+                    <span class="text-[10px] font-normal text-stone-400 group-open:hidden">Показати ▼</span>
+                    <span class="hidden text-[10px] font-normal text-stone-400 group-open:inline">Сховати ▲</span>
+                </summary>
+                <div class="mt-3 space-y-3">
+                    <ul class="space-y-3 text-sm text-stone-800" data-question-hints-container>
+                        @forelse($questionHints as $hint)
                             <li class="rounded-lg border border-blue-100 bg-blue-50/60 px-3 py-2"
                                 data-question-hint-id="{{ $hint->id }}">
                                 <div class="flex items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-blue-700">
                                     <span>{{ $hint->provider }} · {{ strtoupper($hint->locale) }}</span>
-                                    <button type="button" class="text-[11px] font-semibold text-blue-600 underline hover:text-blue-800"
-                                            onclick="techEditor.editQuestionHint({{ $question->id }}, {{ $hint->id }})">Редагувати</button>
+                                    <div class="flex items-center gap-2">
+                                        <button type="button" class="text-[11px] font-semibold text-blue-600 underline hover:text-blue-800"
+                                                onclick="techEditor.editQuestionHint({{ $question->id }}, {{ $hint->id }})">Редагувати</button>
+                                        <button type="button" class="text-[11px] font-semibold text-red-600 underline hover:text-red-700"
+                                                onclick="techEditor.deleteQuestionHint({{ $question->id }}, {{ $hint->id }})">Видалити</button>
+                                    </div>
                                 </div>
                                 <div class="mt-1 whitespace-pre-line text-stone-800" data-question-hint-text>{{ $hint->hint }}</div>
                             </li>
-                        @endforeach
+                        @empty
+                            <li class="rounded-lg border border-dashed border-blue-200 px-3 py-2 text-sm text-blue-600" data-empty>
+                                Підказки відсутні.
+                            </li>
+                        @endforelse
                     </ul>
-                </details>
-            @endif
+                    <button type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-dashed border-blue-300 px-3 py-1.5 text-xs font-semibold text-blue-700 transition hover:bg-blue-50"
+                            onclick="techEditor.addQuestionHint({{ $question->id }})">
+                        <span>+ Додати підказку</span>
+                    </button>
+                </div>
+            </details>
 
             @if($explanations->isNotEmpty())
                 <details class="group">
@@ -383,16 +458,19 @@
         </form>
     </div>
 </div>
+
 <script>
     (() => {
         const techCsrfToken = '{{ csrf_token() }}';
         const routes = {
             question: '{{ url('/questions') }}',
-            answer: '{{ url('/question-answers') }}',
-            variant: '{{ url('/question-variants') }}',
-            option: '{{ url('/questions') }}',
+            questionAnswer: '{{ url('/question-answers') }}',
+            questionVariant: '{{ url('/question-variants') }}',
+            questionOption: '{{ url('/questions') }}',
             questionHint: '{{ url('/question-hints') }}',
             verbHint: '{{ url('/verb-hints') }}',
+        
+            testQuestion: '{{ url('/test/' . $test->slug . '/question') }}',
         };
 
         const cefrLevels = @json($cefrLevels);
@@ -431,7 +509,7 @@
                 return '';
             }
 
-            const segments = text.split(/(\{a\d+\})/gi);
+            const segments = String(text).split(/(\{a\d+\})/gi);
 
             return segments
                 .map(segment => {
@@ -452,30 +530,154 @@
                 .join('');
         }
 
-        function renderOptionHtml(questionId, option) {
-            const classes = ['inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm'];
+        function renderVariantHtml(questionId, variant, index, answersByMarker) {
+            const text = highlightSegments(variant.text || '', answersByMarker);
 
-            if (option.is_correct) {
-                classes.push('border-emerald-200 bg-emerald-50 text-emerald-900 font-semibold shadow-sm');
-            } else {
-                classes.push('border-stone-200 bg-stone-50 text-stone-800');
+            return `
+                <li class="flex flex-col gap-1 rounded-lg border border-stone-200 bg-stone-50 px-3 py-2" data-variant-id="${variant.id}">
+                    <div class="flex items-center justify-between gap-2">
+                        <span class="font-mono text-[11px] uppercase text-stone-500">Варіант ${index}</span>
+                        <div class="flex items-center gap-2">
+                            <button type="button" class="text-[11px] font-semibold text-blue-600 underline hover:text-blue-800" onclick="techEditor.editVariant(${questionId}, ${variant.id})">Редагувати</button>
+                            <button type="button" class="text-[11px] font-semibold text-red-600 underline hover:text-red-700" onclick="techEditor.deleteVariant(${questionId}, ${variant.id})">Видалити</button>
+                        </div>
+                    </div>
+                    <span data-variant-text>${text}</span>
+                </li>
+            `;
+        }
+
+        function renderVariants(questionData) {
+            const variants = Array.isArray(questionData.variants) ? questionData.variants : [];
+            const answersByMarker = questionData.answers_by_marker || {};
+
+            if (!variants.length) {
+                return '<li class="rounded-lg border border-dashed border-stone-300 px-3 py-2 text-sm text-stone-500" data-empty>Варіанти відсутні.</li>';
             }
+
+            return variants
+                .map((variant, index) => renderVariantHtml(questionData.id, variant, index + 1, answersByMarker))
+                .join('');
+        }
+
+        function renderVerbHintControl(questionData, answer) {
+            const verbHint = answer.verb_hint || null;
+
+            if (verbHint && verbHint.id) {
+                return `
+                    <span class="inline-flex flex-wrap items-center gap-2 rounded-full bg-white px-2 py-0.5 text-[11px] font-medium text-emerald-700" data-verb-hint data-verb-hint-id="${verbHint.id}">
+                        <span class="font-semibold uppercase text-[10px] tracking-wide">Verb hint</span>
+                        <span data-verb-hint-value>${escapeHtml(verbHint.value ?? '')}</span>
+                        <div class="flex items-center gap-2">
+                            <button type="button" class="text-[10px] font-semibold text-blue-600 underline hover:text-blue-800" onclick="techEditor.editVerbHint(${questionData.id}, ${verbHint.id})">Редагувати</button>
+                            <button type="button" class="text-[10px] font-semibold text-red-600 underline hover:text-red-700" onclick="techEditor.deleteVerbHint(${questionData.id}, ${verbHint.id})">Видалити</button>
+                        </div>
+                    </span>
+                `;
+            }
+
+            const markerLabel = escapeHtml(answer.marker || '');
+
+            return `
+                <button type="button" class="inline-flex items-center gap-1 rounded-full border border-dashed border-emerald-300 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 hover:bg-emerald-50" onclick="techEditor.addVerbHint(${questionData.id}, ${JSON.stringify(answer.marker || '')})">Додати verb hint</button>
+            `;
+        }
+
+        function renderAnswerHtml(questionData, answer) {
+            const answersMap = questionData.answers_by_marker || {};
+            const value = answer.value || answersMap[answer.marker_key] || '';
+            const marker = escapeHtml(answer.marker || '');
+            const valueHtml = escapeHtml(value);
+            const verbHintHtml = renderVerbHintControl(questionData, answer);
+
+            return `
+                <li class="flex flex-col gap-2 rounded-lg border border-emerald-100 bg-emerald-50/70 px-3 py-2" data-answer-id="${answer.id}">
+                    <div class="flex flex-wrap items-center gap-2 text-sm">
+                        <span class="font-mono text-xs uppercase text-emerald-500">${marker}</span>
+                        <span class="font-semibold text-emerald-900" data-answer-value>${valueHtml}</span>
+                        ${verbHintHtml}
+                    </div>
+                    <div class="flex flex-wrap gap-3 text-xs font-semibold">
+                        <button type="button" class="text-blue-600 underline hover:text-blue-800" onclick="techEditor.editAnswer(${questionData.id}, ${answer.id})">Редагувати відповідь</button>
+                        <button type="button" class="text-red-600 underline hover:text-red-700" onclick="techEditor.deleteAnswer(${questionData.id}, ${answer.id})">Видалити</button>
+                    </div>
+                </li>
+            `;
+        }
+
+        function renderAnswers(questionData) {
+            const answers = Array.isArray(questionData.answers) ? questionData.answers : [];
+
+            if (!answers.length) {
+                return '<li class="rounded-lg border border-dashed border-stone-300 px-3 py-2 text-sm text-stone-500" data-empty>Відповіді відсутні.</li>';
+            }
+
+            return answers.map(answer => renderAnswerHtml(questionData, answer)).join('');
+        }
+
+        function renderOptionHtml(questionId, option) {
+            const isCorrect = !!option.is_correct;
+            const classes = [
+                'inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm',
+                isCorrect ? 'border-emerald-200 bg-emerald-50 text-emerald-900 font-semibold shadow-sm' : 'border-stone-200 bg-stone-50 text-stone-800',
+            ];
 
             const parts = [`<div class="${classes.join(' ')}" data-option-id="${option.id ?? ''}">`];
 
-            if (option.is_correct) {
+            if (isCorrect) {
                 parts.push('<svg class="h-3.5 w-3.5 text-emerald-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.2 7.25a1 1 0 0 1-1.425-.01L3.29 9.967a1 1 0 1 1 1.42-1.407l3.162 3.19 6.49-6.538a1 1 0 0 1 1.342-.088Z" clip-rule="evenodd"></path></svg>');
             }
 
             parts.push(`<span>${escapeHtml(option.label ?? '')}</span>`);
 
             if (option.id) {
-                parts.push(`<button type="button" class="text-xs font-semibold text-blue-600 underline hover:text-blue-800" onclick="techEditor.editOption(${questionId}, ${option.id})">Редагувати</button>`);
+                const actions = [`<button type="button" class="text-xs font-semibold text-blue-600 underline hover:text-blue-800" onclick="techEditor.editOption(${questionId}, ${option.id})">Редагувати</button>`];
+
+                if (!isCorrect) {
+                    actions.push(`<button type="button" class="text-xs font-semibold text-red-600 underline hover:text-red-700" onclick="techEditor.deleteOption(${questionId}, ${option.id})">Видалити</button>`);
+                }
+
+                parts.push(`<div class="flex items-center gap-2">${actions.join('')}</div>`);
             }
 
             parts.push('</div>');
 
             return parts.join('');
+        }
+
+        function renderOptions(questionData) {
+            const options = Array.isArray(questionData.options) ? questionData.options : [];
+
+            if (!options.length) {
+                return '<p class="text-sm text-stone-500" data-empty>Варіанти відсутні.</p>';
+            }
+
+            return options.map(option => renderOptionHtml(questionData.id, option)).join('');
+        }
+
+        function renderQuestionHintHtml(questionId, hint) {
+            return `
+                <li class="rounded-lg border border-blue-100 bg-blue-50/60 px-3 py-2" data-question-hint-id="${hint.id}">
+                    <div class="flex items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-blue-700">
+                        <span>${escapeHtml(hint.provider ?? '')} · ${escapeHtml((hint.locale ?? '').toUpperCase())}</span>
+                        <div class="flex items-center gap-2">
+                            <button type="button" class="text-[11px] font-semibold text-blue-600 underline hover:text-blue-800" onclick="techEditor.editQuestionHint(${questionId}, ${hint.id})">Редагувати</button>
+                            <button type="button" class="text-[11px] font-semibold text-red-600 underline hover:text-red-700" onclick="techEditor.deleteQuestionHint(${questionId}, ${hint.id})">Видалити</button>
+                        </div>
+                    </div>
+                    <div class="mt-1 whitespace-pre-line text-stone-800" data-question-hint-text>${escapeHtml(hint.hint ?? '')}</div>
+                </li>
+            `;
+        }
+
+        function renderQuestionHints(questionData) {
+            const hints = Array.isArray(questionData.question_hints) ? questionData.question_hints : [];
+
+            if (!hints.length) {
+                return '<li class="rounded-lg border border-dashed border-blue-200 px-3 py-2 text-sm text-blue-600" data-empty>Підказки відсутні.</li>';
+            }
+
+            return hints.map(hint => renderQuestionHintHtml(questionData.id, hint)).join('');
         }
 
         function applyQuestionData(questionData) {
@@ -512,49 +714,25 @@
                 levelEl.textContent = levelValue ? levelValue : 'N/A';
             }
 
-            (questionData.variants || []).forEach(variant => {
-                const variantEl = entry.element.querySelector(`[data-variant-id="${variant.id}"] [data-variant-text]`);
-                if (variantEl) {
-                    variantEl.innerHTML = highlightSegments(variant.text, answersMap);
-                }
-            });
+            const variantsContainer = entry.element.querySelector('[data-variants-container]');
+            if (variantsContainer) {
+                variantsContainer.innerHTML = renderVariants(questionData);
+            }
 
-            (questionData.answers || []).forEach(answer => {
-                const answerRow = entry.element.querySelector(`[data-answer-id="${answer.id}"]`);
-                if (!answerRow) {
-                    return;
-                }
-
-                const valueEl = answerRow.querySelector('[data-answer-value]');
-                if (valueEl) {
-                    valueEl.textContent = answer.value ?? '';
-                }
-
-                const verbHintEl = answerRow.querySelector('[data-verb-hint]');
-                if (verbHintEl && answer.verb_hint) {
-                    verbHintEl.setAttribute('data-verb-hint-id', answer.verb_hint.id);
-                    const value = verbHintEl.querySelector('[data-verb-hint-value]');
-                    if (value) {
-                        value.textContent = answer.verb_hint.value ?? '';
-                    }
-                }
-            });
+            const answersContainer = entry.element.querySelector('[data-answers-container]');
+            if (answersContainer) {
+                answersContainer.innerHTML = renderAnswers(questionData);
+            }
 
             const optionsContainer = entry.element.querySelector('[data-options-container]');
             if (optionsContainer) {
-                const html = (questionData.options || [])
-                    .map(option => renderOptionHtml(questionData.id, option))
-                    .join('');
-
-                optionsContainer.innerHTML = html;
+                optionsContainer.innerHTML = renderOptions(questionData);
             }
 
-            (questionData.question_hints || []).forEach(hint => {
-                const hintEl = entry.element.querySelector(`[data-question-hint-id="${hint.id}"] [data-question-hint-text]`);
-                if (hintEl) {
-                    hintEl.textContent = hint.hint ?? '';
-                }
-            });
+            const hintsContainer = entry.element.querySelector('[data-question-hints-container]');
+            if (hintsContainer) {
+                hintsContainer.innerHTML = renderQuestionHints(questionData);
+            }
         }
 
         function clearError() {
@@ -712,22 +890,39 @@
             modal.element.classList.add('flex');
         }
 
-        function sendUpdate(url, payload) {
-            return fetch(url, {
-                method: 'PUT',
+        function sendJson(method, url, payload) {
+            const options = {
+                method,
                 headers: {
                     'X-CSRF-TOKEN': techCsrfToken,
-                    'Content-Type': 'application/json',
                     'Accept': 'application/json',
                 },
-                body: JSON.stringify(payload),
-            }).then(async response => {
+            };
+
+            if (payload !== undefined) {
+                options.headers['Content-Type'] = 'application/json';
+                options.body = JSON.stringify(payload);
+            }
+
+            return fetch(url, options).then(async response => {
                 const contentType = response.headers.get('Content-Type') || '';
 
                 if (response.ok) {
                     if (contentType.includes('application/json')) {
                         const data = await response.json();
-                        return data.data ?? data;
+                        if (data && typeof data === 'object') {
+                            if (data.question) {
+                                return data.question;
+                            }
+                            if (data.data) {
+                                return data.data;
+                            }
+                        }
+                        return data;
+                    }
+
+                    if (response.status === 204) {
+                        return null;
                     }
 
                     throw new Error('Порожня відповідь сервера.');
@@ -737,9 +932,15 @@
 
                 if (response.status === 422 && contentType.includes('application/json')) {
                     const data = await response.json();
-                    const errors = data.errors ? Object.values(data.errors).flat() : [];
-                    if (errors.length) {
-                        message = errors.join(' ');
+                    if (data) {
+                        if (data.errors) {
+                            const errors = Object.values(data.errors).flat();
+                            if (errors.length) {
+                                message = errors.join(' ');
+                            }
+                        } else if (data.message) {
+                            message = data.message;
+                        }
                     }
                 }
 
@@ -748,6 +949,36 @@
         }
 
         const techEditor = {
+            addQuestion() {
+                openModal({
+                    title: 'Додати питання до тесту',
+                    fields: [
+                        {
+                            name: 'question_id',
+                            label: 'ID питання',
+                            type: 'number',
+                            required: true,
+                            autocomplete: 'off',
+                        },
+                    ],
+                    onSubmit(values) {
+                        return sendJson('POST', routes.testQuestion, { question_id: values.question_id })
+                            .then(() => {
+                                window.location.reload();
+                                return null;
+                            });
+                    },
+                });
+            },
+            deleteQuestion(questionId) {
+                if (!window.confirm('Видалити це питання з тесту?')) {
+                    return;
+                }
+
+                sendJson('DELETE', `${routes.testQuestion}/${questionId}`)
+                    .then(() => window.location.reload())
+                    .catch(error => window.alert(error.message || 'Не вдалося видалити питання.'));
+            },
             editQuestion(questionId) {
                 const entry = state.get(questionId);
                 if (!entry) {
@@ -766,7 +997,7 @@
                         },
                     ],
                     onSubmit(values) {
-                        return sendUpdate(`${routes.question}/${questionId}`, { question: values.question })
+                        return sendJson('PUT', `${routes.question}/${questionId}`, { question: values.question })
                             .then(applyQuestionData);
                     },
                 });
@@ -782,9 +1013,7 @@
                 ];
 
                 if (Array.isArray(cefrLevels) && cefrLevels.length) {
-                    options.push(
-                        ...cefrLevels.map(level => ({ value: level, label: level }))
-                    );
+                    options.push(...cefrLevels.map(level => ({ value: level, label: level })));
                 }
 
                 openModal({
@@ -799,7 +1028,24 @@
                         },
                     ],
                     onSubmit(values) {
-                        return sendUpdate(`${routes.question}/${questionId}`, { level: values.level || null })
+                        return sendJson('PUT', `${routes.question}/${questionId}`, { level: values.level || null })
+                            .then(applyQuestionData);
+                    },
+                });
+            },
+            addVariant(questionId) {
+                openModal({
+                    title: 'Додати варіант питання',
+                    fields: [
+                        {
+                            name: 'text',
+                            label: 'Текст варіанту',
+                            type: 'textarea',
+                            required: true,
+                        },
+                    ],
+                    onSubmit(values) {
+                        return sendJson('POST', `${routes.question}/${questionId}/variants`, { text: values.text })
                             .then(applyQuestionData);
                     },
                 });
@@ -827,8 +1073,44 @@
                         },
                     ],
                     onSubmit(values) {
-                        return sendUpdate(`${routes.variant}/${variantId}`, { text: values.text })
+                        return sendJson('PUT', `${routes.questionVariant}/${variantId}`, { text: values.text })
                             .then(applyQuestionData);
+                    },
+                });
+            },
+            deleteVariant(questionId, variantId) {
+                if (!window.confirm('Видалити цей варіант?')) {
+                    return;
+                }
+
+                sendJson('DELETE', `${routes.questionVariant}/${variantId}`)
+                    .then(applyQuestionData)
+                    .catch(error => window.alert(error.message || 'Не вдалося видалити варіант.'));
+            },
+            addAnswer(questionId) {
+                openModal({
+                    title: 'Додати відповідь',
+                    fields: [
+                        {
+                            name: 'marker',
+                            label: 'Маркер (наприклад A1)',
+                            type: 'text',
+                            required: true,
+                            autocomplete: 'off',
+                        },
+                        {
+                            name: 'value',
+                            label: 'Відповідь',
+                            type: 'text',
+                            required: true,
+                            autocomplete: 'off',
+                        },
+                    ],
+                    onSubmit(values) {
+                        return sendJson('POST', `${routes.question}/${questionId}/answers`, {
+                            marker: values.marker,
+                            value: values.value,
+                        }).then(applyQuestionData);
                     },
                 });
             },
@@ -856,7 +1138,34 @@
                         },
                     ],
                     onSubmit(values) {
-                        return sendUpdate(`${routes.answer}/${answerId}`, { value: values.value })
+                        return sendJson('PUT', `${routes.questionAnswer}/${answerId}`, { value: values.value })
+                            .then(applyQuestionData);
+                    },
+                });
+            },
+            deleteAnswer(questionId, answerId) {
+                if (!window.confirm('Видалити цю відповідь?')) {
+                    return;
+                }
+
+                sendJson('DELETE', `${routes.questionAnswer}/${answerId}`)
+                    .then(applyQuestionData)
+                    .catch(error => window.alert(error.message || 'Не вдалося видалити відповідь.'));
+            },
+            addOption(questionId) {
+                openModal({
+                    title: 'Додати варіант відповіді',
+                    fields: [
+                        {
+                            name: 'value',
+                            label: 'Варіант відповіді',
+                            type: 'text',
+                            required: true,
+                            autocomplete: 'off',
+                        },
+                    ],
+                    onSubmit(values) {
+                        return sendJson('POST', `${routes.question}/${questionId}/options`, { value: values.value })
                             .then(applyQuestionData);
                     },
                 });
@@ -885,8 +1194,51 @@
                         },
                     ],
                     onSubmit(values) {
-                        return sendUpdate(`${routes.option}/${questionId}/options/${optionId}`, { value: values.value })
+                        return sendJson('PUT', `${routes.question}/${questionId}/options/${optionId}`, { value: values.value })
                             .then(applyQuestionData);
+                    },
+                });
+            },
+            deleteOption(questionId, optionId) {
+                if (!window.confirm('Видалити цей варіант відповіді?')) {
+                    return;
+                }
+
+                sendJson('DELETE', `${routes.question}/${questionId}/options/${optionId}`)
+                    .then(applyQuestionData)
+                    .catch(error => window.alert(error.message || 'Не вдалося видалити варіант відповіді.'));
+            },
+            addQuestionHint(questionId) {
+                openModal({
+                    title: 'Додати підказку',
+                    fields: [
+                        {
+                            name: 'provider',
+                            label: 'Провайдер',
+                            type: 'text',
+                            required: true,
+                            autocomplete: 'off',
+                        },
+                        {
+                            name: 'locale',
+                            label: 'Мова',
+                            type: 'text',
+                            required: true,
+                            autocomplete: 'off',
+                        },
+                        {
+                            name: 'hint',
+                            label: 'Текст підказки',
+                            type: 'textarea',
+                            required: true,
+                        },
+                    ],
+                    onSubmit(values) {
+                        return sendJson('POST', `${routes.question}/${questionId}/hints`, {
+                            provider: values.provider,
+                            locale: values.locale,
+                            hint: values.hint,
+                        }).then(applyQuestionData);
                     },
                 });
             },
@@ -913,8 +1265,38 @@
                         },
                     ],
                     onSubmit(values) {
-                        return sendUpdate(`${routes.questionHint}/${hintId}`, { hint: values.hint })
+                        return sendJson('PUT', `${routes.questionHint}/${hintId}`, { hint: values.hint })
                             .then(applyQuestionData);
+                    },
+                });
+            },
+            deleteQuestionHint(questionId, hintId) {
+                if (!window.confirm('Видалити цю підказку?')) {
+                    return;
+                }
+
+                sendJson('DELETE', `${routes.questionHint}/${hintId}`)
+                    .then(applyQuestionData)
+                    .catch(error => window.alert(error.message || 'Не вдалося видалити підказку.'));
+            },
+            addVerbHint(questionId, marker) {
+                openModal({
+                    title: 'Додати verb hint',
+                    fields: [
+                        {
+                            name: 'hint',
+                            label: 'Verb hint',
+                            type: 'text',
+                            required: true,
+                            autocomplete: 'off',
+                        },
+                    ],
+                    onSubmit(values) {
+                        return sendJson('POST', routes.verbHint, {
+                            question_id: questionId,
+                            marker,
+                            hint: values.hint,
+                        }).then(applyQuestionData);
                     },
                 });
             },
@@ -942,10 +1324,19 @@
                         },
                     ],
                     onSubmit(values) {
-                        return sendUpdate(`${routes.verbHint}/${verbHintId}`, { hint: values.hint })
+                        return sendJson('PUT', `${routes.verbHint}/${verbHintId}`, { hint: values.hint })
                             .then(applyQuestionData);
                     },
                 });
+            },
+            deleteVerbHint(questionId, verbHintId) {
+                if (!window.confirm('Видалити verb hint?')) {
+                    return;
+                }
+
+                sendJson('DELETE', `${routes.verbHint}/${verbHintId}`)
+                    .then(applyQuestionData)
+                    .catch(error => window.alert(error.message || 'Не вдалося видалити verb hint.'));
             },
             applyQuestionData,
         };
@@ -1025,4 +1416,5 @@
         window.techEditor = techEditor;
     })();
 </script>
+
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,6 +92,7 @@ Route::post('/test/{slug}/step/determine-level-gemini', [GrammarTestController::
 Route::post('/test/{slug}/step/set-level', [GrammarTestController::class, 'setLevel'])->name('saved-test.step.set-level');
 Route::post('/test/{slug}/step/add-tag', [GrammarTestController::class, 'addTag'])->name('saved-test.step.add-tag');
 Route::delete('/test/{slug}/step/remove-tag', [GrammarTestController::class, 'removeTag'])->name('saved-test.step.remove-tag');
+Route::post('/test/{slug}/question', [GrammarTestController::class, 'addQuestion'])->name('saved-test.question.store');
 Route::delete('/test/{slug}/question/{question}', [GrammarTestController::class, 'deleteQuestion'])->name('saved-test.question.destroy');
 Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
 Route::delete('/tests/{test}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
@@ -136,10 +137,18 @@ Route::post('/verb-hints', [VerbHintController::class, 'store'])->name('verb-hin
 Route::put('/verb-hints/{verbHint}', [VerbHintController::class, 'update'])->name('verb-hints.update');
 Route::delete('/verb-hints/{verbHint}', [VerbHintController::class, 'destroy'])->name('verb-hints.destroy');
 Route::put('/questions/{question}', [QuestionController::class, 'update'])->name('questions.update');
+Route::post('/questions/{question}/answers', [QuestionAnswerController::class, 'store'])->name('questions.answers.store');
 Route::put('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'update'])->name('question-answers.update');
+Route::delete('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'destroy'])->name('question-answers.destroy');
+Route::post('/questions/{question}/options', [QuestionOptionController::class, 'store'])->name('questions.options.store');
 Route::put('/questions/{question}/options/{option}', [QuestionOptionController::class, 'update'])->name('questions.options.update');
+Route::delete('/questions/{question}/options/{option}', [QuestionOptionController::class, 'destroy'])->name('questions.options.destroy');
+Route::post('/questions/{question}/variants', [QuestionVariantController::class, 'store'])->name('questions.variants.store');
+Route::delete('/question-variants/{questionVariant}', [QuestionVariantController::class, 'destroy'])->name('question-variants.destroy');
+Route::post('/questions/{question}/hints', [QuestionHintController::class, 'store'])->name('questions.hints.store');
 Route::put('/question-variants/{questionVariant}', [QuestionVariantController::class, 'update'])->name('question-variants.update');
 Route::put('/question-hints/{questionHint}', [QuestionHintController::class, 'update'])->name('question-hints.update');
+Route::delete('/question-hints/{questionHint}', [QuestionHintController::class, 'destroy'])->name('question-hints.destroy');
 
 Route::post('/question-hint', [QuestionHelpController::class, 'hint'])->name('question.hint');
 Route::post('/question-explain', [QuestionHelpController::class, 'explain'])->name('question.explain');


### PR DESCRIPTION
## Summary
- add routes and controller actions to create and delete saved-test questions and their related entities
- enhance the technical saved-test view with controls for adding/removing questions, answers, options, variants, hints, and verb hints
- overhaul the tech editor script to support new CRUD operations and dynamic UI updates

## Testing
- php -l app/Http/Controllers/GrammarTestController.php
- php -l app/Http/Controllers/QuestionAnswerController.php
- php -l app/Http/Controllers/QuestionHintController.php
- php -l app/Http/Controllers/QuestionOptionController.php
- php -l app/Http/Controllers/QuestionVariantController.php
- php -l app/Http/Controllers/VerbHintController.php
- phpunit *(fails: command not available)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdbf769fc832aae43b519c4f66c1d