### PR TITLE
Add base question seeder with reusable UUID generation

### DIFF
--- a/database/seeders/PastSimpleRegularSeeder.php
+++ b/database/seeders/PastSimpleRegularSeeder.php
@@ -2,13 +2,11 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;
-use Illuminate\Support\Str;
 
-class PastSimpleRegularSeeder extends Seeder
+class PastSimpleRegularSeeder extends QuestionSeeder
 {
 
     public function run()
@@ -166,9 +164,7 @@ class PastSimpleRegularSeeder extends Seeder
         $items = [];
         foreach ($questions as $i => $data) {
             $index = $i + 1;
-            $slug  = Str::slug(class_basename(self::class));
-            $max   = 36 - strlen((string) $index) - 1;
-            $uuid  = substr($slug, 0, $max) . '-' . $index;
+            $uuid  = $this->generateQuestionUuid($index);
 
             $items[] = [
                 'uuid'        => $uuid,

--- a/database/seeders/PresentContinuousStorySeeder.php
+++ b/database/seeders/PresentContinuousStorySeeder.php
@@ -5,10 +5,8 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
-use Illuminate\Support\Str;
 
-class PresentContinuousStorySeeder extends Seeder
+class PresentContinuousStorySeeder extends QuestionSeeder
 {
     public function run()
     {
@@ -35,7 +33,7 @@ class PresentContinuousStorySeeder extends Seeder
             ['marker' => 'a10','answer' => 'are singing',  'verb_hint' => 'sing'],
         ];
 
-        $uuid = Str::slug(class_basename(self::class));
+        $uuid = $this->generateQuestionUuid();
 
         $service = new QuestionSeedingService();
         $service->seed([

--- a/database/seeders/QuestionSeeder.php
+++ b/database/seeders/QuestionSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+abstract class QuestionSeeder extends Seeder
+{
+    protected const UUID_LENGTH = 36;
+
+    protected function generateQuestionUuid(int|string ...$segments): string
+    {
+        $base = Str::slug(class_basename(static::class));
+
+        $normalizedSegments = [];
+        foreach ($segments as $segment) {
+            $segment = Str::slug((string) $segment);
+            if ($segment === '') {
+                continue;
+            }
+
+            $normalizedSegments[] = $segment;
+        }
+
+        $suffix = '';
+        if ($normalizedSegments) {
+            $suffix = '-' . implode('-', $normalizedSegments);
+        }
+
+        $maxLength = self::UUID_LENGTH - strlen($suffix);
+
+        if ($maxLength <= 0) {
+            return substr(ltrim($suffix, '-'), 0, self::UUID_LENGTH);
+        }
+
+        $base = substr($base, 0, $maxLength);
+
+        if ($base === '') {
+            return substr(ltrim($suffix, '-'), 0, self::UUID_LENGTH);
+        }
+
+        return $base . $suffix;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `QuestionSeeder` base class that generates deterministic 36-character UUIDs from the child seeder name and optional suffixes
- update `PastSimpleRegularSeeder` and `PresentContinuousStorySeeder` to extend the base class and call the helper instead of duplicating UUID logic

## Testing
- php -l database/seeders/QuestionSeeder.php
- php -l database/seeders/PastSimpleRegularSeeder.php
- php -l database/seeders/PresentContinuousStorySeeder.php

------
https://chatgpt.com/codex/tasks/task_e_68d1a14c0780832ab6d4724b13bd234a