### PR TITLE
Handle incomplete CSV rows in seeder

### DIFF
--- a/database/seeders/WordsWithTranslationsSeeder.php
+++ b/database/seeders/WordsWithTranslationsSeeder.php
@@ -20,6 +20,10 @@ class WordsWithTranslationsSeeder extends Seeder
         try {
             $popularTag = Tag::firstOrCreate(['name' => '1000_most_popular']);
             foreach ($rows as $row) {
+                if (count($row) < 2) {
+                    continue;
+                }
+
                 $en = trim($row[0]);
                 $uk = trim($row[1]);
                 if (empty($en) || empty($uk)) {


### PR DESCRIPTION
## Summary
- skip CSV entries that do not contain both the English word and Ukrainian translation before processing

## Testing
- php artisan db:seed --class=WordsWithTranslationsSeeder --force *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68d593b7cd70832aa9596989d2196657