### PR TITLE
Add automatic question JSON export on save

### DIFF
--- a/app/Observers/QuestionObserver.php
+++ b/app/Observers/QuestionObserver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Question;
+use App\Services\QuestionExportService;
+
+class QuestionObserver
+{
+    public function __construct(private readonly QuestionExportService $exportService)
+    {
+    }
+
+    public function saved(Question $question): void
+    {
+        $this->exportService->export($question->fresh());
+    }
+}
+

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\Question;
+use App\Observers\QuestionObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,5 +22,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         app()->setLocale(session('locale', config('app.locale')));
+
+        Question::observe(QuestionObserver::class);
     }
 }

--- a/app/Services/QuestionExportService.php
+++ b/app/Services/QuestionExportService.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Question;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class QuestionExportService
+{
+    public function export(Question $question): void
+    {
+        if (blank($question->uuid)) {
+            $question->uuid = (string) Str::uuid();
+            $question->saveQuietly();
+        }
+
+        $question->loadMissing([
+            'category',
+            'source',
+            'tags',
+            'options',
+            'answers.option',
+            'verbHints.option',
+            'variants',
+            'hints',
+        ]);
+
+        $payload = [
+            'question' => $this->formatQuestion($question),
+            'category' => $question->category ? $this->formatCategory($question) : null,
+            'source' => $question->source ? $this->formatSource($question) : null,
+            'tags' => $this->formatTags($question),
+            'options' => $this->formatOptions($question),
+            'answers' => $this->formatAnswers($question),
+            'verb_hints' => $this->formatVerbHints($question),
+            'variants' => $this->formatVariants($question),
+            'hints' => $this->formatHints($question),
+        ];
+
+        $this->writeJson($question->uuid, $payload);
+    }
+
+    private function formatQuestion(Question $question): array
+    {
+        return [
+            'id' => $question->id,
+            'uuid' => $question->uuid,
+            'question' => $question->question,
+            'difficulty' => $question->difficulty,
+            'level' => $question->level,
+            'category_id' => $question->category_id,
+            'source_id' => $question->source_id,
+            'flag' => $question->flag,
+            'created_at' => $this->formatDate($question->created_at),
+            'updated_at' => $this->formatDate($question->updated_at),
+        ];
+    }
+
+    private function formatCategory(Question $question): array
+    {
+        return [
+            'id' => $question->category->id,
+            'name' => $question->category->name,
+            'created_at' => $this->formatDate($question->category->created_at),
+            'updated_at' => $this->formatDate($question->category->updated_at),
+        ];
+    }
+
+    private function formatSource(Question $question): array
+    {
+        return [
+            'id' => $question->source->id,
+            'name' => $question->source->name,
+            'created_at' => $this->formatDate($question->source->created_at),
+            'updated_at' => $this->formatDate($question->source->updated_at),
+        ];
+    }
+
+    private function formatTags(Question $question): array
+    {
+        return $question->tags->map(function ($tag) use ($question) {
+            return [
+                'tag' => [
+                    'id' => $tag->id,
+                    'name' => $tag->name,
+                    'category' => $tag->category,
+                    'created_at' => $this->formatDate($tag->created_at),
+                    'updated_at' => $this->formatDate($tag->updated_at),
+                ],
+                'pivot' => [
+                    'question_id' => $tag->pivot?->question_id ?? $question->id,
+                    'tag_id' => $tag->pivot?->tag_id ?? $tag->id,
+                    'created_at' => $this->formatDate($tag->pivot?->created_at),
+                    'updated_at' => $this->formatDate($tag->pivot?->updated_at),
+                ],
+            ];
+        })->values()->all();
+    }
+
+    private function formatOptions(Question $question): array
+    {
+        return $question->options->map(function ($option) use ($question) {
+            return [
+                'option' => [
+                    'id' => $option->id,
+                    'option' => $option->option,
+                    'created_at' => $this->formatDate($option->created_at),
+                    'updated_at' => $this->formatDate($option->updated_at),
+                ],
+                'pivot' => [
+                    'question_id' => $option->pivot?->question_id ?? $question->id,
+                    'option_id' => $option->pivot?->option_id ?? $option->id,
+                    'flag' => $option->pivot?->flag,
+                ],
+            ];
+        })->values()->all();
+    }
+
+    private function formatAnswers(Question $question): array
+    {
+        return $question->answers->map(function ($answer) {
+            return [
+                'answer' => [
+                    'id' => $answer->id,
+                    'question_id' => $answer->question_id,
+                    'marker' => $answer->marker,
+                    'option_id' => $answer->option_id,
+                    'created_at' => $this->formatDate($answer->created_at),
+                    'updated_at' => $this->formatDate($answer->updated_at),
+                ],
+                'option' => $answer->option ? [
+                    'id' => $answer->option->id,
+                    'option' => $answer->option->option,
+                    'created_at' => $this->formatDate($answer->option->created_at),
+                    'updated_at' => $this->formatDate($answer->option->updated_at),
+                ] : null,
+            ];
+        })->values()->all();
+    }
+
+    private function formatVerbHints(Question $question): array
+    {
+        return $question->verbHints->map(function ($hint) {
+            return [
+                'verb_hint' => [
+                    'id' => $hint->id,
+                    'question_id' => $hint->question_id,
+                    'marker' => $hint->marker,
+                    'option_id' => $hint->option_id,
+                    'created_at' => $this->formatDate($hint->created_at),
+                    'updated_at' => $this->formatDate($hint->updated_at),
+                ],
+                'option' => $hint->option ? [
+                    'id' => $hint->option->id,
+                    'option' => $hint->option->option,
+                    'created_at' => $this->formatDate($hint->option->created_at),
+                    'updated_at' => $this->formatDate($hint->option->updated_at),
+                ] : null,
+            ];
+        })->values()->all();
+    }
+
+    private function formatVariants(Question $question): array
+    {
+        return $question->variants->map(function ($variant) {
+            return [
+                'id' => $variant->id,
+                'question_id' => $variant->question_id,
+                'text' => $variant->text,
+                'created_at' => $this->formatDate($variant->created_at),
+                'updated_at' => $this->formatDate($variant->updated_at),
+            ];
+        })->values()->all();
+    }
+
+    private function formatHints(Question $question): array
+    {
+        return $question->hints->map(function ($hint) {
+            return [
+                'id' => $hint->id,
+                'question_id' => $hint->question_id,
+                'provider' => $hint->provider,
+                'locale' => $hint->locale,
+                'hint' => $hint->hint,
+                'created_at' => $this->formatDate($hint->created_at),
+                'updated_at' => $this->formatDate($hint->updated_at),
+            ];
+        })->values()->all();
+    }
+
+    private function writeJson(string $uuid, array $payload): void
+    {
+        $directory = database_path('seeders/questions');
+        File::ensureDirectoryExists($directory);
+
+        $path = $directory . DIRECTORY_SEPARATOR . $uuid . '.json';
+        File::put($path, json_encode($this->convertDates($payload), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+    }
+
+    private function convertDates(array $payload): array
+    {
+        return json_decode(json_encode($payload), true);
+    }
+
+    private function formatDate(mixed $value): ?string
+    {
+        if ($value instanceof CarbonInterface) {
+            return $value->toISOString();
+        }
+
+        if (is_string($value)) {
+            try {
+                return Carbon::parse($value)->toISOString();
+            } catch (\Throwable) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+}
+

--- a/database/seeders/questions/.gitignore
+++ b/database/seeders/questions/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!*.json

--- a/tests/Feature/QuestionExportTest.php
+++ b/tests/Feature/QuestionExportTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Question;
+use App\Models\QuestionAnswer;
+use App\Models\QuestionHint;
+use App\Models\QuestionOption;
+use App\Models\QuestionVariant;
+use App\Models\Source;
+use App\Models\Tag;
+use App\Models\VerbHint;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class QuestionExportTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::disableForeignKeyConstraints();
+        Schema::dropAllTables();
+        Schema::enableForeignKeyConstraints();
+
+        $this->createTables();
+    }
+
+    public function test_question_update_exports_related_data_to_json(): void
+    {
+        $directory = database_path('seeders/questions');
+        if (File::exists($directory)) {
+            File::cleanDirectory($directory);
+        }
+
+        $category = Category::create(['name' => 'Grammar']);
+        $source = Source::create(['name' => 'Manual']);
+        $tag = Tag::create(['name' => 'present-simple', 'category' => 'tense']);
+        $option = QuestionOption::create(['option' => 'runs']);
+
+        $question = Question::create([
+            'uuid' => (string) Str::uuid(),
+            'question' => 'She {a1} every morning.',
+            'difficulty' => 1,
+            'level' => 'A1',
+            'category_id' => $category->id,
+            'source_id' => $source->id,
+            'flag' => 0,
+        ]);
+
+        $question->tags()->attach($tag->id);
+        $question->options()->attach($option->id, ['flag' => null]);
+
+        QuestionAnswer::create([
+            'question_id' => $question->id,
+            'marker' => 'A1',
+            'option_id' => $option->id,
+        ]);
+
+        VerbHint::create([
+            'question_id' => $question->id,
+            'marker' => 'A1',
+            'option_id' => $option->id,
+        ]);
+
+        QuestionVariant::create([
+            'question_id' => $question->id,
+            'text' => 'She runs every morning.',
+        ]);
+
+        QuestionHint::create([
+            'question_id' => $question->id,
+            'provider' => 'system',
+            'locale' => 'en',
+            'hint' => 'Use the third person singular.',
+        ]);
+
+        $question->update(['question' => 'She {a1} after breakfast.']);
+
+        $jsonPath = $directory . DIRECTORY_SEPARATOR . $question->uuid . '.json';
+
+        $this->assertFileExists($jsonPath);
+
+        $payload = json_decode(File::get($jsonPath), true);
+
+        $this->assertEquals($question->uuid, $payload['question']['uuid']);
+        $this->assertSame('She {a1} after breakfast.', $payload['question']['question']);
+        $this->assertCount(1, $payload['tags']);
+        $this->assertCount(1, $payload['options']);
+        $this->assertCount(1, $payload['answers']);
+        $this->assertCount(1, $payload['verb_hints']);
+        $this->assertCount(1, $payload['variants']);
+        $this->assertCount(1, $payload['hints']);
+
+        File::delete($jsonPath);
+    }
+
+    private function createTables(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('sources', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('category')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('questions', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('question');
+            $table->unsignedTinyInteger('difficulty')->default(1);
+            $table->string('level')->nullable();
+            $table->unsignedBigInteger('category_id')->nullable();
+            $table->unsignedBigInteger('source_id')->nullable();
+            $table->integer('flag')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('question_options', function (Blueprint $table) {
+            $table->id();
+            $table->string('option');
+            $table->timestamps();
+        });
+
+        Schema::create('question_option_question', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('question_id');
+            $table->unsignedBigInteger('option_id');
+            $table->tinyInteger('flag')->nullable();
+            $table->unique(['question_id', 'option_id', 'flag']);
+        });
+
+        Schema::create('question_answers', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('question_id');
+            $table->string('marker');
+            $table->unsignedBigInteger('option_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('verb_hints', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('question_id');
+            $table->string('marker');
+            $table->unsignedBigInteger('option_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('question_variants', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('question_id');
+            $table->text('text');
+            $table->timestamps();
+        });
+
+        Schema::create('question_hints', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('question_id');
+            $table->string('provider');
+            $table->string('locale', 8);
+            $table->text('hint');
+            $table->timestamps();
+        });
+
+        Schema::create('question_tag', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tag_id');
+            $table->unsignedBigInteger('question_id');
+            $table->timestamps();
+            $table->unique(['tag_id', 'question_id']);
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add an observer and export service that write each question with related data to a UUID-named JSON file on save
- register the observer and add a git-tracked seeders/questions directory for the exports
- cover the exporter with a feature test that exercises JSON regeneration after a question update

## Testing
- php artisan test --filter=QuestionExportTest *(emits a warning about a missing .env file while assertions pass)*

------
https://chatgpt.com/codex/tasks/task_e_68d66610a944832a913656646de2cc84