### PR TITLE
Ensure question export reflects updated ChatGPT explanations

### DIFF
--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -6,6 +6,7 @@ use App\Http\Resources\TechnicalQuestionResource;
 use App\Models\Question;
 use Illuminate\Http\Request;
 use App\Models\ChatGPTExplanation;
+use App\Services\QuestionExportService;
 
 class QuestionController extends Controller
 {
@@ -36,6 +37,12 @@ class QuestionController extends Controller
                 if (array_key_exists('level', $data)) {
                     ChatGPTExplanation::where('question', $data['question'] ?? $oldQuestion)
                         ->update(['level' => $data['level']]);
+                }
+
+                // Re-export question dump when the question text changes so related
+                // ChatGPT explanations are written with the updated question value
+                if ($question->wasChanged('question')) {
+                    app(QuestionExportService::class)->export($question->fresh());
                 }
             }
         }


### PR DESCRIPTION
## Summary
- re-export question dumps after syncing ChatGPT explanations so the JSON reflects the updated prompt text

## Testing
- php artisan test --filter QuestionExportTest *(fails: 422 due to validation error when creating a verb hint without seeded answers)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b941c0b4832aa957b937922182b8