### PR TITLE
Add UUID-based grammar test builder and unify saved test handling

### DIFF
--- a/app/Models/SavedGrammarTest.php
+++ b/app/Models/SavedGrammarTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class SavedGrammarTest extends Model
+{
+    protected $fillable = [
+        'uuid',
+        'name',
+        'slug',
+        'filters',
+        'description',
+    ];
+
+    protected $casts = [
+        'filters' => 'array',
+    ];
+
+    public function questionLinks(): HasMany
+    {
+        return $this->hasMany(SavedGrammarTestQuestion::class)->orderBy('position');
+    }
+
+    public function getQuestionUuidsAttribute(): array
+    {
+        return $this->relationLoaded('questionLinks')
+            ? $this->questionLinks->pluck('question_uuid')->filter()->values()->all()
+            : $this->questionLinks()->pluck('question_uuid')->filter()->values()->all();
+    }
+}

--- a/app/Models/SavedGrammarTestQuestion.php
+++ b/app/Models/SavedGrammarTestQuestion.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SavedGrammarTestQuestion extends Model
+{
+    protected $fillable = [
+        'question_uuid',
+        'position',
+    ];
+
+    public function test(): BelongsTo
+    {
+        return $this->belongsTo(SavedGrammarTest::class, 'saved_grammar_test_id');
+    }
+}

--- a/app/Services/QuestionVariantService.php
+++ b/app/Services/QuestionVariantService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Question;
+use App\Models\SavedGrammarTest;
 use App\Models\Test;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
@@ -36,7 +37,7 @@ class QuestionVariantService
         return $variants;
     }
 
-    public function applyRandomVariant(Test $test, Question $question, ?string $previousVariant = null): void
+    public function applyRandomVariant(Test|SavedGrammarTest $test, Question $question, ?string $previousVariant = null): void
     {
         if (! $this->supportsVariants()) {
             return;
@@ -78,7 +79,7 @@ class QuestionVariantService
         $question->setAttribute('question', $choice);
     }
 
-    public function applyRandomVariants(Test $test, Collection $questions, array $previousVariants = []): Collection
+    public function applyRandomVariants(Test|SavedGrammarTest $test, Collection $questions, array $previousVariants = []): Collection
     {
         if (! $this->supportsVariants()) {
             return $questions;

--- a/app/Services/ResolvedSavedTest.php
+++ b/app/Services/ResolvedSavedTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+class ResolvedSavedTest
+{
+    public function __construct(
+        public Model $model,
+        public Collection $questionIds,
+        public Collection $questionUuids,
+        public bool $usesUuidLinks
+    ) {
+    }
+}

--- a/app/Services/SavedTestResolver.php
+++ b/app/Services/SavedTestResolver.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Question;
+use App\Models\SavedGrammarTest;
+use App\Models\Test;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Collection;
+
+class SavedTestResolver
+{
+    public function resolve(string $slug): ResolvedSavedTest
+    {
+        $legacy = Test::where('slug', $slug)->first();
+
+        if ($legacy) {
+            $questionIds = collect($legacy->questions ?? [])
+                ->filter(fn ($id) => filled($id))
+                ->map(fn ($id) => (int) $id)
+                ->values();
+
+            $uuidMap = $questionIds->isEmpty()
+                ? collect()
+                : Question::whereIn('id', $questionIds)->pluck('uuid', 'id');
+
+            $questionUuids = $questionIds
+                ->map(fn ($id) => $uuidMap[$id] ?? null)
+                ->filter()
+                ->values();
+
+            return new ResolvedSavedTest($legacy, $questionIds, $questionUuids, false);
+        }
+
+        $saved = SavedGrammarTest::with('questionLinks')->where('slug', $slug)->first();
+
+        if ($saved) {
+            $questionUuids = $saved->questionLinks
+                ->sortBy('position')
+                ->pluck('question_uuid')
+                ->filter(fn ($uuid) => filled($uuid))
+                ->values();
+
+            $idMap = $questionUuids->isEmpty()
+                ? collect()
+                : Question::whereIn('uuid', $questionUuids)->pluck('id', 'uuid');
+
+            $questionIds = $questionUuids
+                ->map(fn ($uuid) => isset($idMap[$uuid]) ? (int) $idMap[$uuid] : null)
+                ->filter(fn ($id) => $id !== null)
+                ->values();
+
+            return new ResolvedSavedTest($saved, $questionIds, $questionUuids, true);
+        }
+
+        throw new ModelNotFoundException("Saved test [{$slug}] not found.");
+    }
+
+    public function loadQuestions(ResolvedSavedTest $resolved, array $relations = []): Collection
+    {
+        if ($resolved->questionIds->isEmpty()) {
+            return collect();
+        }
+
+        $query = Question::with($relations)->whereIn('id', $resolved->questionIds);
+
+        $questions = $query->get()->keyBy('id');
+
+        return $resolved->questionIds
+            ->map(fn ($id) => $questions->get($id))
+            ->filter()
+            ->values();
+    }
+}

--- a/database/migrations/2025_08_15_000000_create_saved_grammar_tests_tables.php
+++ b/database/migrations/2025_08_15_000000_create_saved_grammar_tests_tables.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('saved_grammar_tests', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('uuid')->unique();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->json('filters');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('saved_grammar_test_questions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('saved_grammar_test_id')->constrained('saved_grammar_tests')->cascadeOnDelete();
+            $table->uuid('question_uuid');
+            $table->unsignedInteger('position')->default(0);
+            $table->timestamps();
+
+            $table->index('question_uuid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('saved_grammar_test_questions');
+        Schema::dropIfExists('saved_grammar_tests');
+    }
+};

--- a/resources/views/grammar-test.blade.php
+++ b/resources/views/grammar-test.blade.php
@@ -5,10 +5,15 @@
 @section('content')
 <div class="max-w-3xl mx-auto p-4">
     @php
-        $autocompleteRoute = url('/api/search?lang=en');
-        $checkOneRoute = route('grammar-test.checkOne');
-        $sources = \App\Models\Source::orderBy('name')->get();
-    @endphp
+    $autocompleteRoute = url('/api/search?lang=en');
+    $checkOneRoute = route('grammar-test.checkOne');
+    $sources = \App\Models\Source::orderBy('name')->get();
+    $generateRoute = $generateRoute ?? route('grammar-test.generate');
+    $saveRoute = $saveRoute ?? route('grammar-test.save');
+    $savePayloadField = $savePayloadField ?? 'questions';
+    $savePayloadKey = $savePayloadKey ?? 'id';
+    $questions = collect($questions ?? []);
+@endphp
     
         <div class="flex items-center justify-between mb-6">
             <h1 class="text-2xl font-bold">Конструктор тесту</h1>
@@ -20,7 +25,7 @@
     
     
     {{-- Конструктор тесту --}}
-    <form action="{{ route('grammar-test.generate') }}" method="POST" class="mb-8 space-y-4 bg-white shadow rounded-2xl p-4">
+    <form action="{{ $generateRoute }}" method="POST" class="mb-8 space-y-4 bg-white shadow rounded-2xl p-4">
         @csrf
         <div>
             <label class="block font-bold mb-1">Часи (категорії):</label>
@@ -255,7 +260,7 @@
 
         @if(!empty($questions) && count($questions))
         <div class="mb-4 mt-6">
-            <form action="{{ route('grammar-test.save') }}" method="POST" class="flex items-center gap-3">
+            <form action="{{ $saveRoute }}" method="POST" class="flex items-center gap-3">
                 @csrf
                 <input type="hidden" name="filters" value="{{ htmlentities(json_encode([
                     'categories' => $selectedCategories,
@@ -270,7 +275,7 @@
                     'only_ai' => $onlyAi ?? false,
                     'levels' => $selectedLevels ?? []
                 ])) }}">
-                <input type="hidden" name="questions" value="{{ htmlentities(json_encode($questions->pluck('id'))) }}">
+                <input type="hidden" name="{{ $savePayloadField }}" value="{{ htmlentities(json_encode($questions->pluck($savePayloadKey))) }}">
                 <input type="text" name="name" value="{{$autoTestName}}" placeholder="Назва тесту" required autocomplete="off"
                     class="border rounded px-2 py-1 w-72">
                 <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-2xl shadow font-semibold">

--- a/resources/views/saved-tests.blade.php
+++ b/resources/views/saved-tests.blade.php
@@ -21,9 +21,16 @@
                     <a href="{{ route('saved-test.show', $test->slug) }}" class="text-lg text-blue-700 font-semibold hover:underline">
                         {{ $test->name }}
                     </a>
+                    @php
+                        $questionsAttribute = $test->questions;
+                        if (! is_array($questionsAttribute) && is_string($questionsAttribute)) {
+                            $questionsAttribute = json_decode($questionsAttribute, true) ?? [];
+                        }
+                        $questionCount = $test->question_count ?? (is_array($questionsAttribute) ? count($questionsAttribute) : 0);
+                    @endphp
                     <div class="text-xs text-gray-500 flex gap-3">
                         <span>Створено: {{ $test->created_at->format('d.m.Y H:i') }}</span>
-                        <span>Питань: {{ is_array($test->questions) ? count($test->questions) : (is_string($test->questions) ? count(json_decode($test->questions, true) ?? []) : 0) }}</span>
+                        <span>Питань: {{ $questionCount }}</span>
                     </div>
                     @if($test->description)
                         <div class="test-description text-sm text-gray-800 mt-1">{{ \Illuminate\Support\Str::limit($test->description, 120) }}</div>
@@ -32,7 +39,7 @@
                 <div class="flex gap-2">
                     <a href="{{ route('saved-test.show', $test->slug) }}"
                        class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-1 rounded-2xl text-sm font-semibold">Пройти тест</a>
-                    <form action="{{ route('saved-tests.destroy', $test->id) }}" method="POST"
+                    <form action="{{ route('saved-tests.destroy', $test->slug) }}" method="POST"
                           onsubmit="return confirm('Видалити цей тест?');" class="inline">
                         @csrf
                         @method('DELETE')

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,11 +63,14 @@ Route::post('/translate/test2/reset', [SentenceTranslationTestController::class,
 
 Route::get('/grammar-test', [GrammarTestController::class, 'index'])->name('grammar-test');
 Route::post('/grammar-test', [GrammarTestController::class, 'generate'])->name('grammar-test.generate');
+Route::get('/grammar-test/v2', [GrammarTestController::class, 'indexV2'])->name('grammar-test.v2');
+Route::post('/grammar-test/v2', [GrammarTestController::class, 'generateV2'])->name('grammar-test-v2.generate');
 Route::post('/grammar-test-check', [GrammarTestController::class, 'check'])->name('grammar-test.check');
 Route::get('/grammar-test-autocomplete', [GrammarTestController::class, 'autocomplete'])->name('grammar-test.autocomplete');
 Route::post('/grammar-test-check-answer', [GrammarTestController::class, 'checkOneAnswer'])->name('grammar-test.checkOne');
 
 Route::post('/grammar-test-save', [GrammarTestController::class, 'save'])->name('grammar-test.save');
+Route::post('/grammar-test-v2-save', [GrammarTestController::class, 'saveV2'])->name('grammar-test-v2.save');
 Route::post('/test/{slug}/js/state', [GrammarTestController::class, 'storeSavedTestJsState'])->name('saved-test.js.state');
 Route::get('/test/{slug}/js/questions', [GrammarTestController::class, 'fetchSavedTestJsQuestions'])->name('saved-test.js.questions');
 Route::get('/test/{slug}/js', [GrammarTestController::class, 'showSavedTestJs'])->name('saved-test.js');
@@ -96,7 +99,7 @@ Route::post('/test/{slug}/step/add-tag', [GrammarTestController::class, 'addTag'
 Route::delete('/test/{slug}/step/remove-tag', [GrammarTestController::class, 'removeTag'])->name('saved-test.step.remove-tag');
 Route::delete('/test/{slug}/question/{question}', [GrammarTestController::class, 'deleteQuestion'])->name('saved-test.question.destroy');
 Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
-Route::delete('/tests/{test}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
+Route::delete('/tests/{slug}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
 Route::get('/tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('saved-tests.cards');
 Route::get('/catalog-tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('catalog-tests.cards');
 


### PR DESCRIPTION
## Summary
- introduce saved_grammar_tests tables with UUID-linked question mapping and corresponding models
- add resolver service and controller updates to support both legacy and UUID-based saved grammar tests, including new /grammar-test/v2 entry points
- update routes and views to use configurable form endpoints and render combined saved test listings

## Testing
- php -l app/Http/Controllers/GrammarTestController.php
- php -l app/Services/SavedTestResolver.php
- php -l app/Services/ResolvedSavedTest.php
- php -l app/Models/SavedGrammarTest.php
- php -l app/Models/SavedGrammarTestQuestion.php
- php -l app/Services/QuestionVariantService.php
- php -l database/migrations/2025_08_15_000000_create_saved_grammar_tests_tables.php


------
https://chatgpt.com/codex/tasks/task_e_68d82f54425c832ab0a90c4153939b42