### PR TITLE
Improve grammar test sources layout

### DIFF
--- a/resources/views/grammar-test-v2.blade.php
+++ b/resources/views/grammar-test-v2.blade.php
@@ -29,21 +29,33 @@
         @csrf
         
             <div class="space-y-6 ">
-                <div>
-                    <h2 class="text-sm font-semibold text-gray-700 mb-3">Часи (категорії)</h2>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        @foreach($categoryCollection as $cat)
-                            <label class="flex items-center gap-2 text-sm bg-gray-50 border border-gray-200 rounded-xl px-3 py-2 hover:border-blue-300 transition">
-                                <input type="checkbox" name="categories[]" value="{{ $cat->id }}"
-                                    {{ isset($selectedCategories) && in_array($cat->id, $selectedCategories) ? 'checked' : '' }}
-                                    class="h-5 w-5 text-blue-600 border-gray-300 rounded">
-                                <span class="truncate">{{ ucfirst($cat->name) }}</span>
-                            </label>
-                        @endforeach
+                <div x-data="{ openCategoryTimes: {{ (!empty($selectedCategories) || $errors->has('categories')) ? 'true' : 'false' }} }" class="space-y-3">
+                    <div class="flex items-center justify-between gap-3">
+                        <h2 class="text-sm font-semibold text-gray-700">Часи (категорії)</h2>
+                        <button type="button"
+                                class="inline-flex items-center gap-1 text-xs font-semibold text-blue-700 px-3 py-1 rounded-full bg-blue-50 hover:bg-blue-100 transition"
+                                @click="openCategoryTimes = !openCategoryTimes">
+                            <span x-text="openCategoryTimes ? 'Згорнути' : 'Розгорнути'"></span>
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transition-transform" :class="{ 'rotate-180': openCategoryTimes }" viewBox="0 0 20 20" fill="currentColor">
+                                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.585l3.71-3.356a.75.75 0 011.04 1.08l-4.25 3.845a.75.75 0 01-1.04 0l-4.25-3.845a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                            </svg>
+                        </button>
                     </div>
-                    @error('categories')
-                        <div class="text-red-500 text-sm mt-2">{{ $message }}</div>
-                    @enderror
+                    <div class="space-y-3" x-show="openCategoryTimes" x-transition style="display: none;">
+                        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                            @foreach($categoryCollection as $cat)
+                                <label class="flex items-center gap-2 text-sm bg-gray-50 border border-gray-200 rounded-xl px-3 py-2 hover:border-blue-300 transition">
+                                    <input type="checkbox" name="categories[]" value="{{ $cat->id }}"
+                                        {{ isset($selectedCategories) && in_array($cat->id, $selectedCategories) ? 'checked' : '' }}
+                                        class="h-5 w-5 text-blue-600 border-gray-300 rounded">
+                                    <span class="truncate">{{ ucfirst($cat->name) }}</span>
+                                </label>
+                            @endforeach
+                        </div>
+                        @error('categories')
+                            <div class="text-red-500 text-sm mt-2">{{ $message }}</div>
+                        @enderror
+                    </div>
                 </div>
 
                 @if($sourceGroups->isNotEmpty())
@@ -59,9 +71,9 @@
                             </button>
                         </div>
                         <div x-show="openSources" x-transition style="display: none;">
-                            <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                            <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3 items-start">
                                 @foreach($sourceGroups as $group)
-                                    <div x-data="{ open: false }" class="border border-gray-200 rounded-2xl overflow-hidden h-full">
+                                    <div x-data="{ open: false }" class="border border-gray-200 rounded-2xl overflow-hidden">
                                         <button type="button" class="w-full flex items-center justify-between px-4 py-2 bg-gray-50 text-left font-semibold text-gray-800"
                                             @click="open = !open">
                                             <span class="truncate">{{ ucfirst($group['category']->name) }} (ID: {{ $group['category']->id }})</span>

--- a/resources/views/grammar-test-v2.blade.php
+++ b/resources/views/grammar-test-v2.blade.php
@@ -47,7 +47,7 @@
                 </div>
 
                 @if($sourceGroups->isNotEmpty())
-                    <div x-data="{ openSources: true }" class="space-y-3">
+                    <div x-data="{ openSources: false }" class="space-y-3">
                         <div class="flex items-center justify-between gap-3">
                             <h2 class="text-sm font-semibold text-gray-700">Джерела по категоріях</h2>
                             <button type="button" class="inline-flex items-center gap-1 text-xs font-semibold text-blue-700 px-3 py-1 rounded-full bg-blue-50 hover:bg-blue-100 transition"
@@ -61,7 +61,7 @@
                         <div x-show="openSources" x-transition style="display: none;">
                             <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                                 @foreach($sourceGroups as $group)
-                                    <div x-data="{ open: true }" class="border border-gray-200 rounded-2xl overflow-hidden h-full">
+                                    <div x-data="{ open: false }" class="border border-gray-200 rounded-2xl overflow-hidden h-full">
                                         <button type="button" class="w-full flex items-center justify-between px-4 py-2 bg-gray-50 text-left font-semibold text-gray-800"
                                             @click="open = !open">
                                             <span class="truncate">{{ ucfirst($group['category']->name) }} (ID: {{ $group['category']->id }})</span>
@@ -72,11 +72,11 @@
                                         <div x-show="open" x-transition style="display: none;" class="px-4 pb-4 pt-2">
                                             <div class="flex flex-wrap gap-2">
                                                 @foreach($group['sources'] as $source)
-                                                    <label class="flex items-center gap-2 px-3 py-1 rounded-full border border-gray-200 text-sm bg-white hover:border-blue-300 transition">
+                                                    <label class="flex items-start gap-2 px-3 py-1 rounded-full border border-gray-200 text-sm bg-white hover:border-blue-300 transition text-left">
                                                         <input type="checkbox" name="sources[]" value="{{ $source->id }}"
                                                             {{ isset($selectedSources) && in_array($source->id, $selectedSources) ? 'checked' : '' }}
                                                             class="h-4 w-4 text-indigo-600 border-gray-300 rounded">
-                                                        <span class="truncate">{{ $source->name }} (ID: {{ $source->id }})</span>
+                                                        <span class="whitespace-normal break-words">{{ $source->name }} (ID: {{ $source->id }})</span>
                                                     </label>
                                                 @endforeach
                                             </div>
@@ -108,9 +108,18 @@
                 @endif
 
                 @if($tagGroups->isNotEmpty())
-                    <div class="space-y-3">
-                        <h2 class="text-sm font-semibold text-gray-700">Tags</h2>
-                        <div class="space-y-3">
+                    <div x-data="{ openTags: true }" class="space-y-3">
+                        <div class="flex items-center justify-between gap-3">
+                            <h2 class="text-sm font-semibold text-gray-700">Tags</h2>
+                            <button type="button" class="inline-flex items-center gap-1 text-xs font-semibold text-blue-700 px-3 py-1 rounded-full bg-blue-50 hover:bg-blue-100 transition"
+                                    @click="openTags = !openTags">
+                                <span x-text="openTags ? 'Згорнути' : 'Розгорнути'"></span>
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transition-transform" :class="{ 'rotate-180': openTags }" viewBox="0 0 20 20" fill="currentColor">
+                                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.585l3.71-3.356a.75.75 0 011.04 1.08l-4.25 3.845a.75.75 0 01-1.04 0l-4.25-3.845a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                                </svg>
+                            </button>
+                        </div>
+                        <div class="space-y-3" x-show="openTags" x-transition style="display: none;">
                             @foreach($tagGroups as $tagCategory => $tags)
                                 <div x-data="{ open: {{ $loop->index < 1 ? 'true' : 'false' }} }" class="border border-gray-200 rounded-2xl overflow-hidden">
                                     <button type="button" class="w-full flex items-center justify-between px-4 py-2 bg-gray-50 text-left font-semibold text-gray-800"

--- a/resources/views/grammar-test-v2.blade.php
+++ b/resources/views/grammar-test-v2.blade.php
@@ -47,32 +47,43 @@
                 </div>
 
                 @if($sourceGroups->isNotEmpty())
-                    <div class="space-y-3">
-                        <h2 class="text-sm font-semibold text-gray-700">Джерела по категоріях</h2>
-                        <div class="space-y-3">
-                            @foreach($sourceGroups as $group)
-                                <div x-data="{ open: true }" class="border border-gray-200 rounded-2xl overflow-hidden">
-                                    <button type="button" class="w-full flex items-center justify-between px-4 py-2 bg-gray-50 text-left font-semibold text-gray-800"
-                                        @click="open = !open">
-                                        <span>{{ ucfirst($group['category']->name) }} (ID: {{ $group['category']->id }})</span>
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transition-transform" :class="{ 'rotate-180': open }" viewBox="0 0 20 20" fill="currentColor">
-                                            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.585l3.71-3.356a.75.75 0 011.04 1.08l-4.25 3.845a.75.75 0 01-1.04 0l-4.25-3.845a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-                                        </svg>
-                                    </button>
-                                    <div x-show="open" x-transition style="display: none;" class="px-4 pb-4 pt-2">
-                                        <div class="flex flex-wrap gap-2">
-                                            @foreach($group['sources'] as $source)
-                                                <label class="flex items-center gap-2 px-3 py-1 rounded-full border border-gray-200 text-sm bg-white hover:border-blue-300 transition">
-                                                    <input type="checkbox" name="sources[]" value="{{ $source->id }}"
-                                                        {{ isset($selectedSources) && in_array($source->id, $selectedSources) ? 'checked' : '' }}
-                                                        class="h-4 w-4 text-indigo-600 border-gray-300 rounded">
-                                                    <span class="truncate">{{ $source->name }} (ID: {{ $source->id }})</span>
-                                                </label>
-                                            @endforeach
+                    <div x-data="{ openSources: true }" class="space-y-3">
+                        <div class="flex items-center justify-between gap-3">
+                            <h2 class="text-sm font-semibold text-gray-700">Джерела по категоріях</h2>
+                            <button type="button" class="inline-flex items-center gap-1 text-xs font-semibold text-blue-700 px-3 py-1 rounded-full bg-blue-50 hover:bg-blue-100 transition"
+                                    @click="openSources = !openSources">
+                                <span x-text="openSources ? 'Згорнути' : 'Розгорнути'"></span>
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transition-transform" :class="{ 'rotate-180': openSources }" viewBox="0 0 20 20" fill="currentColor">
+                                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.585l3.71-3.356a.75.75 0 011.04 1.08l-4.25 3.845a.75.75 0 01-1.04 0l-4.25-3.845a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                                </svg>
+                            </button>
+                        </div>
+                        <div x-show="openSources" x-transition style="display: none;">
+                            <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                                @foreach($sourceGroups as $group)
+                                    <div x-data="{ open: true }" class="border border-gray-200 rounded-2xl overflow-hidden h-full">
+                                        <button type="button" class="w-full flex items-center justify-between px-4 py-2 bg-gray-50 text-left font-semibold text-gray-800"
+                                            @click="open = !open">
+                                            <span class="truncate">{{ ucfirst($group['category']->name) }} (ID: {{ $group['category']->id }})</span>
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transition-transform" :class="{ 'rotate-180': open }" viewBox="0 0 20 20" fill="currentColor">
+                                                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.585l3.71-3.356a.75.75 0 011.04 1.08l-4.25 3.845a.75.75 0 01-1.04 0l-4.25-3.845a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                                            </svg>
+                                        </button>
+                                        <div x-show="open" x-transition style="display: none;" class="px-4 pb-4 pt-2">
+                                            <div class="flex flex-wrap gap-2">
+                                                @foreach($group['sources'] as $source)
+                                                    <label class="flex items-center gap-2 px-3 py-1 rounded-full border border-gray-200 text-sm bg-white hover:border-blue-300 transition">
+                                                        <input type="checkbox" name="sources[]" value="{{ $source->id }}"
+                                                            {{ isset($selectedSources) && in_array($source->id, $selectedSources) ? 'checked' : '' }}
+                                                            class="h-4 w-4 text-indigo-600 border-gray-300 rounded">
+                                                        <span class="truncate">{{ $source->name }} (ID: {{ $source->id }})</span>
+                                                    </label>
+                                                @endforeach
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                            @endforeach
+                                @endforeach
+                            </div>
                         </div>
                     </div>
                 @endif


### PR DESCRIPTION
## Summary
- add a toggle to collapse the grouped sources section on the grammar test v2 page
- arrange source category cards in a responsive grid that shows three columns on desktop

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8426368b0832ab8b5c56d05f65d12