### PR TITLE
Make admin layout responsive and enhance saved tests list

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -17,88 +17,51 @@
             border-radius: 0.5rem;
             margin-bottom: 1rem;
         }
+        [x-cloak] {
+            display: none !important;
+        }
     </style>
 </head>
 <body class="bg-gray-50 min-h-screen flex flex-col">
 
     <!-- Навігація -->
-    <nav class="bg-white shadow py-4 mb-6">
-        <div class="container mx-auto flex justify-between items-center px-4">
-            <a href="{{ url('/') }}" class="text-2xl font-bold text-blue-700">English Test Hub</a>
-
-            <!-- Пошук по сайту -->
-            <div x-data="siteSearch()" class="relative w-72 mx-4">
-                <form action="{{ route('site.search') }}" method="GET">
-                    <input
-                        id="site_search"
-                        name="q"
-                        type="text"
-                        x-model="query"
-                        @input="search"
-                        class="w-full rounded-xl border px-4 py-2 focus:outline-blue-400"
-                        placeholder="{{ __('messages.search_placeholder') }}"
-                        autocomplete="off"
-                    >
-                </form>
-                <!-- Список підказок, absolute! -->
-                <ul
-                    x-show="results.length"
-                    class="absolute left-0 right-0 bg-white shadow rounded-xl divide-y mt-1 z-50"
-                    style="top: 100%;"
+    <nav class="bg-white shadow mb-6" x-data="{ open: false }">
+        <div class="container mx-auto px-4">
+            <div class="flex items-center justify-between py-4">
+                <a href="{{ url('/tests') }}" class="text-2xl font-bold text-blue-700">
+                    Admin Hub
+                </a>
+                <button
+                    type="button"
+                    class="md:hidden text-gray-600 hover:text-blue-600 focus:outline-none"
+                    @click="open = !open"
+                    aria-label="Toggle navigation"
                 >
-                    <template x-for="item in results" :key="item.url">
-                        <li>
-                            <a :href="item.url" class="block px-4 py-2 hover:bg-blue-50 flex items-center justify-between">
-                                <span class="font-medium text-gray-900" x-text="item.title"></span>
-                                <span class="ml-3 text-gray-500" x-text="item.type"></span>
-                            </a>
-                        </li>
-                    </template>
-                </ul>
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                    </svg>
+                </button>
+                <div class="hidden md:flex md:items-center md:gap-6 text-gray-600 font-medium">
+                    <a href="{{ url('/grammar-test/v2') }}" class="hover:text-blue-500 transition">Граматика v2</a>
+                    <a href="{{ url('/tests') }}" class="hover:text-blue-500 transition">Збережені тести</a>
+                    <a href="{{ url('/') }}" class="hover:text-blue-500 transition">До публічної частини</a>
+                </div>
             </div>
-
-            <ul class="flex gap-6 text-gray-600 font-medium">
-                <li><a href="{{ url('/words/test') }}" class="hover:text-blue-500">Words</a></li>
-                <li><a href="{{ route('translate.test') }}" class="hover:text-blue-500">Translate Test</a></li>
-                <li><a href="{{ route('question-review.index') }}" class="hover:text-blue-500">Question Review</a></li>
-                <li><a href="{{ route('saved-tests.cards') }}" class="hover:text-blue-500">Tests Catalog</a></li>
-                <li><a href="{{ route('pages.index') }}" class="hover:text-blue-500">Theory</a></li>
-                <li><a href="{{ url('/about') }}" class="hover:text-blue-500">About</a></li>
-            </ul>
-            <!-- Dropdown у layout'і -->
-            <form method="GET" action="{{ route('setlocale') }}" class="inline-block ml-4 align-middle">
-                <select name="lang" onchange="this.form.submit()" class="w-20 min-w-[60px] max-w-[80px] text-center border rounded px-2 py-1 text-sm bg-white shadow focus:outline-blue-400">
-                    <option value="en" {{ app()->getLocale() == 'en' ? 'selected' : '' }}>EN</option>
-                    <option value="uk" {{ app()->getLocale() == 'uk' ? 'selected' : '' }}>UA</option>
-                    <option value="pl" {{ app()->getLocale() == 'pl' ? 'selected' : '' }}>PL</option>
-                </select>
-            </form>
+            <div
+                class="md:hidden border-t border-gray-100 pt-2 pb-4 space-y-2 text-gray-600 font-medium"
+                x-show="open"
+                x-cloak
+                x-transition
+            >
+                <a href="{{ url('/grammar-test/v2') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">Граматика v2</a>
+                <a href="{{ url('/tests') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">Збережені тести</a>
+                <a href="{{ url('/') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">До публічної частини</a>
+            </div>
         </div>
     </nav>
 
     <!-- Alpine.js для реактивності -->
     <script src="//unpkg.com/alpinejs" defer></script>
-    <script>
-    function siteSearch() {
-        return {
-            query: '',
-            results: [],
-            search() {
-                if (this.query.length < 2) {
-                    this.results = [];
-                    return;
-                }
-                fetch('/search?q=' + encodeURIComponent(this.query), {
-                        headers: {
-                            'Accept': 'application/json'
-                        }
-                    })
-                    .then(res => res.json())
-                    .then(data => this.results = data);
-            }
-        }
-    }
-    </script>
     <!-- Контент -->
     <main class="flex-1 container mx-auto px-4">
         @php $pageTitle = trim($__env->yieldContent('title')); @endphp

--- a/resources/views/saved-tests.blade.php
+++ b/resources/views/saved-tests.blade.php
@@ -3,21 +3,21 @@
 @section('title', 'Збережені тести')
 
 @section('content')
-<div class="max-w-3xl mx-auto p-4">
-    <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-bold">Збережені тести</h1>
+<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">Збережені тести</h1>
         <a href="{{ route('grammar-test') }}"
-           class="bg-blue-50 text-blue-700 border border-blue-200 px-4 py-2 rounded-2xl font-semibold hover:bg-blue-100">
+           class="inline-flex items-center justify-center bg-blue-50 text-blue-700 border border-blue-200 px-4 py-2 rounded-2xl font-semibold hover:bg-blue-100 transition">
             + До фільтра / конструктора тестів
         </a>
     </div>
 
     @include('components.word-search')
     @if($tests->count())
-        <ul class="divide-y">
+        <ul class="space-y-4">
             @foreach($tests as $test)
-            <li class="py-3 flex items-center justify-between">
-                <div>
+            <li class="bg-white rounded-2xl shadow-sm border border-gray-100 p-4 sm:p-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div class="flex-1 min-w-0">
                     <a href="{{ route('saved-test.show', $test->slug) }}" class="text-lg text-blue-700 font-semibold hover:underline">
                         {{ $test->name }}
                     </a>
@@ -28,29 +28,35 @@
                         }
                         $questionCount = $test->question_count ?? (is_array($questionsAttribute) ? count($questionsAttribute) : 0);
                     @endphp
-                    <div class="text-xs text-gray-500 flex gap-3">
-                        <span>Створено: {{ $test->created_at->format('d.m.Y H:i') }}</span>
-                        <span>Питань: {{ $questionCount }}</span>
+                    <div class="mt-2 text-xs text-gray-500 flex flex-wrap gap-x-3 gap-y-1">
+                        <span class="whitespace-nowrap">Створено: {{ $test->created_at->format('d.m.Y H:i') }}</span>
+                        <span class="whitespace-nowrap">Питань: {{ $questionCount }}</span>
                     </div>
                     @if($test->description)
-                        <div class="test-description text-sm text-gray-800 mt-1">{{ \Illuminate\Support\Str::limit($test->description, 120) }}</div>
+                        <div class="test-description text-sm text-gray-800 mt-3">{{ \Illuminate\Support\Str::limit($test->description, 140) }}</div>
                     @endif
                 </div>
-                <div class="flex gap-2">
+                <div class="flex flex-wrap gap-2 sm:w-48">
                     <a href="{{ route('saved-test.show', $test->slug) }}"
-                       class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-1 rounded-2xl text-sm font-semibold">Пройти тест</a>
+                       class="flex-1 sm:flex-none text-center bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-2xl text-sm font-semibold transition">
+                        Пройти тест
+                    </a>
+                    <a href="{{ route('saved-test.tech', $test->slug) }}"
+                       class="flex-1 sm:flex-none text-center bg-white border border-blue-200 text-blue-700 px-4 py-2 rounded-2xl text-sm font-semibold hover:bg-blue-50 transition">
+                        Технічна сторінка
+                    </a>
                     <form action="{{ route('saved-tests.destroy', $test->slug) }}" method="POST"
-                          onsubmit="return confirm('Видалити цей тест?');" class="inline">
+                          onsubmit="return confirm('Видалити цей тест?');" class="inline-flex flex-1 sm:flex-none">
                         @csrf
                         @method('DELETE')
                         <button type="submit"
-                            class="bg-red-500 hover:bg-red-700 text-white px-3 py-1 rounded-2xl text-sm font-semibold">
+                            class="w-full bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-2xl text-sm font-semibold transition">
                             Видалити
                         </button>
                     </form>
                 </div>
             </li>
-            
+
             @endforeach
         </ul>
         <div class="mt-6">


### PR DESCRIPTION
## Summary
- replace the admin layout header with a responsive navigation that focuses on grammar v2, saved tests, and a link back to the public site
- clean up unused search and locale controls and add an Alpine x-cloak helper for smoother menu toggling
- restyle the saved tests list into responsive cards and surface a link to each test's technical page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d923fff27c832aa08ced0ba2c6015b