### PR TITLE
Add delete-all questions control to saved test technical page

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -83,6 +83,7 @@ Route::get('/test/{slug}/js/step/select', [GrammarTestController::class, 'showSa
 Route::get('/test/{slug}/js/select', [GrammarTestController::class, 'showSavedTestJsSelect'])->name('saved-test.js.select');
 Route::get('/test/{slug}/tech', [GrammarTestController::class, 'showSavedTestTech'])->name('saved-test.tech');
 Route::post('/test/{slug}/questions', [GrammarTestController::class, 'storeSavedTestQuestion'])->name('saved-test.questions.store');
+Route::delete('/test/{slug}/questions', [GrammarTestController::class, 'deleteAllQuestions'])->name('saved-test.questions.destroy-all');
 Route::get('/test/{slug}', [GrammarTestController::class, 'showSavedTest'])->name('saved-test.show');
 Route::get('/test/{slug}/random', [GrammarTestController::class, 'showSavedTestRandom'])->name('saved-test.random');
 Route::get('/test/{slug}/step', [GrammarTestController::class, 'showSavedTestStep'])->name('saved-test.step');


### PR DESCRIPTION
## Summary
- add backend endpoint and controller refactor to support deleting all questions in a saved test
- expose a delete-all button on the technical page and wire it to the new endpoint via JavaScript
- cover bulk deletion flow with a feature test

## Testing
- php artisan test --filter=SavedTestTechnicalPageTest


------
https://chatgpt.com/codex/tasks/task_e_68d9685f44f4832aa16df6f0fb47967f