### PR TITLE
Add filter-based saved tests for grammar test v2

### DIFF
--- a/app/Services/GrammarTestFilterService.php
+++ b/app/Services/GrammarTestFilterService.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Category;
+use App\Models\Question;
+use App\Models\Source;
+use App\Models\Tag;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+
+class GrammarTestFilterService
+{
+    public function prepare(array $input): array
+    {
+        $filters = $this->normalize($input);
+
+        $categories = Category::all();
+        $minDifficulty = 1;
+        $maxDifficulty = 10;
+        $maxQuestions = 999999;
+
+        $selectedCategories = $filters['categories'];
+        $difficultyFrom = $filters['difficulty_from'];
+        $difficultyTo = $filters['difficulty_to'];
+        $numQuestions = max(1, min($filters['num_questions'], $maxQuestions));
+
+        $manualInput = $filters['manual_input'];
+        $autocompleteInput = $filters['autocomplete_input'];
+        $checkOneInput = $filters['check_one_input'];
+        $builderInput = $filters['builder_input'];
+        $includeAi = $filters['include_ai'];
+        $onlyAi = $filters['only_ai'];
+        $includeAiV2 = $filters['include_ai_v2'];
+        $onlyAiV2 = $filters['only_ai_v2'];
+        $selectedTags = $filters['tags'];
+        $selectedLevels = $filters['levels'];
+        $selectedSources = $filters['sources'];
+        $randomizeFiltered = $filters['randomize_filtered'];
+
+        $groupBy = ! empty($selectedSources) ? 'source_id' : 'category_id';
+        $groups = ! empty($selectedCategories) ? $selectedCategories : $categories->pluck('id')->toArray();
+        if ($groupBy === 'source_id') {
+            $groups = $selectedSources;
+        }
+        $groups = array_values($groups);
+        if (empty($groups)) {
+            $groups = [null];
+        }
+
+        $groupCount = max(count($groups), 1);
+        $questionsPerGroup = (int) floor($numQuestions / $groupCount);
+        $remaining = $numQuestions % $groupCount;
+
+        $questions = collect();
+        $canRandomizeFiltered = false;
+
+        foreach ($groups as $group) {
+            $take = $questionsPerGroup + ($remaining > 0 ? 1 : 0);
+            if ($remaining > 0) {
+                $remaining--;
+            }
+
+            $query = Question::with(['category', 'answers.option', 'options', 'verbHints.option', 'source'])
+                ->whereBetween('difficulty', [$difficultyFrom, $difficultyTo]);
+
+            if (! empty($selectedLevels)) {
+                $query->whereIn('level', $selectedLevels);
+            }
+
+            if ($groupBy === 'source_id') {
+                if ($group !== null) {
+                    $query->where('source_id', $group);
+                }
+            } else {
+                if ($group !== null) {
+                    $query->where('category_id', $group);
+                }
+            }
+
+            if (! empty($selectedSources) && $groupBy !== 'source_id') {
+                $query->whereIn('source_id', $selectedSources);
+            }
+
+            if (! empty($selectedCategories) && $groupBy !== 'category_id') {
+                $query->whereIn('category_id', $selectedCategories);
+            }
+
+            if (! empty($selectedTags)) {
+                $query->whereHas('tags', fn ($q) => $q->whereIn('name', $selectedTags));
+            }
+
+            $onlyFlags = [];
+            if ($onlyAi) {
+                $onlyFlags[] = 1;
+            }
+            if ($onlyAiV2) {
+                $onlyFlags[] = 2;
+            }
+
+            if (! empty($onlyFlags)) {
+                if (count($onlyFlags) === 1) {
+                    $query->where('flag', $onlyFlags[0]);
+                } else {
+                    $query->whereIn('flag', $onlyFlags);
+                }
+            } else {
+                $allowedFlags = [0];
+                if ($includeAi) {
+                    $allowedFlags[] = 1;
+                }
+                if ($includeAiV2) {
+                    $allowedFlags[] = 2;
+                }
+
+                $allowedFlags = array_values(array_unique($allowedFlags));
+
+                if (count($allowedFlags) === 1) {
+                    $query->where('flag', $allowedFlags[0]);
+                } elseif (count($allowedFlags) < 3) {
+                    $query->whereIn('flag', $allowedFlags);
+                }
+            }
+
+            $availableCount = (clone $query)->count();
+
+            if ($availableCount > $take && $take > 0) {
+                $canRandomizeFiltered = true;
+            }
+
+            if ($take > 0) {
+                $selectionQuery = clone $query;
+
+                if ($randomizeFiltered && $availableCount > $take) {
+                    $selectionQuery->inRandomOrder();
+                } else {
+                    $selectionQuery->orderBy('id');
+                }
+
+                $selected = $selectionQuery->take($take)->get();
+
+                $questions = $questions->merge($selected);
+            }
+        }
+
+        $questions = $randomizeFiltered
+            ? $questions->values()
+            : $questions->sortBy('id')->values();
+
+        $categoryNames = $questions->pluck('category.name')->filter()->unique()->values();
+        $autoTestName = ucwords($categoryNames->join(' - '));
+
+        $sources = Schema::hasTable('sources')
+            ? Source::orderBy('name')->get()
+            : collect();
+
+        $allTags = Schema::hasTable('tags')
+            ? Tag::whereHas('questions')->get()
+            : collect();
+
+        $order = array_flip(['A1','A2','B1','B2','C1','C2']);
+        $levels = Question::select('level')->distinct()->pluck('level')
+            ->filter()
+            ->sortBy(fn($lvl) => $order[$lvl] ?? 99)
+            ->values();
+
+        return [
+            'categories' => $categories,
+            'minDifficulty' => $minDifficulty,
+            'maxDifficulty' => $maxDifficulty,
+            'maxQuestions' => $maxQuestions,
+            'selectedCategories' => $selectedCategories,
+            'difficultyFrom' => $difficultyFrom,
+            'difficultyTo' => $difficultyTo,
+            'numQuestions' => $numQuestions,
+            'manualInput' => $manualInput,
+            'autocompleteInput' => $autocompleteInput,
+            'checkOneInput' => $checkOneInput,
+            'builderInput' => $builderInput,
+            'includeAi' => $includeAi,
+            'onlyAi' => $onlyAi,
+            'includeAiV2' => $includeAiV2,
+            'onlyAiV2' => $onlyAiV2,
+            'questions' => $questions,
+            'sources' => $sources,
+            'selectedSources' => $selectedSources,
+            'autoTestName' => $autoTestName,
+            'allTags' => $allTags,
+            'selectedTags' => $selectedTags,
+            'levels' => $levels,
+            'selectedLevels' => $selectedLevels,
+            'randomizeFiltered' => $randomizeFiltered,
+            'canRandomizeFiltered' => $canRandomizeFiltered,
+            'normalizedFilters' => $filters,
+        ];
+    }
+
+    public function normalize(array $input): array
+    {
+        $categories = $this->intArray(Arr::get($input, 'categories', []));
+        $levels = $this->stringArray(Arr::get($input, 'levels', []));
+        $tags = $this->stringArray(Arr::get($input, 'tags', []));
+        $sources = $this->intArray(Arr::get($input, 'sources', []));
+
+        return [
+            'categories' => $categories,
+            'difficulty_from' => $this->intValue(Arr::get($input, 'difficulty_from'), 1),
+            'difficulty_to' => $this->intValue(Arr::get($input, 'difficulty_to'), 10),
+            'num_questions' => $this->intValue(Arr::get($input, 'num_questions'), 10),
+            'manual_input' => $this->toBool(Arr::get($input, 'manual_input', false)),
+            'autocomplete_input' => $this->toBool(Arr::get($input, 'autocomplete_input', false)),
+            'check_one_input' => $this->toBool(Arr::get($input, 'check_one_input', false)),
+            'builder_input' => $this->toBool(Arr::get($input, 'builder_input', false)),
+            'include_ai' => $this->toBool(Arr::get($input, 'include_ai', false)),
+            'only_ai' => $this->toBool(Arr::get($input, 'only_ai', false)),
+            'include_ai_v2' => $this->toBool(Arr::get($input, 'include_ai_v2', false)),
+            'only_ai_v2' => $this->toBool(Arr::get($input, 'only_ai_v2', false)),
+            'levels' => $levels,
+            'tags' => $tags,
+            'sources' => $sources,
+            'randomize_filtered' => $this->toBool(Arr::get($input, 'randomize_filtered', false)),
+        ];
+    }
+
+    public function questionsFromFilters(array $filters): Collection
+    {
+        $data = $this->prepare($filters);
+
+        return $data['questions'];
+    }
+
+    private function intArray($value): array
+    {
+        return collect($value)->filter(fn($v) => $v !== null && $v !== '')->map(fn($v) => (int) $v)->values()->all();
+    }
+
+    private function stringArray($value): array
+    {
+        return collect($value)->filter(fn($v) => is_string($v) && $v !== '')->map(fn($v) => (string) $v)->values()->all();
+    }
+
+    private function intValue($value, int $default): int
+    {
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return $default;
+    }
+
+    private function toBool($value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value === 1;
+        }
+
+        if (is_string($value)) {
+            return in_array(strtolower($value), ['1', 'true', 'on', 'yes'], true);
+        }
+
+        return (bool) $value;
+    }
+}

--- a/app/Services/ResolvedSavedTest.php
+++ b/app/Services/ResolvedSavedTest.php
@@ -11,7 +11,9 @@ class ResolvedSavedTest
         public Model $model,
         public Collection $questionIds,
         public Collection $questionUuids,
-        public bool $usesUuidLinks
+        public bool $usesUuidLinks,
+        public ?Collection $preloadedQuestions = null,
+        public bool $isFilterBased = false,
     ) {
     }
 }

--- a/app/Services/SavedTestResolver.php
+++ b/app/Services/SavedTestResolver.php
@@ -5,11 +5,18 @@ namespace App\Services;
 use App\Models\Question;
 use App\Models\SavedGrammarTest;
 use App\Models\Test;
+use App\Services\GrammarTestFilterService;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Arr;
 
 class SavedTestResolver
 {
+    public function __construct(
+        private GrammarTestFilterService $filterService,
+    ) {
+    }
+
     public function resolve(string $slug): ResolvedSavedTest
     {
         $legacy = Test::where('slug', $slug)->first();
@@ -35,6 +42,31 @@ class SavedTestResolver
         $saved = SavedGrammarTest::with('questionLinks')->where('slug', $slug)->first();
 
         if ($saved) {
+            $rawFilters = $saved->filters ?? [];
+            if (is_string($rawFilters)) {
+                $decoded = json_decode($rawFilters, true);
+                $rawFilters = is_array($decoded) ? $decoded : [];
+            }
+
+            $isFilterBased = is_array($rawFilters)
+                && Arr::get($rawFilters, '__meta.mode') === 'filters';
+
+            if ($isFilterBased) {
+                $normalized = $this->filterService->normalize($rawFilters);
+                $questions = $this->filterService->questionsFromFilters($normalized);
+
+                $questionIds = $questions->pluck('id')
+                    ->filter(fn ($id) => filled($id))
+                    ->map(fn ($id) => (int) $id)
+                    ->values();
+
+                $questionUuids = $questions->pluck('uuid')
+                    ->filter(fn ($uuid) => filled($uuid))
+                    ->values();
+
+                return new ResolvedSavedTest($saved, $questionIds, $questionUuids, true, $questions, true);
+            }
+
             $questionUuids = $saved->questionLinks
                 ->sortBy('position')
                 ->pluck('question_uuid')
@@ -58,6 +90,10 @@ class SavedTestResolver
 
     public function loadQuestions(ResolvedSavedTest $resolved, array $relations = []): Collection
     {
+        if ($resolved->preloadedQuestions !== null) {
+            return $resolved->preloadedQuestions;
+        }
+
         if ($resolved->questionIds->isEmpty()) {
             return collect();
         }

--- a/resources/views/grammar-test-v2.blade.php
+++ b/resources/views/grammar-test-v2.blade.php
@@ -19,6 +19,7 @@
         $selectedCategories = collect($selectedCategories ?? [])->all();
         $selectedSources = collect($selectedSources ?? [])->all();
         $selectedTags = collect($selectedTags ?? [])->all();
+        $normalizedFilters = $normalizedFilters ?? null;
 
         $hasSelectedCategories = !empty($selectedCategories);
         $hasSelectedSources = !empty($selectedSources);
@@ -428,30 +429,38 @@
         <div class="bg-white shadow rounded-2xl p-4 sm:p-6">
             <form action="{{ $saveRoute }}" method="POST" class="flex flex-col sm:flex-row sm:items-center gap-3" id="save-test-form">
                 @csrf
-                <input type="hidden" name="filters" value="{{ htmlentities(json_encode([
-                    'categories' => $selectedCategories,
-                    'difficulty_from' => $difficultyFrom,
-                    'difficulty_to' => $difficultyTo,
-                    'num_questions' => $numQuestions,
-                    'manual_input' => $manualInput,
-                    'autocomplete_input' => $autocompleteInput,
-                    'check_one_input' => $checkOneInput,
-                    'builder_input' => $builderInput,
-                    'include_ai' => $includeAi ?? false,
-                    'only_ai' => $onlyAi ?? false,
-                    'include_ai_v2' => $includeAiV2 ?? false,
-                    'only_ai_v2' => $onlyAiV2 ?? false,
-                    'levels' => $selectedLevels ?? [],
-                    'tags' => $selectedTags,
-                    'sources' => $selectedSources,
-                    'randomize_filtered' => !empty($randomizeFiltered),
-                ])) }}">
+                @php
+                    $filtersForSave = $normalizedFilters ?? [
+                        'categories' => $selectedCategories,
+                        'difficulty_from' => $difficultyFrom,
+                        'difficulty_to' => $difficultyTo,
+                        'num_questions' => $numQuestions,
+                        'manual_input' => (bool) $manualInput,
+                        'autocomplete_input' => (bool) $autocompleteInput,
+                        'check_one_input' => (bool) $checkOneInput,
+                        'builder_input' => (bool) $builderInput,
+                        'include_ai' => (bool) ($includeAi ?? false),
+                        'only_ai' => (bool) ($onlyAi ?? false),
+                        'include_ai_v2' => (bool) ($includeAiV2 ?? false),
+                        'only_ai_v2' => (bool) ($onlyAiV2 ?? false),
+                        'levels' => $selectedLevels ?? [],
+                        'tags' => $selectedTags,
+                        'sources' => $selectedSources,
+                        'randomize_filtered' => (bool) ($randomizeFiltered ?? false),
+                    ];
+                @endphp
+                <input type="hidden" name="filters" value="{{ htmlentities(json_encode($filtersForSave)) }}">
                 <input type="hidden" name="{{ $savePayloadField }}" id="questions-order-input" value="{{ htmlentities(json_encode($questions->pluck($savePayloadKey))) }}">
                 <input type="text" name="name" value="{{ $autoTestName }}" placeholder="Назва тесту" required autocomplete="off"
                        class="border rounded-lg px-3 py-2 w-full sm:w-80">
-                <button type="submit" class="inline-flex justify-center bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded-2xl shadow font-semibold transition">
-                    Зберегти тест
-                </button>
+                <div class="flex flex-col sm:flex-row gap-2">
+                    <button type="submit" name="save_mode" value="questions" class="inline-flex justify-center bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded-2xl shadow font-semibold transition">
+                        Зберегти тест
+                    </button>
+                    <button type="submit" name="save_mode" value="filters" class="inline-flex justify-center bg-emerald-100 hover:bg-emerald-200 text-emerald-700 px-6 py-2 rounded-2xl shadow font-semibold transition">
+                        Зберегти фільтр
+                    </button>
+                </div>
             </form>
         </div>
     @elseif(isset($questions))


### PR DESCRIPTION
## Summary
- introduce a GrammarTestFilterService to normalize request filters and build question collections for grammar tests
- update the grammar test controller and resolver logic to save and resolve filter-based saved tests and expose a dedicated UI action
- expand JS saved test coverage to verify question generation for filter-driven saved tests

## Testing
- ./vendor/bin/phpunit --filter SavedTestJsStateTest

------
https://chatgpt.com/codex/tasks/task_e_68dabb9af59c832a8bf0f682705ee910