### PR TITLE
Add admin login protection

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\View;
+
+class AuthController extends Controller
+{
+    public function showLoginForm(Request $request)
+    {
+        if ($request->session()->get('admin_authenticated', false)) {
+            return Redirect::route('home');
+        }
+
+        return View::make('auth.login');
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->only(['username', 'password']);
+
+        $validator = Validator::make($credentials, [
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+        ]);
+
+        if ($validator->fails()) {
+            return Redirect::back()
+                ->withErrors($validator)
+                ->withInput($request->except('password'));
+        }
+
+        $expectedUsername = config('admin.username');
+        $expectedPasswordHash = config('admin.password_hash');
+
+        if ($credentials['username'] !== $expectedUsername || ! password_verify($credentials['password'], $expectedPasswordHash)) {
+            return Redirect::back()
+                ->withErrors(['username' => __('auth.failed')])
+                ->withInput($request->except('password'));
+        }
+
+        $request->session()->regenerate();
+        $request->session()->put('admin_authenticated', true);
+
+        return Redirect::intended(route('home'));
+    }
+
+    public function logout(Request $request)
+    {
+        $request->session()->forget('admin_authenticated');
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return Redirect::route('login.show');
+    }
+}

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Barryvdh\Debugbar\Facades\Debugbar;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Redirect;
@@ -12,6 +13,10 @@ class AuthController extends Controller
 {
     public function showLoginForm(Request $request)
     {
+        if (class_exists(Debugbar::class)) {
+            Debugbar::disable();
+        }
+
         if ($request->session()->get('admin_authenticated', false)) {
             return Redirect::route('home');
         }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'auth.admin' => \App\Http\Middleware\AdminAuthenticate::class,
     ];
 }

--- a/app/Http/Middleware/AdminAuthenticate.php
+++ b/app/Http/Middleware/AdminAuthenticate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminAuthenticate
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->session()->get('admin_authenticated', false)) {
+            $request->session()->put('url.intended', $request->fullUrl());
+
+            return redirect()->route('login.show');
+        }
+
+        return $next($request);
+    }
+}

--- a/config/admin.php
+++ b/config/admin.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'username' => env('ADMIN_USERNAME', 'admin'),
+    'password_hash' => env('ADMIN_PASSWORD_HASH', '$2y$12$iTF0hutm35wjYhkKUqU3fuJCLR.boRWIVjnH4R4mho8OSh1QIke/.'),
+];

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Seeder;
 use Database\Seeders\Ai\NegativePresentPerfectHabitsTestSeeder;
 use Database\Seeders\V2\PastTimeClausesMixedTestSeeder;
 use Database\Seeders\V2\FutureTensesPracticeV2Seeder;
+use Database\Seeders\V2\FirstConditionalPracticeV2Seeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -97,6 +98,7 @@ class DatabaseSeeder extends Seeder
             PastPerfectSimpleVsContinuousCTestSeeder::class,
             PastTimeClausesMixedTestSeeder::class,
             FutureTensesPracticeV2Seeder::class,
+            FirstConditionalPracticeV2Seeder::class,
             PagesSeeder::class,
             IrregularVerbsSeeder::class,
             FutureSimpleFutureContinuousFuturePerfectTestSeeder::class,

--- a/database/seeders/V2/FirstConditionalPracticeV2Seeder.php
+++ b/database/seeders/V2/FirstConditionalPracticeV2Seeder.php
@@ -1,0 +1,503 @@
+<?php
+
+namespace Database\Seeders\V2;
+
+use App\Models\Category;
+use App\Models\Source;
+use App\Models\Tag;
+use Database\Seeders\QuestionSeeder;
+
+class FirstConditionalPracticeV2Seeder extends QuestionSeeder
+{
+    public function run(): void
+    {
+        $categoryId = Category::firstOrCreate(['name' => 'Conditionals'])->id;
+        $sourceId = Source::firstOrCreate(['name' => 'Custom: First Conditional Practice V2'])->id;
+
+        $themeTagId = Tag::firstOrCreate(
+            ['name' => 'First Conditional Practice'],
+            ['category' => 'English Grammar Theme']
+        )->id;
+
+        $structureTagId = Tag::firstOrCreate(
+            ['name' => 'First Conditional Sentences'],
+            ['category' => 'English Grammar Structure']
+        )->id;
+
+        $tenseTagId = Tag::firstOrCreate(['name' => 'First Conditional'], ['category' => 'Tenses'])->id;
+
+        $levelDifficulty = [
+            'A1' => 1,
+            'A2' => 2,
+            'B1' => 3,
+            'B2' => 4,
+            'C1' => 5,
+            'C2' => 5,
+        ];
+
+        $questions = [
+            [
+                'question' => 'If it {a1} tomorrow, we {a2} indoors.',
+                'verb_hint' => ['a1' => '(rain)', 'a2' => '(stay)'],
+                'options' => [
+                    'a1' => ['rains', 'will rain', 'is raining'],
+                    'a2' => ['will stay', 'stays', 'are staying'],
+                ],
+                'answers' => ['a1' => 'rains', 'a2' => 'will stay'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If she {a1} hard, she {a2} the exam.',
+                'verb_hint' => ['a1' => '(study)', 'a2' => '(pass)'],
+                'options' => [
+                    'a1' => ['studies', 'will study', 'is studying'],
+                    'a2' => ['will pass', 'passes', 'is passing'],
+                ],
+                'answers' => ['a1' => 'studies', 'a2' => 'will pass'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'I will call you if I {a1} my work early.',
+                'verb_hint' => ['a1' => '(finish)'],
+                'options' => ['finish', 'will finish', 'am finishing'],
+                'answers' => ['a1' => 'finish'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If they {a1} the bus, they {a2} late for school.',
+                'verb_hint' => ['a1' => '(miss)', 'a2' => '(be)'],
+                'options' => [
+                    'a1' => ['miss', 'will miss', 'are missing'],
+                    'a2' => ['will be', 'are', 'is being'],
+                ],
+                'answers' => ['a1' => 'miss', 'a2' => 'will be'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If you {a1} too much, you {a2} sick.',
+                'verb_hint' => ['a1' => '(eat)', 'a2' => '(feel)'],
+                'options' => [
+                    'a1' => ['eat', 'will eat', 'are eating'],
+                    'a2' => ['will feel', 'feel', 'are feeling'],
+                ],
+                'answers' => ['a1' => 'eat', 'a2' => 'will feel'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'We {a1} to the beach if it {a2} cold.',
+                'verb_hint' => ['a1' => '(not go)', 'a2' => '(be)'],
+                'options' => [
+                    'a1' => ["won't go", "don't go", "aren't going"],
+                    'a2' => ['is', 'will be', 'was'],
+                ],
+                'answers' => ['a1' => "won't go", 'a2' => 'is'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If he {a1} late, he {a2} the meeting.',
+                'verb_hint' => ['a1' => '(work)', 'a2' => '(not attend)'],
+                'options' => [
+                    'a1' => ['works', 'is working', 'will work'],
+                    'a2' => ["won't attend", "doesn't attend", "is not attending"],
+                ],
+                'answers' => ['a1' => 'works', 'a2' => "won't attend"],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If the price {a1}, people {a2} less.',
+                'verb_hint' => ['a1' => '(rise)', 'a2' => '(buy)'],
+                'options' => [
+                    'a1' => ['rises', 'will rise', 'is rising'],
+                    'a2' => ['will buy', 'buy', 'are buying'],
+                ],
+                'answers' => ['a1' => 'rises', 'a2' => 'will buy'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'She {a1} upset if you {a2}.',
+                'verb_hint' => ['a1' => '(not be)', 'a2' => '(apologize)'],
+                'options' => [
+                    'a1' => ["won't be", "isn't", 'will not be'],
+                    'a2' => ['apologize', 'will apologize', 'are apologizing'],
+                ],
+                'answers' => ['a1' => "won't be", 'a2' => 'apologize'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If you {a1} regularly, you {a2} healthier.',
+                'verb_hint' => ['a1' => '(exercise)', 'a2' => '(be)'],
+                'options' => [
+                    'a1' => ['exercise', 'will exercise', 'are exercising'],
+                    'a2' => ['will be', 'are', 'be'],
+                ],
+                'answers' => ['a1' => 'exercise', 'a2' => 'will be'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If the traffic {a1} heavy, we {a2} a different route.',
+                'verb_hint' => ['a1' => '(be)', 'a2' => '(take)'],
+                'options' => [
+                    'a1' => ['is', 'will be', 'was'],
+                    'a2' => ['will take', 'take', 'are taking'],
+                ],
+                'answers' => ['a1' => 'is', 'a2' => 'will take'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If they {a1}, they {a2} the train.',
+                'verb_hint' => ['a1' => '(not hurry)', 'a2' => '(miss)'],
+                'options' => [
+                    'a1' => ["don't hurry", "won't hurry", "aren't hurrying"],
+                    'a2' => ['will miss', 'miss', 'are missing'],
+                ],
+                'answers' => ['a1' => "don't hurry", 'a2' => 'will miss'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If I {a1} her, I {a2} her the news.',
+                'verb_hint' => ['a1' => '(see)', 'a2' => '(tell)'],
+                'options' => [
+                    'a1' => ['see', 'will see', 'am seeing'],
+                    'a2' => ['will tell', 'tell', 'am telling'],
+                ],
+                'answers' => ['a1' => 'see', 'a2' => 'will tell'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If the car {a1} down, we {a2} for help.',
+                'verb_hint' => ['a1' => '(break)', 'a2' => '(call)'],
+                'options' => [
+                    'a1' => ['breaks', 'will break', 'is breaking'],
+                    'a2' => ['will call', 'call', 'are calling'],
+                ],
+                'answers' => ['a1' => 'breaks', 'a2' => 'will call'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'We {a1} for a picnic if it {a2}.',
+                'verb_hint' => ['a1' => '(not go)', 'a2' => '(rain)'],
+                'options' => [
+                    'a1' => ["won't go", "don't go", "aren't going"],
+                    'a2' => ['rains', 'will rain', 'is raining'],
+                ],
+                'answers' => ['a1' => "won't go", 'a2' => 'rains'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If he {a1} more, he {a2} better grades.',
+                'verb_hint' => ['a1' => '(study)', 'a2' => '(get)'],
+                'options' => [
+                    'a1' => ['studies', 'will study', 'is studying'],
+                    'a2' => ['will get', 'gets', 'is getting'],
+                ],
+                'answers' => ['a1' => 'studies', 'a2' => 'will get'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If you {a1} the plants, they {a2}.',
+                'verb_hint' => ['a1' => '(not water)', 'a2' => '(die)'],
+                'options' => [
+                    'a1' => ["don't water", "won't water", "aren't watering"],
+                    'a2' => ['will die', 'die', 'are dying'],
+                ],
+                'answers' => ['a1' => "don't water", 'a2' => 'will die'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+        ];
+
+        $items = [];
+        $meta = [];
+
+        foreach ($questions as $index => $question) {
+            $answersMap = [];
+            foreach ($question['answers'] as $marker => $value) {
+                $answersMap[$marker] = $this->normalizeValue($value);
+            }
+
+            $optionSets = $this->prepareOptionSets($question['options'], $answersMap);
+            $flattenedOptions = $this->flattenOptions($optionSets);
+
+            $verbHints = [];
+            foreach ($answersMap as $marker => $value) {
+                $hintSource = $question['verb_hint'][$marker] ?? null;
+                $verbHints[$marker] = $this->normalizeHint($hintSource);
+            }
+
+            $example = $this->buildExample($question['question'], $answersMap);
+
+            $answers = [];
+            foreach ($answersMap as $marker => $answer) {
+                $answers[] = [
+                    'marker' => $marker,
+                    'answer' => $answer,
+                    'verb_hint' => $verbHints[$marker] ?? null,
+                ];
+            }
+
+            $hints = [];
+            $explanations = [];
+            $optionMarkerMap = [];
+
+            foreach ($optionSets as $marker => $options) {
+                foreach ($options as $option) {
+                    if (! isset($optionMarkerMap[$option])) {
+                        $optionMarkerMap[$option] = $marker;
+                    }
+                }
+
+                $clauseType = $this->detectClauseType($question['question'], $marker);
+                $hints[$marker] = $this->buildHintForClause($clauseType, $verbHints[$marker] ?? null, $example);
+
+                $explanations = array_merge(
+                    $explanations,
+                    $this->buildExplanationsForClause(
+                        $clauseType,
+                        $options,
+                        $answersMap[$marker],
+                        $example
+                    )
+                );
+            }
+
+            $tagIds = [$themeTagId, $structureTagId, $tenseTagId];
+            foreach ($question['tense'] as $tenseName) {
+                $tagIds[] = Tag::firstOrCreate(['name' => $tenseName], ['category' => 'Tenses'])->id;
+            }
+
+            $uuid = $this->generateQuestionUuid($index + 1, $question['question']);
+
+            $items[] = [
+                'uuid' => $uuid,
+                'question' => $question['question'],
+                'category_id' => $categoryId,
+                'difficulty' => $levelDifficulty[$question['level']] ?? 3,
+                'source_id' => $sourceId,
+                'flag' => 0,
+                'level' => $question['level'],
+                'tag_ids' => array_values(array_unique($tagIds)),
+                'answers' => $answers,
+                'options' => $flattenedOptions,
+                'variants' => [$question['question']],
+            ];
+
+            $meta[] = [
+                'uuid' => $uuid,
+                'answers' => $answersMap,
+                'option_markers' => $optionMarkerMap,
+                'hints' => $hints,
+                'explanations' => $explanations,
+            ];
+        }
+
+        $this->seedQuestionData($items, $meta);
+    }
+
+    private function prepareOptionSets(array $options, array $answers): array
+    {
+        if ($this->isAssoc($options)) {
+            $result = [];
+            foreach ($options as $marker => $choices) {
+                $result[$marker] = array_map(fn ($value) => $this->normalizeValue((string) $value), (array) $choices);
+            }
+
+            return $result;
+        }
+
+        $marker = array_key_first($answers);
+        if ($marker === null) {
+            return [];
+        }
+
+        return [
+            $marker => array_map(fn ($value) => $this->normalizeValue((string) $value), $options),
+        ];
+    }
+
+    private function flattenOptions(array $optionSets): array
+    {
+        $all = [];
+        foreach ($optionSets as $options) {
+            foreach ($options as $option) {
+                $all[] = $option;
+            }
+        }
+
+        return array_values(array_unique($all));
+    }
+
+    private function detectClauseType(string $question, string $marker): string
+    {
+        $placeholder = '{' . $marker . '}';
+        $position = mb_stripos($question, $placeholder);
+
+        if ($position === false) {
+            return 'result';
+        }
+
+        $before = mb_substr($question, 0, $position);
+        $beforeLower = mb_strtolower($before);
+
+        if (mb_strripos($beforeLower, 'if') !== false) {
+            return 'condition';
+        }
+
+        return 'result';
+    }
+
+    private function buildHintForClause(string $clauseType, ?string $verbHint, string $example): string
+    {
+        $base = $clauseType === 'condition'
+            ? 'If-clause → Present Simple (без will).'
+            : "Main clause → will + V1 / won't + V1 для результату.";
+
+        if ($verbHint) {
+            $base .= ' Дієслово: ' . $verbHint . '.';
+        }
+
+        return $base . ' Приклад: *' . $example . '*.';
+    }
+
+    private function buildExplanationsForClause(string $clauseType, array $options, string $answer, string $example): array
+    {
+        $result = [];
+        foreach ($options as $option) {
+            if ($option === $answer) {
+                $result[$option] = $this->buildCorrectExplanation($clauseType, $option, $example);
+            } else {
+                $result[$option] = $this->buildWrongExplanation($clauseType, $option, $answer, $example);
+            }
+        }
+
+        return $result;
+    }
+
+    private function buildCorrectExplanation(string $clauseType, string $answer, string $example): string
+    {
+        if ($clauseType === 'condition') {
+            return '✅ «' . $answer . '» — правильна форма Present Simple у частині з if. Приклад: *' . $example . '*.';
+        }
+
+        return '✅ «' . $answer . '» — коректна форма Future Simple у головному реченні. Приклад: *' . $example . '*.';
+    }
+
+    private function buildWrongExplanation(string $clauseType, string $option, string $answer, string $example): string
+    {
+        $type = $this->classifyOption($option);
+
+        if ($clauseType === 'condition') {
+            return match ($type) {
+                'future' => '❌ У підрядній частині першого умовного не вживаємо will/won\'t. Дивись приклад: *' . $example . '*.',
+                'continuous' => '❌ If-clause вимагає Present Simple, а не тривалий час. Правильний приклад: *' . $example . '*.',
+                'past' => '❌ Перший умовний після if використовує теперішній час, не минулий. Приклад: *' . $example . '*.',
+                'perfect' => '❌ Потрібна проста форма, без have + V3. Орієнтуйся на приклад: *' . $example . '*.',
+                default => '❌ Спробуй Present Simple у частині з if. Правильний приклад: *' . $example . '*.',
+            };
+        }
+
+        if ($type === 'future' && $this->isFullNegativeVariant($option, $answer)) {
+            return '❌ «' . $option . '» граматично можливо, але завдання очікує скорочення «' . $answer . '». Приклад: *' . $example . '*.';
+        }
+
+        return match ($type) {
+            'future' => '❌ Форма «' . $option . '» не відповідає потрібній моделі will + правильне дієслово. Подивись: *' . $example . '*.',
+            'continuous' => '❌ У головному реченні потрібне will + V1 (або won\'t + V1), а не тривалий час. Правильний приклад: *' . $example . '*.',
+            'do' => '❌ Заперечення з do/does не підходить; потрібне will/won\'t. Подивись на приклад: *' . $example . '*.',
+            'past' => '❌ Результат у першому умовному будуємо через will, не минулий час. Приклад: *' . $example . '*.',
+            'perfect' => '❌ Не використовуй have + V3 у результаті; потрібна проста форма з will. Приклад: *' . $example . '*.',
+            'be_negative' => '❌ Краще використати will/won\'t + be, як у прикладі: *' . $example . '*.',
+            default => '❌ Основне речення має містити will або won\'t. Орієнтуйся на приклад: *' . $example . '*.',
+        };
+    }
+
+    private function classifyOption(string $option): string
+    {
+        $value = mb_strtolower($option);
+
+        if (str_contains($value, 'will have')) {
+            return 'perfect';
+        }
+
+        if (str_contains($value, "won't") || preg_match('/\bwill\b/', $value)) {
+            return 'future';
+        }
+
+        if (preg_match('/\b(am|is|are|was|were)\b[^a-z]*[a-z]+ing/', $value)) {
+            return 'continuous';
+        }
+
+        if (preg_match('/\b(did|was|were)\b/', $value)) {
+            return 'past';
+        }
+
+        if (preg_match("/\b(do|does|don't|doesn't)\b/", $value)) {
+            return 'do';
+        }
+
+        if (preg_match("/\b(has|have|had)\b/", $value)) {
+            return 'perfect';
+        }
+
+        if (preg_match("/\b(isn't|aren't)\b/", $value)) {
+            return 'be_negative';
+        }
+
+        return 'present_simple';
+    }
+
+    private function isFullNegativeVariant(string $option, string $answer): bool
+    {
+        $optionNormalized = str_replace(' ', '', mb_strtolower($option));
+        $answerNormalized = str_replace(' ', '', mb_strtolower($answer));
+
+        return str_contains($optionNormalized, 'willnot') && str_contains($answerNormalized, "won't");
+    }
+
+    private function buildExample(string $question, array $answers): string
+    {
+        $result = $question;
+        foreach ($answers as $marker => $answer) {
+            $result = str_replace('{' . $marker . '}', $answer, $result);
+        }
+
+        $result = preg_replace('/\s+/', ' ', trim($result));
+
+        $first = mb_substr($result, 0, 1, 'UTF-8');
+        $rest = mb_substr($result, 1, null, 'UTF-8');
+
+        return mb_strtoupper($first, 'UTF-8') . $rest;
+    }
+
+    private function normalizeValue(string $value): string
+    {
+        $value = str_replace(['’', '‘', '‛', 'ʻ'], "'", $value);
+        $value = preg_replace('/\s+/', ' ', $value);
+
+        return trim($value);
+    }
+
+    private function isAssoc(array $array): bool
+    {
+        if ($array === []) {
+            return false;
+        }
+
+        return array_keys($array) !== range(0, count($array) - 1);
+    }
+}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,63 @@
+@extends('layouts.app')
+
+@section('title', 'Вхід до адмін-панелі')
+
+@section('content')
+    <div class="flex justify-center">
+        <div class="w-full max-w-md bg-white shadow rounded-lg p-8">
+            <h1 class="text-2xl font-semibold text-center text-gray-800 mb-6">Вхід до адмін-панелі</h1>
+
+            @if(session('status'))
+                <div class="mb-4 p-3 rounded bg-green-100 text-green-700 text-sm">
+                    {{ session('status') }}
+                </div>
+            @endif
+
+            <form method="POST" action="{{ route('login.perform') }}" class="space-y-5">
+                @csrf
+
+                <div>
+                    <label for="username" class="block text-sm font-medium text-gray-700">Логін</label>
+                    <input
+                        id="username"
+                        type="text"
+                        name="username"
+                        value="{{ old('username') }}"
+                        required
+                        autofocus
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                    >
+                    @error('username')
+                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="password" class="block text-sm font-medium text-gray-700">Пароль</label>
+                    <input
+                        id="password"
+                        type="password"
+                        name="password"
+                        required
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                    >
+                    @error('password')
+                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <button
+                    type="submit"
+                    class="w-full py-2 px-4 text-white font-semibold bg-blue-600 hover:bg-blue-700 rounded-md shadow"
+                >
+                    Увійти
+                </button>
+            </form>
+
+            <div class="mt-6 text-sm text-gray-500">
+                <p>Стандартний логін: <span class="font-semibold text-gray-700">admin</span></p>
+                <p>Пароль: <span class="font-semibold text-gray-700">engapp2024</span></p>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,63 +1,76 @@
-@extends('layouts.app')
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Вхід до адмін-панелі</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center p-4">
+    <div class="w-full max-w-md bg-white shadow rounded-lg p-8">
+        <h1 class="text-2xl font-semibold text-center text-gray-800 mb-6">Вхід до адмін-панелі</h1>
 
-@section('title', 'Вхід до адмін-панелі')
-
-@section('content')
-    <div class="flex justify-center">
-        <div class="w-full max-w-md bg-white shadow rounded-lg p-8">
-            <h1 class="text-2xl font-semibold text-center text-gray-800 mb-6">Вхід до адмін-панелі</h1>
-
-            @if(session('status'))
-                <div class="mb-4 p-3 rounded bg-green-100 text-green-700 text-sm">
-                    {{ session('status') }}
-                </div>
-            @endif
-
-            <form method="POST" action="{{ route('login.perform') }}" class="space-y-5">
-                @csrf
-
-                <div>
-                    <label for="username" class="block text-sm font-medium text-gray-700">Логін</label>
-                    <input
-                        id="username"
-                        type="text"
-                        name="username"
-                        value="{{ old('username') }}"
-                        required
-                        autofocus
-                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                    >
-                    @error('username')
-                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                    @enderror
-                </div>
-
-                <div>
-                    <label for="password" class="block text-sm font-medium text-gray-700">Пароль</label>
-                    <input
-                        id="password"
-                        type="password"
-                        name="password"
-                        required
-                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                    >
-                    @error('password')
-                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                    @enderror
-                </div>
-
-                <button
-                    type="submit"
-                    class="w-full py-2 px-4 text-white font-semibold bg-blue-600 hover:bg-blue-700 rounded-md shadow"
-                >
-                    Увійти
-                </button>
-            </form>
-
-            <div class="mt-6 text-sm text-gray-500">
-                <p>Стандартний логін: <span class="font-semibold text-gray-700">admin</span></p>
-                <p>Пароль: <span class="font-semibold text-gray-700">engapp2024</span></p>
+        @if(session('status'))
+            <div class="mb-4 p-3 rounded bg-green-100 text-green-700 text-sm">
+                {{ session('status') }}
             </div>
-        </div>
+        @endif
+
+        <form method="POST" action="{{ route('login.perform') }}" class="space-y-5">
+            @csrf
+
+            <div>
+                <label for="username" class="block text-sm font-medium text-gray-700">Логін</label>
+                <input
+                    id="username"
+                    type="text"
+                    name="username"
+                    value="{{ old('username') }}"
+                    required
+                    autofocus
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                >
+                @error('username')
+                    <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="password" class="block text-sm font-medium text-gray-700">Пароль</label>
+                <input
+                    id="password"
+                    type="password"
+                    name="password"
+                    required
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                >
+                @error('password')
+                    <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div class="flex items-center justify-between">
+                <label for="remember" class="flex items-center text-sm text-gray-600">
+                    <input
+                        id="remember"
+                        type="checkbox"
+                        name="remember"
+                        value="1"
+                        class="mr-2 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        @checked(old('remember'))
+                    >
+                    Запам'ятати мене
+                </label>
+                <a href="{{ url('/') }}" class="text-sm text-blue-600 hover:text-blue-700">На головну</a>
+            </div>
+
+            <button
+                type="submit"
+                class="w-full py-2 px-4 text-white font-semibold bg-blue-600 hover:bg-blue-700 rounded-md shadow"
+            >
+                Увійти
+            </button>
+        </form>
     </div>
-@endsection
+</body>
+</html>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -49,7 +49,7 @@
                 @enderror
             </div>
 
-            <div class="flex items-center justify-between">
+            <div class="flex items-center">
                 <label for="remember" class="flex items-center text-sm text-gray-600">
                     <input
                         id="remember"
@@ -61,7 +61,6 @@
                     >
                     Запам'ятати мене
                 </label>
-                <a href="{{ url('/') }}" class="text-sm text-blue-600 hover:text-blue-700">На головну</a>
             </div>
 
             <button

--- a/resources/views/engram/catalog-tests-cards.blade.php
+++ b/resources/views/engram/catalog-tests-cards.blade.php
@@ -4,7 +4,21 @@
 
 @section('content')
 <div class="flex flex-col md:flex-row gap-6">
-    <aside class="md:w-48 w-full md:shrink-0">
+    <div class="md:hidden">
+        <button type="button" id="filter-toggle" class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-border text-sm font-medium">
+            <span>Фільтр</span>
+            <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M3.5 5a.75.75 0 01.75-.75h11.5a.75.75 0 01.53 1.28L12 10.06v4.19a.75.75 0 01-1.13.65l-2.5-1.5a.75.75 0 01-.37-.65v-2.69L3.97 5.53A.75.75 0 013.5 5z" clip-rule="evenodd" />
+            </svg>
+        </button>
+    </div>
+    <aside id="filters" class="md:w-48 w-full md:shrink-0 hidden md:block md:sticky md:top-20 md:self-start bg-card md:bg-transparent md:p-0 p-4 rounded-2xl shadow-soft md:shadow-none">
+        <div class="flex justify-between items-center md:hidden mb-4">
+            <h2 class="text-base font-semibold">Фільтр</h2>
+            <button type="button" id="filter-close" class="text-sm text-primary underline">
+                Закрити
+            </button>
+        </div>
         <form id="tag-filter" action="{{ route('catalog-tests.cards') }}" method="GET">
             @if(isset($availableLevels) && $availableLevels->count())
                 <div class="mb-4">
@@ -103,6 +117,19 @@
             const hidden = tags.style.display === 'none';
             tags.style.display = hidden ? '' : 'none';
             toggleBtn.textContent = hidden ? 'Hide' : 'Show';
+        });
+    }
+    const filterToggle = document.getElementById('filter-toggle');
+    const filterClose = document.getElementById('filter-close');
+    const filters = document.getElementById('filters');
+    if (filterToggle && filters) {
+        filterToggle.addEventListener('click', () => {
+            filters.classList.toggle('hidden');
+        });
+    }
+    if (filterClose && filters) {
+        filterClose.addEventListener('click', () => {
+            filters.classList.add('hidden');
         });
     }
 </script>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -45,6 +45,14 @@
                     <a href="{{ url('/grammar-test/v2') }}" class="hover:text-blue-500 transition">Граматика v2</a>
                     <a href="{{ url('/tests') }}" class="hover:text-blue-500 transition">Збережені тести</a>
                     <a href="{{ url('/') }}" class="hover:text-blue-500 transition">До публічної частини</a>
+                    @if(session('admin_authenticated'))
+                        <form method="POST" action="{{ route('logout') }}">
+                            @csrf
+                            <button type="submit" class="text-red-500 hover:text-red-600 transition">Вийти</button>
+                        </form>
+                    @else
+                        <a href="{{ route('login.show') }}" class="hover:text-blue-500 transition">Увійти</a>
+                    @endif
                 </div>
             </div>
             <div
@@ -56,6 +64,14 @@
                 <a href="{{ url('/grammar-test/v2') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">Граматика v2</a>
                 <a href="{{ url('/tests') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">Збережені тести</a>
                 <a href="{{ url('/') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">До публічної частини</a>
+                @if(session('admin_authenticated'))
+                    <form method="POST" action="{{ route('logout') }}" class="px-2 py-2">
+                        @csrf
+                        <button type="submit" class="w-full text-left text-red-500 hover:text-red-600">Вийти</button>
+                    </form>
+                @else
+                    <a href="{{ route('login.show') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">Увійти</a>
+                @endif
             </div>
         </div>
     </nav>

--- a/resources/views/layouts/engram.blade.php
+++ b/resources/views/layouts/engram.blade.php
@@ -118,24 +118,22 @@
   <!-- HEADER / NAV -->
   <header class="sticky top-0 z-40 border-b border-border/70 backdrop-blur bg-background/80">
     <div class="container mx-auto px-4">
-      <div class="flex h-16 items-center justify-between gap-4">
-        <div class="flex items-center gap-3">
+      <div class="flex flex-wrap items-center justify-between gap-4 py-4 md:h-16 md:flex-nowrap">
+        <div class="flex items-center gap-3 flex-shrink-0">
           <div class="h-9 w-9 rounded-2xl bg-primary text-primary-foreground grid place-items-center font-bold">E</div>
           <span class="text-lg font-semibold tracking-tight">Engram</span>
           <span class="ml-2 inline-flex items-center rounded-lg bg-accent text-accent-foreground px-2 py-0.5 text-xs font-medium">beta</span>
         </div>
-        <nav class="hidden md:flex items-center gap-6 text-sm">
+        <nav class="order-3 w-full flex flex-wrap items-center gap-4 text-sm md:order-none md:w-auto md:flex-nowrap md:gap-6">
           <a class="text-muted-foreground hover:text-foreground" href="{{ route('catalog-tests.cards') }}">Тести</a>
           <a class="text-muted-foreground hover:text-foreground" href="{{ route('pages.index') }}">Теорія</a>
         </nav>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 order-2 ml-auto md:order-none md:ml-0">
           <form action="{{ route('site.search') }}" method="GET" class="hidden md:block relative">
             <input type="search" name="q" id="search-box" autocomplete="off" placeholder="Пошук..." class="w-48 rounded-xl border border-input bg-background px-3 py-2 text-sm" />
             <div id="search-box-list" class="absolute left-0 mt-1 w-full bg-background border border-border rounded-xl shadow-soft text-sm hidden z-50"></div>
           </form>
           <button id="mobile-search-btn" class="md:hidden rounded-xl border border-border p-2 text-sm">🔍</button>
-          <button id="theme-toggle" class="hidden sm:inline-flex rounded-xl border border-border px-3 py-2 text-sm">🌙 Тема</button>
-          <button class="rounded-2xl bg-primary px-4 py-2 text-primary-foreground text-sm">Реєстрація</button>
         </div>
       </div>
       <div id="mobile-search" class="md:hidden hidden pb-3">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,17 +1,25 @@
 <?php
 
+use App\Http\Controllers\AiTestController;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\ChatGPTExplanationController;
 use App\Http\Controllers\GrammarTestController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\PageController;
-use App\Http\Controllers\QuestionHelpController;
 use App\Http\Controllers\QuestionAnswerController;
+use App\Http\Controllers\QuestionController;
+use App\Http\Controllers\QuestionHelpController;
 use App\Http\Controllers\QuestionHintController;
 use App\Http\Controllers\QuestionOptionController;
+use App\Http\Controllers\QuestionReviewController;
+use App\Http\Controllers\QuestionReviewResultController;
 use App\Http\Controllers\QuestionVariantController;
-use App\Http\Controllers\ChatGPTExplanationController;
-use App\Http\Controllers\TrainController;
-use App\Http\Controllers\WordSearchController;
+use App\Http\Controllers\SentenceTranslationTestController;
 use App\Http\Controllers\SiteSearchController;
+use App\Http\Controllers\TrainController;
+use App\Http\Controllers\VerbHintController;
+use App\Http\Controllers\WordSearchController;
+use App\Http\Controllers\WordsTestController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -25,140 +33,135 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('set-locale', function (\Illuminate\Http\Request $request) {
-    $lang = $request->input('lang', 'en');
-    if (! in_array($lang, ['en', 'uk', 'pl'])) {
-        $lang = 'en';
-    }
-    session(['locale' => $lang]);
-    app()->setLocale($lang);
+Route::get('/login', [AuthController::class, 'showLoginForm'])->name('login.show');
+Route::post('/login', [AuthController::class, 'login'])->name('login.perform');
+Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
 
-    return redirect()->back();
-})->name('setlocale');
+Route::middleware('auth.admin')->group(function () {
+    Route::get('set-locale', function (\Illuminate\Http\Request $request) {
+        $lang = $request->input('lang', 'en');
+        if (! in_array($lang, ['en', 'uk', 'pl'])) {
+            $lang = 'en';
+        }
+        session(['locale' => $lang]);
+        app()->setLocale($lang);
 
-Route::get('/', [HomeController::class, 'index'])->name('home');
+        return redirect()->back();
+    })->name('setlocale');
 
-Route::get('/train/{topic?}', [TrainController::class, 'index'])->name('train');
+    Route::get('/', [HomeController::class, 'index'])->name('home');
 
-Route::get('/theory', [PageController::class, 'index'])->name('pages.index');
-Route::get('/theory/{slug}', [PageController::class, 'show'])->name('pages.show');
+    Route::get('/train/{topic?}', [TrainController::class, 'index'])->name('train');
 
-use App\Http\Controllers\SentenceTranslationTestController;
-use App\Http\Controllers\WordsTestController;
-
-Route::get('/words/test', [WordsTestController::class, 'index'])->name('words.test');
-Route::post('/words/test/check', [WordsTestController::class, 'check'])->name('words.test.check');
-Route::post('/words/test/reset', function () {
-    session()->forget('words_test_stats');
-
-    return redirect()->route('words.test');
-})->name('words.test.reset');
-
-Route::get('/translate/test', [SentenceTranslationTestController::class, 'index'])->name('translate.test');
-Route::post('/translate/test/check', [SentenceTranslationTestController::class, 'check'])->name('translate.test.check');
-Route::post('/translate/test/reset', [SentenceTranslationTestController::class, 'reset'])->name('translate.test.reset');
-Route::get('/translate/test2', [SentenceTranslationTestController::class, 'indexV2'])->name('translate.test2');
-Route::post('/translate/test2/check', [SentenceTranslationTestController::class, 'checkV2'])->name('translate.test2.check');
-Route::post('/translate/test2/reset', [SentenceTranslationTestController::class, 'resetV2'])->name('translate.test2.reset');
-
-Route::get('/grammar-test', [GrammarTestController::class, 'index'])->name('grammar-test');
-Route::post('/grammar-test', [GrammarTestController::class, 'generate'])->name('grammar-test.generate');
-Route::get('/grammar-test/v2', [GrammarTestController::class, 'indexV2'])->name('grammar-test.v2');
-Route::post('/grammar-test/v2', [GrammarTestController::class, 'generateV2'])->name('grammar-test-v2.generate');
-Route::post('/grammar-test-check', [GrammarTestController::class, 'check'])->name('grammar-test.check');
-Route::get('/grammar-test-autocomplete', [GrammarTestController::class, 'autocomplete'])->name('grammar-test.autocomplete');
-Route::post('/grammar-test-check-answer', [GrammarTestController::class, 'checkOneAnswer'])->name('grammar-test.checkOne');
-
-Route::post('/grammar-test-save', [GrammarTestController::class, 'save'])->name('grammar-test.save');
-Route::post('/grammar-test-v2-save', [GrammarTestController::class, 'saveV2'])->name('grammar-test-v2.save');
-Route::post('/test/{slug}/js/state', [GrammarTestController::class, 'storeSavedTestJsState'])->name('saved-test.js.state');
-Route::get('/test/{slug}/js/questions', [GrammarTestController::class, 'fetchSavedTestJsQuestions'])->name('saved-test.js.questions');
-Route::get('/test/{slug}/js', [GrammarTestController::class, 'showSavedTestJs'])->name('saved-test.js');
-Route::get('/test/{slug}/js/step', [GrammarTestController::class, 'showSavedTestJsStep'])->name('saved-test.js.step');
-Route::get('/test/{slug}/js/manual', [GrammarTestController::class, 'showSavedTestJsManual'])->name('saved-test.js.manual');
-Route::get('/test/{slug}/js/step/manual', [GrammarTestController::class, 'showSavedTestJsStepManual'])->name('saved-test.js.step-manual');
-Route::get('/test/{slug}/js/step/input', [GrammarTestController::class, 'showSavedTestJsStepInput'])->name('saved-test.js.step-input');
-Route::get('/test/{slug}/js/input', [GrammarTestController::class, 'showSavedTestJsInput'])->name('saved-test.js.input');
-Route::get('/test/{slug}/js/step/select', [GrammarTestController::class, 'showSavedTestJsStepSelect'])->name('saved-test.js.step-select');
-Route::get('/test/{slug}/js/select', [GrammarTestController::class, 'showSavedTestJsSelect'])->name('saved-test.js.select');
-Route::get('/test/{slug}/tech', [GrammarTestController::class, 'showSavedTestTech'])->name('saved-test.tech');
-Route::post('/test/{slug}/questions', [GrammarTestController::class, 'storeSavedTestQuestion'])->name('saved-test.questions.store');
-Route::delete('/test/{slug}/questions', [GrammarTestController::class, 'deleteAllQuestions'])->name('saved-test.questions.destroy-all');
-Route::get('/test/{slug}', [GrammarTestController::class, 'showSavedTest'])->name('saved-test.show');
-Route::get('/test/{slug}/random', [GrammarTestController::class, 'showSavedTestRandom'])->name('saved-test.random');
-Route::get('/test/{slug}/step', [GrammarTestController::class, 'showSavedTestStep'])->name('saved-test.step');
-Route::post('/test/{slug}/refresh-description', [GrammarTestController::class, 'refreshDescription'])->name('saved-test.refresh');
-Route::post('/test/{slug}/refresh-description-gemini', [GrammarTestController::class, 'refreshDescriptionGemini'])->name('saved-test.refresh-gemini');
-Route::post('/test/{slug}/step/check', [GrammarTestController::class, 'checkSavedTestStep'])->name('saved-test.step.check');
-Route::post('/test/{slug}/step/reset', [GrammarTestController::class, 'resetSavedTestStep'])->name('saved-test.step.reset');
-Route::post('/test/{slug}/step/determine-tense', [GrammarTestController::class, 'determineTense'])->name('saved-test.step.determine-tense');
-Route::post('/test/{slug}/step/determine-tense-gemini', [GrammarTestController::class, 'determineTenseGemini'])->name('saved-test.step.determine-tense-gemini');
-Route::post('/test/{slug}/step/determine-level', [GrammarTestController::class, 'determineLevel'])->name('saved-test.step.determine-level');
-Route::post('/test/{slug}/step/determine-level-gemini', [GrammarTestController::class, 'determineLevelGemini'])->name('saved-test.step.determine-level-gemini');
-Route::post('/test/{slug}/step/set-level', [GrammarTestController::class, 'setLevel'])->name('saved-test.step.set-level');
-Route::post('/test/{slug}/step/add-tag', [GrammarTestController::class, 'addTag'])->name('saved-test.step.add-tag');
-Route::delete('/test/{slug}/step/remove-tag', [GrammarTestController::class, 'removeTag'])->name('saved-test.step.remove-tag');
-Route::delete('/test/{slug}/question/{question}', [GrammarTestController::class, 'deleteQuestion'])->name('saved-test.question.destroy');
-Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
-Route::delete('/tests/{slug}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
-Route::get('/tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('saved-tests.cards');
-Route::get('/catalog-tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('catalog-tests.cards');
-
-Route::get('/words', [WordSearchController::class, 'search'])->name('words.search');
-
-Route::get('/search', SiteSearchController::class)->name('site.search');
-
-use App\Http\Controllers\AiTestController;
-
-Route::get('/ai-test', [AiTestController::class, 'form'])->name('ai-test.form');
-Route::post('/ai-test/start', [AiTestController::class, 'start'])->name('ai-test.start');
-Route::get('/ai-test/step', [AiTestController::class, 'step'])->name('ai-test.step');
-Route::get('/ai-test/next', [AiTestController::class, 'next'])->name('ai-test.next');
-Route::post('/ai-test/check', [AiTestController::class, 'check'])->name('ai-test.check');
-Route::post('/ai-test/skip', [AiTestController::class, 'skip'])->name('ai-test.skip');
-Route::post('/ai-test/reset', [AiTestController::class, 'reset'])->name('ai-test.reset');
-Route::post('/ai-test/provider', [AiTestController::class, 'provider'])->name('ai-test.provider');
-Route::post('/ai-test/step/determine-tense', [AiTestController::class, 'determineTense'])->name('ai-test.step.determine-tense');
-Route::post('/ai-test/step/determine-tense-gemini', [AiTestController::class, 'determineTenseGemini'])->name('ai-test.step.determine-tense-gemini');
-Route::post('/ai-test/step/determine-level', [AiTestController::class, 'determineLevel'])->name('ai-test.step.determine-level');
-Route::post('/ai-test/step/determine-level-gemini', [AiTestController::class, 'determineLevelGemini'])->name('ai-test.step.determine-level-gemini');
-Route::post('/ai-test/step/set-level', [AiTestController::class, 'setLevel'])->name('ai-test.step.set-level');
-Route::post('/ai-test/step/add-tag', [AiTestController::class, 'addTag'])->name('ai-test.step.add-tag');
-Route::delete('/ai-test/step/remove-tag', [AiTestController::class, 'removeTag'])->name('ai-test.step.remove-tag');
-
-use App\Http\Controllers\QuestionReviewController;
-
-Route::get('/question-review', [QuestionReviewController::class, 'index'])->name('question-review.index');
-Route::post('/question-review', [QuestionReviewController::class, 'store'])->name('question-review.store');
-Route::get('/question-review/{question}', [QuestionReviewController::class, 'edit'])->name('question-review.edit');
-
-use App\Http\Controllers\QuestionController;
-use App\Http\Controllers\QuestionReviewResultController;
-use App\Http\Controllers\VerbHintController;
-
-Route::get('/question-review-results', [QuestionReviewResultController::class, 'index'])->name('question-review-results.index');
-
-Route::post('/verb-hints', [VerbHintController::class, 'store'])->name('verb-hints.store');
-Route::put('/verb-hints/{verbHint}', [VerbHintController::class, 'update'])->name('verb-hints.update');
-Route::delete('/verb-hints/{verbHint}', [VerbHintController::class, 'destroy'])->name('verb-hints.destroy');
-Route::put('/questions/{question}', [QuestionController::class, 'update'])->name('questions.update');
-Route::post('/questions/{question}/export', [QuestionController::class, 'export'])->name('questions.export');
-Route::post('/questions/export/by-uuid', [QuestionController::class, 'exportByUuid'])->name('questions.export-by-uuid');
-Route::post('/questions/restore/from-dumps', [QuestionController::class, 'restoreFromDumps'])->name('questions.restore-from-dumps');
-Route::post('/questions/restore/by-uuid', [QuestionController::class, 'restoreByUuid'])->name('questions.restore-by-uuid');
-Route::post('/question-answers', [QuestionAnswerController::class, 'store'])->name('question-answers.store');
-Route::put('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'update'])->name('question-answers.update');
-Route::delete('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'destroy'])->name('question-answers.destroy');
-Route::post('/questions/{question}/options', [QuestionOptionController::class, 'store'])->name('questions.options.store');
-Route::put('/questions/{question}/options/{option}', [QuestionOptionController::class, 'update'])->name('questions.options.update');
-Route::delete('/questions/{question}/options/{option}', [QuestionOptionController::class, 'destroy'])->name('questions.options.destroy');
-Route::put('/question-variants/{questionVariant}', [QuestionVariantController::class, 'update'])->name('question-variants.update');
-Route::delete('/question-variants/{questionVariant}', [QuestionVariantController::class, 'destroy'])->name('question-variants.destroy');
-Route::post('/question-hints', [QuestionHintController::class, 'store'])->name('question-hints.store');
-Route::put('/question-hints/{questionHint}', [QuestionHintController::class, 'update'])->name('question-hints.update');
-Route::delete('/question-hints/{questionHint}', [QuestionHintController::class, 'destroy'])->name('question-hints.destroy');
-Route::post('/chatgpt-explanations', [ChatGPTExplanationController::class, 'store'])->name('chatgpt-explanations.store');
-Route::delete('/chatgpt-explanations/{chatGPTExplanation}', [ChatGPTExplanationController::class, 'destroy'])->name('chatgpt-explanations.destroy');
-
-Route::post('/question-hint', [QuestionHelpController::class, 'hint'])->name('question.hint');
-Route::post('/question-explain', [QuestionHelpController::class, 'explain'])->name('question.explain');
+    Route::get('/theory', [PageController::class, 'index'])->name('pages.index');
+    Route::get('/theory/{slug}', [PageController::class, 'show'])->name('pages.show');
+    
+    Route::get('/words/test', [WordsTestController::class, 'index'])->name('words.test');
+    Route::post('/words/test/check', [WordsTestController::class, 'check'])->name('words.test.check');
+    Route::post('/words/test/reset', function () {
+        session()->forget('words_test_stats');
+    
+        return redirect()->route('words.test');
+    })->name('words.test.reset');
+    
+    Route::get('/translate/test', [SentenceTranslationTestController::class, 'index'])->name('translate.test');
+    Route::post('/translate/test/check', [SentenceTranslationTestController::class, 'check'])->name('translate.test.check');
+    Route::post('/translate/test/reset', [SentenceTranslationTestController::class, 'reset'])->name('translate.test.reset');
+    Route::get('/translate/test2', [SentenceTranslationTestController::class, 'indexV2'])->name('translate.test2');
+    Route::post('/translate/test2/check', [SentenceTranslationTestController::class, 'checkV2'])->name('translate.test2.check');
+    Route::post('/translate/test2/reset', [SentenceTranslationTestController::class, 'resetV2'])->name('translate.test2.reset');
+    
+    Route::get('/grammar-test', [GrammarTestController::class, 'index'])->name('grammar-test');
+    Route::post('/grammar-test', [GrammarTestController::class, 'generate'])->name('grammar-test.generate');
+    Route::get('/grammar-test/v2', [GrammarTestController::class, 'indexV2'])->name('grammar-test.v2');
+    Route::post('/grammar-test/v2', [GrammarTestController::class, 'generateV2'])->name('grammar-test-v2.generate');
+    Route::post('/grammar-test-check', [GrammarTestController::class, 'check'])->name('grammar-test.check');
+    Route::get('/grammar-test-autocomplete', [GrammarTestController::class, 'autocomplete'])->name('grammar-test.autocomplete');
+    Route::post('/grammar-test-check-answer', [GrammarTestController::class, 'checkOneAnswer'])->name('grammar-test.checkOne');
+    
+    Route::post('/grammar-test-save', [GrammarTestController::class, 'save'])->name('grammar-test.save');
+    Route::post('/grammar-test-v2-save', [GrammarTestController::class, 'saveV2'])->name('grammar-test-v2.save');
+    Route::post('/test/{slug}/js/state', [GrammarTestController::class, 'storeSavedTestJsState'])->name('saved-test.js.state');
+    Route::get('/test/{slug}/js/questions', [GrammarTestController::class, 'fetchSavedTestJsQuestions'])->name('saved-test.js.questions');
+    Route::get('/test/{slug}/js', [GrammarTestController::class, 'showSavedTestJs'])->name('saved-test.js');
+    Route::get('/test/{slug}/js/step', [GrammarTestController::class, 'showSavedTestJsStep'])->name('saved-test.js.step');
+    Route::get('/test/{slug}/js/manual', [GrammarTestController::class, 'showSavedTestJsManual'])->name('saved-test.js.manual');
+    Route::get('/test/{slug}/js/step/manual', [GrammarTestController::class, 'showSavedTestJsStepManual'])->name('saved-test.js.step-manual');
+    Route::get('/test/{slug}/js/step/input', [GrammarTestController::class, 'showSavedTestJsStepInput'])->name('saved-test.js.step-input');
+    Route::get('/test/{slug}/js/input', [GrammarTestController::class, 'showSavedTestJsInput'])->name('saved-test.js.input');
+    Route::get('/test/{slug}/js/step/select', [GrammarTestController::class, 'showSavedTestJsStepSelect'])->name('saved-test.js.step-select');
+    Route::get('/test/{slug}/js/select', [GrammarTestController::class, 'showSavedTestJsSelect'])->name('saved-test.js.select');
+    Route::get('/test/{slug}/tech', [GrammarTestController::class, 'showSavedTestTech'])->name('saved-test.tech');
+    Route::post('/test/{slug}/questions', [GrammarTestController::class, 'storeSavedTestQuestion'])->name('saved-test.questions.store');
+    Route::delete('/test/{slug}/questions', [GrammarTestController::class, 'deleteAllQuestions'])->name('saved-test.questions.destroy-all');
+    Route::get('/test/{slug}', [GrammarTestController::class, 'showSavedTest'])->name('saved-test.show');
+    Route::get('/test/{slug}/random', [GrammarTestController::class, 'showSavedTestRandom'])->name('saved-test.random');
+    Route::get('/test/{slug}/step', [GrammarTestController::class, 'showSavedTestStep'])->name('saved-test.step');
+    Route::post('/test/{slug}/refresh-description', [GrammarTestController::class, 'refreshDescription'])->name('saved-test.refresh');
+    Route::post('/test/{slug}/refresh-description-gemini', [GrammarTestController::class, 'refreshDescriptionGemini'])->name('saved-test.refresh-gemini');
+    Route::post('/test/{slug}/step/check', [GrammarTestController::class, 'checkSavedTestStep'])->name('saved-test.step.check');
+    Route::post('/test/{slug}/step/reset', [GrammarTestController::class, 'resetSavedTestStep'])->name('saved-test.step.reset');
+    Route::post('/test/{slug}/step/determine-tense', [GrammarTestController::class, 'determineTense'])->name('saved-test.step.determine-tense');
+    Route::post('/test/{slug}/step/determine-tense-gemini', [GrammarTestController::class, 'determineTenseGemini'])->name('saved-test.step.determine-tense-gemini');
+    Route::post('/test/{slug}/step/determine-level', [GrammarTestController::class, 'determineLevel'])->name('saved-test.step.determine-level');
+    Route::post('/test/{slug}/step/determine-level-gemini', [GrammarTestController::class, 'determineLevelGemini'])->name('saved-test.step.determine-level-gemini');
+    Route::post('/test/{slug}/step/set-level', [GrammarTestController::class, 'setLevel'])->name('saved-test.step.set-level');
+    Route::post('/test/{slug}/step/add-tag', [GrammarTestController::class, 'addTag'])->name('saved-test.step.add-tag');
+    Route::delete('/test/{slug}/step/remove-tag', [GrammarTestController::class, 'removeTag'])->name('saved-test.step.remove-tag');
+    Route::delete('/test/{slug}/question/{question}', [GrammarTestController::class, 'deleteQuestion'])->name('saved-test.question.destroy');
+    Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
+    Route::delete('/tests/{slug}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
+    Route::get('/tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('saved-tests.cards');
+    Route::get('/catalog-tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('catalog-tests.cards');
+    
+    Route::get('/words', [WordSearchController::class, 'search'])->name('words.search');
+    
+    Route::get('/search', SiteSearchController::class)->name('site.search');
+    
+    Route::get('/ai-test', [AiTestController::class, 'form'])->name('ai-test.form');
+    Route::post('/ai-test/start', [AiTestController::class, 'start'])->name('ai-test.start');
+    Route::get('/ai-test/step', [AiTestController::class, 'step'])->name('ai-test.step');
+    Route::get('/ai-test/next', [AiTestController::class, 'next'])->name('ai-test.next');
+    Route::post('/ai-test/check', [AiTestController::class, 'check'])->name('ai-test.check');
+    Route::post('/ai-test/skip', [AiTestController::class, 'skip'])->name('ai-test.skip');
+    Route::post('/ai-test/reset', [AiTestController::class, 'reset'])->name('ai-test.reset');
+    Route::post('/ai-test/provider', [AiTestController::class, 'provider'])->name('ai-test.provider');
+    Route::post('/ai-test/step/determine-tense', [AiTestController::class, 'determineTense'])->name('ai-test.step.determine-tense');
+    Route::post('/ai-test/step/determine-tense-gemini', [AiTestController::class, 'determineTenseGemini'])->name('ai-test.step.determine-tense-gemini');
+    Route::post('/ai-test/step/determine-level', [AiTestController::class, 'determineLevel'])->name('ai-test.step.determine-level');
+    Route::post('/ai-test/step/determine-level-gemini', [AiTestController::class, 'determineLevelGemini'])->name('ai-test.step.determine-level-gemini');
+    Route::post('/ai-test/step/set-level', [AiTestController::class, 'setLevel'])->name('ai-test.step.set-level');
+    Route::post('/ai-test/step/add-tag', [AiTestController::class, 'addTag'])->name('ai-test.step.add-tag');
+    Route::delete('/ai-test/step/remove-tag', [AiTestController::class, 'removeTag'])->name('ai-test.step.remove-tag');
+    
+    Route::get('/question-review', [QuestionReviewController::class, 'index'])->name('question-review.index');
+    Route::post('/question-review', [QuestionReviewController::class, 'store'])->name('question-review.store');
+    Route::get('/question-review/{question}', [QuestionReviewController::class, 'edit'])->name('question-review.edit');
+    
+    Route::get('/question-review-results', [QuestionReviewResultController::class, 'index'])->name('question-review-results.index');
+    
+    Route::post('/verb-hints', [VerbHintController::class, 'store'])->name('verb-hints.store');
+    Route::put('/verb-hints/{verbHint}', [VerbHintController::class, 'update'])->name('verb-hints.update');
+    Route::delete('/verb-hints/{verbHint}', [VerbHintController::class, 'destroy'])->name('verb-hints.destroy');
+    Route::put('/questions/{question}', [QuestionController::class, 'update'])->name('questions.update');
+    Route::post('/questions/{question}/export', [QuestionController::class, 'export'])->name('questions.export');
+    Route::post('/questions/export/by-uuid', [QuestionController::class, 'exportByUuid'])->name('questions.export-by-uuid');
+    Route::post('/questions/restore/from-dumps', [QuestionController::class, 'restoreFromDumps'])->name('questions.restore-from-dumps');
+    Route::post('/questions/restore/by-uuid', [QuestionController::class, 'restoreByUuid'])->name('questions.restore-by-uuid');
+    Route::post('/question-answers', [QuestionAnswerController::class, 'store'])->name('question-answers.store');
+    Route::put('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'update'])->name('question-answers.update');
+    Route::delete('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'destroy'])->name('question-answers.destroy');
+    Route::post('/questions/{question}/options', [QuestionOptionController::class, 'store'])->name('questions.options.store');
+    Route::put('/questions/{question}/options/{option}', [QuestionOptionController::class, 'update'])->name('questions.options.update');
+    Route::delete('/questions/{question}/options/{option}', [QuestionOptionController::class, 'destroy'])->name('questions.options.destroy');
+    Route::put('/question-variants/{questionVariant}', [QuestionVariantController::class, 'update'])->name('question-variants.update');
+    Route::delete('/question-variants/{questionVariant}', [QuestionVariantController::class, 'destroy'])->name('question-variants.destroy');
+    Route::post('/question-hints', [QuestionHintController::class, 'store'])->name('question-hints.store');
+    Route::put('/question-hints/{questionHint}', [QuestionHintController::class, 'update'])->name('question-hints.update');
+    Route::delete('/question-hints/{questionHint}', [QuestionHintController::class, 'destroy'])->name('question-hints.destroy');
+    Route::post('/chatgpt-explanations', [ChatGPTExplanationController::class, 'store'])->name('chatgpt-explanations.store');
+    Route::delete('/chatgpt-explanations/{chatGPTExplanation}', [ChatGPTExplanationController::class, 'destroy'])->name('chatgpt-explanations.destroy');
+    
+    Route::post('/question-hint', [QuestionHelpController::class, 'hint'])->name('question.hint');
+    Route::post('/question-explain', [QuestionHelpController::class, 'explain'])->name('question.explain');
+});


### PR DESCRIPTION
## Summary
- add an admin authentication controller and middleware that require a login before accessing site pages
- store the default admin credentials in configuration and expose a styled login form with the standard username/password
- update the navigation layout and route definitions so every page is behind the new guard with logout support

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2ee258bc832ab644077fcb2f1393