### PR TITLE
Add AI first conditional future forms seeder

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Barryvdh\Debugbar\Facades\Debugbar;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\View;
+
+class AuthController extends Controller
+{
+    public function showLoginForm(Request $request)
+    {
+        if (class_exists(Debugbar::class)) {
+            Debugbar::disable();
+        }
+
+        if ($request->session()->get('admin_authenticated', false)) {
+            return Redirect::route('home');
+        }
+
+        if ($request->hasCookie('admin_remember_token') && $request->cookie('admin_remember_token') === $this->rememberToken()) {
+            $request->session()->put('admin_authenticated', true);
+
+            return Redirect::route('home');
+        }
+
+        return View::make('auth.login');
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->only(['username', 'password']);
+
+        $validator = Validator::make($credentials, [
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+        ]);
+
+        if ($validator->fails()) {
+            return Redirect::back()
+                ->withErrors($validator)
+                ->withInput($request->except('password'));
+        }
+
+        $expectedUsername = config('admin.username');
+        $expectedPasswordHash = config('admin.password_hash');
+
+        if ($credentials['username'] !== $expectedUsername || ! password_verify($credentials['password'], $expectedPasswordHash)) {
+            return Redirect::back()
+                ->withErrors(['username' => __('auth.failed')])
+                ->withInput($request->except('password'));
+        }
+
+        $request->session()->regenerate();
+        $request->session()->put('admin_authenticated', true);
+
+        if ($request->boolean('remember')) {
+            Cookie::queue(
+                Cookie::make(
+                    'admin_remember_token',
+                    $this->rememberToken(),
+                    60 * 24 * 30,
+                    null,
+                    null,
+                    false,
+                    true,
+                    false,
+                    'lax'
+                )
+            );
+        } else {
+            Cookie::queue(Cookie::forget('admin_remember_token'));
+        }
+
+        return Redirect::intended(route('home'));
+    }
+
+    public function logout(Request $request)
+    {
+        $request->session()->forget('admin_authenticated');
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        Cookie::queue(Cookie::forget('admin_remember_token'));
+
+        return Redirect::route('login.show');
+    }
+
+    private function rememberToken(): string
+    {
+        return hash('sha256', config('admin.username') . '|' . config('admin.password_hash'));
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'auth.admin' => \App\Http\Middleware\AdminAuthenticate::class,
     ];
 }

--- a/app/Http/Middleware/AdminAuthenticate.php
+++ b/app/Http/Middleware/AdminAuthenticate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminAuthenticate
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->session()->get('admin_authenticated', false)) {
+            $request->session()->put('url.intended', $request->fullUrl());
+
+            return redirect()->route('login.show');
+        }
+
+        return $next($request);
+    }
+}

--- a/config/admin.php
+++ b/config/admin.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'username' => env('ADMIN_USERNAME', 'admin'),
+    'password_hash' => env('ADMIN_PASSWORD_HASH', '$2y$12$iTF0hutm35wjYhkKUqU3fuJCLR.boRWIVjnH4R4mho8OSh1QIke/.'),
+];

--- a/database/seeders/Ai/FirstConditionalFutureFormsAiSeeder.php
+++ b/database/seeders/Ai/FirstConditionalFutureFormsAiSeeder.php
@@ -1,0 +1,2785 @@
+<?php
+
+namespace Database\Seeders\Ai;
+
+use App\Models\Category;
+use App\Models\Source;
+use App\Models\Tag;
+use Database\Seeders\QuestionSeeder;
+
+class FirstConditionalFutureFormsAiSeeder extends QuestionSeeder
+{
+    public function run(): void
+    {
+        $categoryId = Category::firstOrCreate(['name' => 'Conditionals'])->id;
+        $sourceId = Source::firstOrCreate(['name' => 'Custom: First Conditional Future Forms AI'])->id;
+
+        $themeTagId = Tag::firstOrCreate(
+            ['name' => 'First Conditional Future Forms Practice'],
+            ['category' => 'English Grammar Theme']
+        )->id;
+
+        $structureTagId = Tag::firstOrCreate(
+            ['name' => 'First Conditional Sentences'],
+            ['category' => 'English Grammar Structure']
+        )->id;
+
+        $tenseTagIds = [
+            'First Conditional' => Tag::firstOrCreate(['name' => 'First Conditional'], ['category' => 'Tenses'])->id,
+            'Future Simple' => Tag::firstOrCreate(['name' => 'Future Simple'], ['category' => 'Tenses'])->id,
+            'Future Continuous' => Tag::firstOrCreate(['name' => 'Future Continuous'], ['category' => 'Tenses'])->id,
+            'Future Perfect' => Tag::firstOrCreate(['name' => 'Future Perfect'], ['category' => 'Tenses'])->id,
+            'Future Perfect Continuous' => Tag::firstOrCreate(['name' => 'Future Perfect Continuous'], ['category' => 'Tenses'])->id,
+        ];
+
+        $levelDifficulty = [
+            'A1' => 1,
+            'A2' => 2,
+            'B1' => 3,
+            'B2' => 4,
+            'C1' => 5,
+            'C2' => 5,
+        ];
+
+        $items = [];
+        $meta = [];
+
+        foreach ($this->buildQuestions() as $index => $question) {
+            $options = [];
+            $answersMap = [];
+            $verbHints = [];
+            $markerMeta = [];
+
+            foreach ($question['markers'] as $marker => $markerData) {
+                $options[$marker] = $markerData['options'];
+                $answersMap[$marker] = $this->normalizeValue($markerData['answer']);
+                $verbHints[$marker] = $this->normalizeHint($markerData['hint'] ?? null);
+                $markerMeta[$marker] = $markerData['meta'] ?? [];
+            }
+
+            $optionSets = $this->prepareOptionSets($options, $answersMap);
+            $flattenedOptions = $this->flattenOptions($optionSets);
+
+            $example = $this->buildExample($question['question'], $answersMap);
+
+            $answers = [];
+            foreach ($answersMap as $marker => $answer) {
+                $answers[] = [
+                    'marker' => $marker,
+                    'answer' => $answer,
+                    'verb_hint' => $verbHints[$marker] ?? null,
+                ];
+            }
+
+            $hints = [];
+            $explanations = [];
+            $optionMarkerMap = [];
+
+            foreach ($optionSets as $marker => $optionList) {
+                $metaInfo = $markerMeta[$marker] ?? [];
+
+                foreach ($optionList as $option) {
+                    if (! isset($optionMarkerMap[$option])) {
+                        $optionMarkerMap[$option] = $marker;
+                    }
+                }
+
+                $hints[$marker] = $this->buildHintForClause($metaInfo, $verbHints[$marker] ?? null, $example);
+                $explanations = array_merge(
+                    $explanations,
+                    $this->buildExplanationsForClause(
+                        $metaInfo,
+                        $optionList,
+                        $answersMap[$marker],
+                        $example
+                    )
+                );
+            }
+
+            $tagIds = [$themeTagId, $structureTagId];
+            foreach ($question['tense_tags'] as $tenseName) {
+                if (! isset($tenseTagIds[$tenseName])) {
+                    $tenseTagIds[$tenseName] = Tag::firstOrCreate(['name' => $tenseName], ['category' => 'Tenses'])->id;
+                }
+
+                $tagIds[] = $tenseTagIds[$tenseName];
+            }
+
+            $uuid = $this->generateQuestionUuid($index + 1, $question['question']);
+
+            $items[] = [
+                'uuid' => $uuid,
+                'question' => $question['question'],
+                'category_id' => $categoryId,
+                'difficulty' => $levelDifficulty[$question['level']] ?? 3,
+                'source_id' => $sourceId,
+                'flag' => 2,
+                'level' => $question['level'],
+                'tag_ids' => array_values(array_unique($tagIds)),
+                'answers' => $answers,
+                'options' => $flattenedOptions,
+                'variants' => [$question['question']],
+            ];
+
+            $meta[] = [
+                'uuid' => $uuid,
+                'answers' => $answersMap,
+                'option_markers' => $optionMarkerMap,
+                'hints' => $hints,
+                'explanations' => $explanations,
+            ];
+        }
+
+        $this->seedQuestionData($items, $meta);
+    }
+
+    private function buildQuestions(): array
+    {
+        $questions = [];
+
+        // A1 level — Future Simple (questions)
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will we {a2} the picnic if the weather {a1} sunny?',
+            [
+                'options' => ['is', 'will be', 'are being'],
+                'answer' => 'is',
+                'hint' => '(be)',
+            ],
+            [
+                'options' => ['have', 'has', 'having'],
+                'answer' => 'have',
+                'hint' => '(have)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will she {a2} you if the train {a1} late?',
+            [
+                'options' => ['arrives', 'will arrive', 'is arriving'],
+                'answer' => 'arrives',
+                'hint' => '(arrive)',
+            ],
+            [
+                'options' => ['call', 'calls', 'calling'],
+                'answer' => 'call',
+                'hint' => '(call)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will they {a2} a taxi if the rain {a1} heavy?',
+            [
+                'options' => ['gets', 'will get', 'is getting'],
+                'answer' => 'gets',
+                'hint' => '(get)',
+            ],
+            [
+                'options' => ['take', 'takes', 'taking'],
+                'answer' => 'take',
+                'hint' => '(take)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        // A1 level — Future Simple (negatives)
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'We {a2} the picnic if the weather {a1} rainy.',
+            [
+                'options' => ['is', 'will be', 'was'],
+                'answer' => 'is',
+                'hint' => '(be)',
+            ],
+            [
+                'options' => ["won't have", 'will have', 'are having'],
+                'answer' => "won't have",
+                'hint' => '(have)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'She {a2} you if the train {a1} late again.',
+            [
+                'options' => ['arrives', 'will arrive', 'arrived'],
+                'answer' => 'arrives',
+                'hint' => '(arrive)',
+            ],
+            [
+                'options' => ["won't call", 'will call', 'is calling'],
+                'answer' => "won't call",
+                'hint' => '(call)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'They {a2} a taxi if the rain {a1} light showers.',
+            [
+                'options' => ['brings', 'will bring', 'is bringing'],
+                'answer' => 'brings',
+                'hint' => '(bring)',
+            ],
+            [
+                'options' => ["won't take", 'will take', 'are taking'],
+                'answer' => "won't take",
+                'hint' => '(take)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        // A1 level — Future Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will you be {a2} outside if the sun {a1} warm?',
+            [
+                'options' => ['is', 'will be', 'was'],
+                'answer' => 'is',
+                'hint' => '(be)',
+            ],
+            [
+                'options' => ['playing', 'play', 'played'],
+                'answer' => 'playing',
+                'hint' => '(play)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will the kids be {a2} in the yard if the rain {a1}?',
+            [
+                'options' => ['stops', 'will stop', 'is stopping'],
+                'answer' => 'stops',
+                'hint' => '(stop)',
+            ],
+            [
+                'options' => ['running', 'run', 'ran'],
+                'answer' => 'running',
+                'hint' => '(run)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will Anna be {a2} dinner if the guests {a1} early?',
+            [
+                'options' => ['arrive', 'will arrive', 'are arriving'],
+                'answer' => 'arrive',
+                'hint' => '(arrive)',
+            ],
+            [
+                'options' => ['cooking', 'cook', 'cooked'],
+                'answer' => 'cooking',
+                'hint' => '(cook)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        // A1 level — Future Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'You {a2} outside if the sun {a1} too hot.',
+            [
+                'options' => ['gets', 'will get', 'is getting'],
+                'answer' => 'gets',
+                'hint' => '(get)',
+            ],
+            [
+                'options' => ["won't be playing", "won't play", "aren't playing"],
+                'answer' => "won't be playing",
+                'hint' => '(play)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'The kids {a2} in the yard if the rain {a1} again.',
+            [
+                'options' => ['starts', 'will start', 'started'],
+                'answer' => 'starts',
+                'hint' => '(start)',
+            ],
+            [
+                'options' => ["won't be running", "won't run", "aren't running"],
+                'answer' => "won't be running",
+                'hint' => '(run)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Anna {a2} dinner if the guests {a1} late.',
+            [
+                'options' => ['come', 'will come', 'are coming'],
+                'answer' => 'come',
+                'hint' => '(come)',
+            ],
+            [
+                'options' => ["won't be cooking", "won't cook", "isn't cooking"],
+                'answer' => "won't be cooking",
+                'hint' => '(cook)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        // A1 level — Future Perfect (questions)
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will she have {a2} her homework if the class {a1} early?',
+            [
+                'options' => ['ends', 'will end', 'is ending'],
+                'answer' => 'ends',
+                'hint' => '(end)',
+            ],
+            [
+                'options' => ['finished', 'finish', 'finishing'],
+                'answer' => 'finished',
+                'hint' => '(finish)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will they have {a2} the room if the teacher {a1} the bell?',
+            [
+                'options' => ['rings', 'will ring', 'is ringing'],
+                'answer' => 'rings',
+                'hint' => '(ring)',
+            ],
+            [
+                'options' => ['cleaned', 'clean', 'cleaning'],
+                'answer' => 'cleaned',
+                'hint' => '(clean)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will we have {a2} the bags if the bus {a1} on time?',
+            [
+                'options' => ['arrives', 'will arrive', 'arrived'],
+                'answer' => 'arrives',
+                'hint' => '(arrive)',
+            ],
+            [
+                'options' => ['packed', 'pack', 'packing'],
+                'answer' => 'packed',
+                'hint' => '(pack)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        // A1 level — Future Perfect (negatives)
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'She {a2} her homework if the class {a1} late.',
+            [
+                'options' => ['runs', 'will run', 'is running'],
+                'answer' => 'runs',
+                'hint' => '(run)',
+            ],
+            [
+                'options' => ["won't have finished", 'will have finished', 'is finishing'],
+                'answer' => "won't have finished",
+                'hint' => '(finish)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'They {a2} the room if the teacher {a1} early.',
+            [
+                'options' => ['leaves', 'will leave', 'left'],
+                'answer' => 'leaves',
+                'hint' => '(leave)',
+            ],
+            [
+                'options' => ["won't have cleaned", 'will have cleaned', 'are cleaning'],
+                'answer' => "won't have cleaned",
+                'hint' => '(clean)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'We {a2} the bags if the bus {a1} soon.',
+            [
+                'options' => ['comes', 'will come', 'is coming'],
+                'answer' => 'comes',
+                'hint' => '(come)',
+            ],
+            [
+                'options' => ["won't have packed", 'will have packed', 'are packing'],
+                'answer' => "won't have packed",
+                'hint' => '(pack)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        // A1 level — Future Perfect Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will they have been {a2} long if the bus {a1} late?',
+            [
+                'options' => ['arrives', 'will arrive', 'arrived'],
+                'answer' => 'arrives',
+                'hint' => '(arrive)',
+            ],
+            [
+                'options' => ['waiting', 'wait', 'waited'],
+                'answer' => 'waiting',
+                'hint' => '(wait)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will she have been {a2} for hours if the store {a1} late?',
+            [
+                'options' => ['opens', 'will open', 'opening'],
+                'answer' => 'opens',
+                'hint' => '(open)',
+            ],
+            [
+                'options' => ['waiting', 'wait', 'waited'],
+                'answer' => 'waiting',
+                'hint' => '(wait)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'Will we have been {a2} long if the teacher {a1} after lunch?',
+            [
+                'options' => ['returns', 'will return', 'returned'],
+                'answer' => 'returns',
+                'hint' => '(return)',
+            ],
+            [
+                'options' => ['studying', 'study', 'studied'],
+                'answer' => 'studying',
+                'hint' => '(study)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // A1 level — Future Perfect Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'They {a2} long if the bus {a1} on time.',
+            [
+                'options' => ['arrives', 'will arrive', 'arrived'],
+                'answer' => 'arrives',
+                'hint' => '(arrive)',
+            ],
+            [
+                'options' => ["won't have been waiting", 'will have been waiting', 'are waiting'],
+                'answer' => "won't have been waiting",
+                'hint' => '(wait)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'She {a2} for hours if the store {a1} early.',
+            [
+                'options' => ['opens', 'will open', 'opened'],
+                'answer' => 'opens',
+                'hint' => '(open)',
+            ],
+            [
+                'options' => ["won't have been standing", 'will have been standing', 'is standing'],
+                'answer' => "won't have been standing",
+                'hint' => '(stand)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A1',
+            'We {a2} long if the teacher {a1} before noon.',
+            [
+                'options' => ['comes', 'will come', 'coming'],
+                'answer' => 'comes',
+                'hint' => '(come)',
+            ],
+            [
+                'options' => ["won't have been studying", 'will have been studying', 'are studying'],
+                'answer' => "won't have been studying",
+                'hint' => '(study)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // A2 level — Future Simple (questions)
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will the team {a2} the report if the manager {a1} feedback?',
+            [
+                'options' => ['gives', 'will give', 'is giving'],
+                'answer' => 'gives',
+                'hint' => '(give)',
+            ],
+            [
+                'options' => ['submit', 'submits', 'submitting'],
+                'answer' => 'submit',
+                'hint' => '(submit)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will you {a2} the client if the office {a1} open early?',
+            [
+                'options' => ['opens', 'will open', 'opening'],
+                'answer' => 'opens',
+                'hint' => '(open)',
+            ],
+            [
+                'options' => ['call', 'calls', 'calling'],
+                'answer' => 'call',
+                'hint' => '(call)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will the students {a2} the trip if the school {a1} buses?',
+            [
+                'options' => ['provides', 'will provide', 'is providing'],
+                'answer' => 'provides',
+                'hint' => '(provide)',
+            ],
+            [
+                'options' => ['take', 'takes', 'taking'],
+                'answer' => 'take',
+                'hint' => '(take)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        // A2 level — Future Simple (negatives)
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'The team {a2} the report if the manager {a1} late feedback.',
+            [
+                'options' => ['gives', 'will give', 'gave'],
+                'answer' => 'gives',
+                'hint' => '(give)',
+            ],
+            [
+                'options' => ["won't submit", 'will submit', 'is submitting'],
+                'answer' => "won't submit",
+                'hint' => '(submit)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'You {a2} the client if the office {a1} closed.',
+            [
+                'options' => ['stays', 'will stay', 'is staying'],
+                'answer' => 'stays',
+                'hint' => '(stay)',
+            ],
+            [
+                'options' => ["won't call", 'will call', 'are calling'],
+                'answer' => "won't call",
+                'hint' => '(call)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'The students {a2} the trip if the school {a1} buses.',
+            [
+                'options' => ['cancels', 'will cancel', 'is cancelling'],
+                'answer' => 'cancels',
+                'hint' => '(cancel)',
+            ],
+            [
+                'options' => ["won't take", 'will take', 'are taking'],
+                'answer' => "won't take",
+                'hint' => '(take)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        // A2 level — Future Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will the designers be {a2} if the client {a1} new sketches?',
+            [
+                'options' => ['sends', 'will send', 'is sending'],
+                'answer' => 'sends',
+                'hint' => '(send)',
+            ],
+            [
+                'options' => ['working', 'work', 'worked'],
+                'answer' => 'working',
+                'hint' => '(work)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will you be {a2} notes if the lecturer {a1} slowly?',
+            [
+                'options' => ['speaks', 'will speak', 'is speaking'],
+                'answer' => 'speaks',
+                'hint' => '(speak)',
+            ],
+            [
+                'options' => ['taking', 'take', 'took'],
+                'answer' => 'taking',
+                'hint' => '(take)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will the volunteers be {a2} if the storm {a1} early?',
+            [
+                'options' => ['clears', 'will clear', 'is clearing'],
+                'answer' => 'clears',
+                'hint' => '(clear)',
+            ],
+            [
+                'options' => ['setting up', 'set up', 'setted up'],
+                'answer' => 'setting up',
+                'hint' => '(set up)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        // A2 level — Future Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'The designers {a2} if the client {a1} late updates.',
+            [
+                'options' => ['sends', 'will send', 'sent'],
+                'answer' => 'sends',
+                'hint' => '(send)',
+            ],
+            [
+                'options' => ["won't be working", "won't work", "aren't working"],
+                'answer' => "won't be working",
+                'hint' => '(work)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'You {a2} notes if the lecturer {a1} too fast.',
+            [
+                'options' => ['speaks', 'will speak', 'spoke'],
+                'answer' => 'speaks',
+                'hint' => '(speak)',
+            ],
+            [
+                'options' => ["won't be taking", "won't take", "aren't taking"],
+                'answer' => "won't be taking",
+                'hint' => '(take)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'The volunteers {a2} if the storm {a1} all morning.',
+            [
+                'options' => ['lasts', 'will last', 'lasting'],
+                'answer' => 'lasts',
+                'hint' => '(last)',
+            ],
+            [
+                'options' => ["won't be setting up", "won't set up", "aren't setting up"],
+                'answer' => "won't be setting up",
+                'hint' => '(set up)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        // A2 level — Future Perfect (questions)
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will the editor have {a2} the article if the writer {a1} on time?',
+            [
+                'options' => ['hands', 'will hand', 'handed'],
+                'answer' => 'hands',
+                'hint' => '(hand in)',
+            ],
+            [
+                'options' => ['finished', 'finish', 'finishing'],
+                'answer' => 'finished',
+                'hint' => '(finish)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will you have {a2} the slides if the meeting {a1} early?',
+            [
+                'options' => ['starts', 'will start', 'starting'],
+                'answer' => 'starts',
+                'hint' => '(start)',
+            ],
+            [
+                'options' => ['prepared', 'prepare', 'preparing'],
+                'answer' => 'prepared',
+                'hint' => '(prepare)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will the cooks have {a2} the meals if the market {a1} fresh food?',
+            [
+                'options' => ['brings', 'will bring', 'bringing'],
+                'answer' => 'brings',
+                'hint' => '(bring)',
+            ],
+            [
+                'options' => ['prepared', 'prepare', 'preparing'],
+                'answer' => 'prepared',
+                'hint' => '(prepare)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        // A2 level — Future Perfect (negatives)
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'The editor {a2} the article if the writer {a1} late.',
+            [
+                'options' => ['hands', 'will hand', 'handed'],
+                'answer' => 'hands',
+                'hint' => '(hand in)',
+            ],
+            [
+                'options' => ["won't have finished", 'will have finished', 'is finishing'],
+                'answer' => "won't have finished",
+                'hint' => '(finish)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'You {a2} the slides if the meeting {a1} late.',
+            [
+                'options' => ['starts', 'will start', 'started'],
+                'answer' => 'starts',
+                'hint' => '(start)',
+            ],
+            [
+                'options' => ["won't have prepared", 'will have prepared', 'are preparing'],
+                'answer' => "won't have prepared",
+                'hint' => '(prepare)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'The cooks {a2} the meals if the market {a1} supplies.',
+            [
+                'options' => ['delays', 'will delay', 'delayed'],
+                'answer' => 'delays',
+                'hint' => '(delay)',
+            ],
+            [
+                'options' => ["won't have prepared", 'will have prepared', 'are preparing'],
+                'answer' => "won't have prepared",
+                'hint' => '(prepare)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        // A2 level — Future Perfect Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will the trainees have been {a2} long if the coach {a1} late?',
+            [
+                'options' => ['arrives', 'will arrive', 'arrived'],
+                'answer' => 'arrives',
+                'hint' => '(arrive)',
+            ],
+            [
+                'options' => ['waiting', 'wait', 'waited'],
+                'answer' => 'waiting',
+                'hint' => '(wait)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will you have been {a2} long if the bus {a1} late?',
+            [
+                'options' => ['comes', 'will come', 'coming'],
+                'answer' => 'comes',
+                'hint' => '(come)',
+            ],
+            [
+                'options' => ['standing', 'stand', 'stood'],
+                'answer' => 'standing',
+                'hint' => '(stand)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'Will the researchers have been {a2} if the lab {a1} early samples?',
+            [
+                'options' => ['delivers', 'will deliver', 'delivered'],
+                'answer' => 'delivers',
+                'hint' => '(deliver)',
+            ],
+            [
+                'options' => ['testing', 'test', 'tested'],
+                'answer' => 'testing',
+                'hint' => '(test)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // A2 level — Future Perfect Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'The trainees {a2} long if the coach {a1} on time.',
+            [
+                'options' => ['arrives', 'will arrive', 'arrived'],
+                'answer' => 'arrives',
+                'hint' => '(arrive)',
+            ],
+            [
+                'options' => ["won't have been waiting", 'will have been waiting', 'are waiting'],
+                'answer' => "won't have been waiting",
+                'hint' => '(wait)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'You {a2} long if the bus {a1} quickly.',
+            [
+                'options' => ['comes', 'will come', 'coming'],
+                'answer' => 'comes',
+                'hint' => '(come)',
+            ],
+            [
+                'options' => ["won't have been standing", 'will have been standing', 'are standing'],
+                'answer' => "won't have been standing",
+                'hint' => '(stand)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'A2',
+            'The researchers {a2} if the lab {a1} quickly.',
+            [
+                'options' => ['delivers', 'will deliver', 'delivered'],
+                'answer' => 'delivers',
+                'hint' => '(deliver)',
+            ],
+            [
+                'options' => ["won't have been testing", 'will have been testing', 'are testing'],
+                'answer' => "won't have been testing",
+                'hint' => '(test)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // B1 level — Future Simple (questions)
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will the analysts {a2} a summary if the director {a1} fresh instructions?',
+            [
+                'options' => ['sends', 'will send', 'is sending'],
+                'answer' => 'sends',
+                'hint' => '(send)',
+            ],
+            [
+                'options' => ['prepare', 'prepares', 'preparing'],
+                'answer' => 'prepare',
+                'hint' => '(prepare)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will the committee {a2} a vote if the agenda {a1} ready on time?',
+            [
+                'options' => ['is', 'will be', 'being'],
+                'answer' => 'is',
+                'hint' => '(be)',
+            ],
+            [
+                'options' => ['hold', 'holds', 'holding'],
+                'answer' => 'hold',
+                'hint' => '(hold)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will you {a2} the budget if the finance team {a1} approval?',
+            [
+                'options' => ['grants', 'will grant', 'is granting'],
+                'answer' => 'grants',
+                'hint' => '(grant)',
+            ],
+            [
+                'options' => ['revise', 'revises', 'revising'],
+                'answer' => 'revise',
+                'hint' => '(revise)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        // B1 level — Future Simple (negatives)
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'The analysts {a2} a summary if the director {a1} unclear notes.',
+            [
+                'options' => ['sends', 'will send', 'sent'],
+                'answer' => 'sends',
+                'hint' => '(send)',
+            ],
+            [
+                'options' => ["won't prepare", 'will prepare', 'are preparing'],
+                'answer' => "won't prepare",
+                'hint' => '(prepare)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'The committee {a2} a vote if the agenda {a1} incomplete.',
+            [
+                'options' => ['is', 'will be', 'was'],
+                'answer' => 'is',
+                'hint' => '(be)',
+            ],
+            [
+                'options' => ["won't hold", 'will hold', 'is holding'],
+                'answer' => "won't hold",
+                'hint' => '(hold)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'You {a2} the budget if the finance team {a1} permission.',
+            [
+                'options' => ['withholds', 'will withhold', 'withheld'],
+                'answer' => 'withholds',
+                'hint' => '(withhold)',
+            ],
+            [
+                'options' => ["won't revise", 'will revise', 'are revising'],
+                'answer' => "won't revise",
+                'hint' => '(revise)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        // B1 level — Future Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will the engineers be {a2} if the supplier {a1} the prototype?',
+            [
+                'options' => ['delivers', 'will deliver', 'is delivering'],
+                'answer' => 'delivers',
+                'hint' => '(deliver)',
+            ],
+            [
+                'options' => ['testing', 'test', 'tested'],
+                'answer' => 'testing',
+                'hint' => '(test)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will the consultants be {a2} if the client {a1} extra sessions?',
+            [
+                'options' => ['requests', 'will request', 'requested'],
+                'answer' => 'requests',
+                'hint' => '(request)',
+            ],
+            [
+                'options' => ['presenting', 'present', 'presented'],
+                'answer' => 'presenting',
+                'hint' => '(present)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will you be {a2} the database if the system {a1} stable?',
+            [
+                'options' => ['stays', 'will stay', 'is staying'],
+                'answer' => 'stays',
+                'hint' => '(stay)',
+            ],
+            [
+                'options' => ['updating', 'update', 'updated'],
+                'answer' => 'updating',
+                'hint' => '(update)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        // B1 level — Future Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'The engineers {a2} if the supplier {a1} delays.',
+            [
+                'options' => ['causes', 'will cause', 'caused'],
+                'answer' => 'causes',
+                'hint' => '(cause)',
+            ],
+            [
+                'options' => ["won't be testing", "won't test", "aren't testing"],
+                'answer' => "won't be testing",
+                'hint' => '(test)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'The consultants {a2} if the client {a1} the extra sessions.',
+            [
+                'options' => ['cancels', 'will cancel', 'cancelled'],
+                'answer' => 'cancels',
+                'hint' => '(cancel)',
+            ],
+            [
+                'options' => ["won't be presenting", "won't present", "aren't presenting"],
+                'answer' => "won't be presenting",
+                'hint' => '(present)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'You {a2} the database if the system {a1} errors.',
+            [
+                'options' => ['shows', 'will show', 'showed'],
+                'answer' => 'shows',
+                'hint' => '(show)',
+            ],
+            [
+                'options' => ["won't be updating", "won't update", "aren't updating"],
+                'answer' => "won't be updating",
+                'hint' => '(update)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        // B1 level — Future Perfect (questions)
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will the researchers have {a2} the data if the samples {a1} early?',
+            [
+                'options' => ['arrive', 'will arrive', 'arriving'],
+                'answer' => 'arrive',
+                'hint' => '(arrive)',
+            ],
+            [
+                'options' => ['analysed', 'analyse', 'analysing'],
+                'answer' => 'analysed',
+                'hint' => '(analyse)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will the authors have {a2} the draft if the editor {a1} suggestions?',
+            [
+                'options' => ['sends', 'will send', 'is sending'],
+                'answer' => 'sends',
+                'hint' => '(send)',
+            ],
+            [
+                'options' => ['revised', 'revise', 'revising'],
+                'answer' => 'revised',
+                'hint' => '(revise)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will you have {a2} the keynote if the conference {a1} funding?',
+            [
+                'options' => ['secures', 'will secure', 'secured'],
+                'answer' => 'secures',
+                'hint' => '(secure)',
+            ],
+            [
+                'options' => ['prepared', 'prepare', 'preparing'],
+                'answer' => 'prepared',
+                'hint' => '(prepare)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        // B1 level — Future Perfect (negatives)
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'The researchers {a2} the data if the samples {a1} late.',
+            [
+                'options' => ['arrive', 'will arrive', 'arrived'],
+                'answer' => 'arrive',
+                'hint' => '(arrive)',
+            ],
+            [
+                'options' => ["won't have analysed", 'will have analysed', 'are analysing'],
+                'answer' => "won't have analysed",
+                'hint' => '(analyse)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'The authors {a2} the draft if the editor {a1} slowly.',
+            [
+                'options' => ['responds', 'will respond', 'responded'],
+                'answer' => 'responds',
+                'hint' => '(respond)',
+            ],
+            [
+                'options' => ["won't have revised", 'will have revised', 'are revising'],
+                'answer' => "won't have revised",
+                'hint' => '(revise)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'You {a2} the keynote if the conference {a1} support.',
+            [
+                'options' => ['loses', 'will lose', 'lost'],
+                'answer' => 'loses',
+                'hint' => '(lose)',
+            ],
+            [
+                'options' => ["won't have prepared", 'will have prepared', 'are preparing'],
+                'answer' => "won't have prepared",
+                'hint' => '(prepare)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        // B1 level — Future Perfect Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will the analysts have been {a2} the metrics if the system {a1} longer hours?',
+            [
+                'options' => ['runs', 'will run', 'running'],
+                'answer' => 'runs',
+                'hint' => '(run)',
+            ],
+            [
+                'options' => ['tracking', 'track', 'tracked'],
+                'answer' => 'tracking',
+                'hint' => '(track)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will the interns have been {a2} new code if the mentor {a1} extra tasks?',
+            [
+                'options' => ['assigns', 'will assign', 'assigned'],
+                'answer' => 'assigns',
+                'hint' => '(assign)',
+            ],
+            [
+                'options' => ['writing', 'write', 'wrote'],
+                'answer' => 'writing',
+                'hint' => '(write)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'Will you have been {a2} clients if the company {a1} new leads?',
+            [
+                'options' => ['sends', 'will send', 'sent'],
+                'answer' => 'sends',
+                'hint' => '(send)',
+            ],
+            [
+                'options' => ['calling', 'call', 'called'],
+                'answer' => 'calling',
+                'hint' => '(call)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // B1 level — Future Perfect Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'The analysts {a2} the metrics if the system {a1} downtime.',
+            [
+                'options' => ['faces', 'will face', 'faced'],
+                'answer' => 'faces',
+                'hint' => '(face)',
+            ],
+            [
+                'options' => ["won't have been tracking", 'will have been tracking', 'are tracking'],
+                'answer' => "won't have been tracking",
+                'hint' => '(track)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'The interns {a2} new code if the mentor {a1} extra tasks.',
+            [
+                'options' => ['ignores', 'will ignore', 'ignored'],
+                'answer' => 'ignores',
+                'hint' => '(ignore)',
+            ],
+            [
+                'options' => ["won't have been writing", 'will have been writing', 'are writing'],
+                'answer' => "won't have been writing",
+                'hint' => '(write)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B1',
+            'You {a2} clients if the company {a1} new leads.',
+            [
+                'options' => ['stops', 'will stop', 'stopped'],
+                'answer' => 'stops',
+                'hint' => '(stop)',
+            ],
+            [
+                'options' => ["won't have been calling", 'will have been calling', 'are calling'],
+                'answer' => "won't have been calling",
+                'hint' => '(call)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // B2 level — Future Simple (questions)
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will the board {a2} the merger if the regulators {a1} approval?',
+            [
+                'options' => ['grant', 'will grant', 'granting'],
+                'answer' => 'grant',
+                'hint' => '(grant)',
+            ],
+            [
+                'options' => ['approve', 'approves', 'approving'],
+                'answer' => 'approve',
+                'hint' => '(approve)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will the lead scientist {a2} publication if the peer review {a1} supportive?',
+            [
+                'options' => ['remains', 'will remain', 'remaining'],
+                'answer' => 'remains',
+                'hint' => '(remain)',
+            ],
+            [
+                'options' => ['pursue', 'pursues', 'pursuing'],
+                'answer' => 'pursue',
+                'hint' => '(pursue)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will you {a2} the expansion if investors {a1} capital?',
+            [
+                'options' => ['release', 'will release', 'releasing'],
+                'answer' => 'release',
+                'hint' => '(release)',
+            ],
+            [
+                'options' => ['initiate', 'initiates', 'initiating'],
+                'answer' => 'initiate',
+                'hint' => '(initiate)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        // B2 level — Future Simple (negatives)
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'The board {a2} the merger if the regulators {a1} objections.',
+            [
+                'options' => ['raise', 'will raise', 'raising'],
+                'answer' => 'raise',
+                'hint' => '(raise)',
+            ],
+            [
+                'options' => ["won't approve", 'will approve', 'are approving'],
+                'answer' => "won't approve",
+                'hint' => '(approve)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'The lead scientist {a2} publication if the peer review {a1} hostile.',
+            [
+                'options' => ['turns', 'will turn', 'turned'],
+                'answer' => 'turns',
+                'hint' => '(turn)',
+            ],
+            [
+                'options' => ["won't pursue", 'will pursue', 'is pursuing'],
+                'answer' => "won't pursue",
+                'hint' => '(pursue)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'You {a2} the expansion if investors {a1} hesitant.',
+            [
+                'options' => ['grow', 'will grow', 'grew'],
+                'answer' => 'grow',
+                'hint' => '(grow)',
+            ],
+            [
+                'options' => ["won't initiate", 'will initiate', 'are initiating'],
+                'answer' => "won't initiate",
+                'hint' => '(initiate)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        // B2 level — Future Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will the auditors be {a2} the accounts if the firm {a1} detailed records?',
+            [
+                'options' => ['provides', 'will provide', 'provided'],
+                'answer' => 'provides',
+                'hint' => '(provide)',
+            ],
+            [
+                'options' => ['reviewing', 'review', 'reviewed'],
+                'answer' => 'reviewing',
+                'hint' => '(review)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will the negotiators be {a2} proposals if the council {a1} new demands?',
+            [
+                'options' => ['issues', 'will issue', 'issued'],
+                'answer' => 'issues',
+                'hint' => '(issue)',
+            ],
+            [
+                'options' => ['drafting', 'draft', 'drafted'],
+                'answer' => 'drafting',
+                'hint' => '(draft)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will you be {a2} the keynote if the sponsor {a1} final confirmation?',
+            [
+                'options' => ['delivers', 'will deliver', 'delivered'],
+                'answer' => 'delivers',
+                'hint' => '(deliver)',
+            ],
+            [
+                'options' => ['rehearsing', 'rehearse', 'rehearsed'],
+                'answer' => 'rehearsing',
+                'hint' => '(rehearse)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        // B2 level — Future Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'The auditors {a2} the accounts if the firm {a1} disorganised files.',
+            [
+                'options' => ['keeps', 'will keep', 'kept'],
+                'answer' => 'keeps',
+                'hint' => '(keep)',
+            ],
+            [
+                'options' => ["won't be reviewing", "won't review", "aren't reviewing"],
+                'answer' => "won't be reviewing",
+                'hint' => '(review)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'The negotiators {a2} proposals if the council {a1} talks.',
+            [
+                'options' => ['suspends', 'will suspend', 'suspended'],
+                'answer' => 'suspends',
+                'hint' => '(suspend)',
+            ],
+            [
+                'options' => ["won't be drafting", "won't draft", "aren't drafting"],
+                'answer' => "won't be drafting",
+                'hint' => '(draft)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'You {a2} the keynote if the sponsor {a1} support.',
+            [
+                'options' => ['withdraws', 'will withdraw', 'withdrew'],
+                'answer' => 'withdraws',
+                'hint' => '(withdraw)',
+            ],
+            [
+                'options' => ["won't be rehearsing", "won't rehearse", "aren't rehearsing"],
+                'answer' => "won't be rehearsing",
+                'hint' => '(rehearse)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        // B2 level — Future Perfect (questions)
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will the development team have {a2} the release if the testers {a1} approval?',
+            [
+                'options' => ['grant', 'will grant', 'granted'],
+                'answer' => 'grant',
+                'hint' => '(grant)',
+            ],
+            [
+                'options' => ['finalised', 'finalise', 'finalising'],
+                'answer' => 'finalised',
+                'hint' => '(finalise)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will the scholars have {a2} their findings if the archive {a1} access?',
+            [
+                'options' => ['permits', 'will permit', 'permitted'],
+                'answer' => 'permits',
+                'hint' => '(permit)',
+            ],
+            [
+                'options' => ['published', 'publish', 'publishing'],
+                'answer' => 'published',
+                'hint' => '(publish)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will you have {a2} the audit if the software {a1} stable builds?',
+            [
+                'options' => ['produces', 'will produce', 'produced'],
+                'answer' => 'produces',
+                'hint' => '(produce)',
+            ],
+            [
+                'options' => ['completed', 'complete', 'completing'],
+                'answer' => 'completed',
+                'hint' => '(complete)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        // B2 level — Future Perfect (negatives)
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'The development team {a2} the release if the testers {a1} blocking bugs.',
+            [
+                'options' => ['report', 'will report', 'reported'],
+                'answer' => 'report',
+                'hint' => '(report)',
+            ],
+            [
+                'options' => ["won't have finalised", 'will have finalised', 'are finalising'],
+                'answer' => "won't have finalised",
+                'hint' => '(finalise)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'The scholars {a2} their findings if the archive {a1} restricted.',
+            [
+                'options' => ['stays', 'will stay', 'stayed'],
+                'answer' => 'stays',
+                'hint' => '(stay)',
+            ],
+            [
+                'options' => ["won't have published", 'will have published', 'are publishing'],
+                'answer' => "won't have published",
+                'hint' => '(publish)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'You {a2} the audit if the software {a1} unstable.',
+            [
+                'options' => ['remains', 'will remain', 'remained'],
+                'answer' => 'remains',
+                'hint' => '(remain)',
+            ],
+            [
+                'options' => ["won't have completed", 'will have completed', 'are completing'],
+                'answer' => "won't have completed",
+                'hint' => '(complete)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        // B2 level — Future Perfect Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will the analysts have been {a2} volatility if the market {a1} sharp swings?',
+            [
+                'options' => ['shows', 'will show', 'showed'],
+                'answer' => 'shows',
+                'hint' => '(show)',
+            ],
+            [
+                'options' => ['monitoring', 'monitor', 'monitored'],
+                'answer' => 'monitoring',
+                'hint' => '(monitor)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will the medical team have been {a2} the patients if the ward {a1} extra staff?',
+            [
+                'options' => ['assigns', 'will assign', 'assigned'],
+                'answer' => 'assigns',
+                'hint' => '(assign)',
+            ],
+            [
+                'options' => ['monitoring', 'monitor', 'monitored'],
+                'answer' => 'monitoring',
+                'hint' => '(monitor)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'Will you have been {a2} new partners if the accelerator {a1} introductions?',
+            [
+                'options' => ['arranges', 'will arrange', 'arranged'],
+                'answer' => 'arranges',
+                'hint' => '(arrange)',
+            ],
+            [
+                'options' => ['cultivating', 'cultivate', 'cultivated'],
+                'answer' => 'cultivating',
+                'hint' => '(cultivate)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // B2 level — Future Perfect Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'The analysts {a2} volatility if the market {a1} calm.',
+            [
+                'options' => ['stays', 'will stay', 'stayed'],
+                'answer' => 'stays',
+                'hint' => '(stay)',
+            ],
+            [
+                'options' => ["won't have been monitoring", 'will have been monitoring', 'are monitoring'],
+                'answer' => "won't have been monitoring",
+                'hint' => '(monitor)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'The medical team {a2} the patients if the ward {a1} fewer staff.',
+            [
+                'options' => ['loses', 'will lose', 'lost'],
+                'answer' => 'loses',
+                'hint' => '(lose)',
+            ],
+            [
+                'options' => ["won't have been monitoring", 'will have been monitoring', 'are monitoring'],
+                'answer' => "won't have been monitoring",
+                'hint' => '(monitor)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'B2',
+            'You {a2} new partners if the accelerator {a1} introductions.',
+            [
+                'options' => ['halts', 'will halt', 'halted'],
+                'answer' => 'halts',
+                'hint' => '(halt)',
+            ],
+            [
+                'options' => ["won't have been cultivating", 'will have been cultivating', 'are cultivating'],
+                'answer' => "won't have been cultivating",
+                'hint' => '(cultivate)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // C1 level — Future Simple (questions)
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will the policy committee {a2} reforms if the audit {a1} systemic gaps?',
+            [
+                'options' => ['identifies', 'will identify', 'identifying'],
+                'answer' => 'identifies',
+                'hint' => '(identify)',
+            ],
+            [
+                'options' => ['enact', 'enacts', 'enacting'],
+                'answer' => 'enact',
+                'hint' => '(enact)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will the principal investigator {a2} the grant if the foundation {a1} revised metrics?',
+            [
+                'options' => ['introduces', 'will introduce', 'introduced'],
+                'answer' => 'introduces',
+                'hint' => '(introduce)',
+            ],
+            [
+                'options' => ['accept', 'accepts', 'accepting'],
+                'answer' => 'accept',
+                'hint' => '(accept)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will you {a2} the acquisition if the market {a1} favourable shifts?',
+            [
+                'options' => ['shows', 'will show', 'showed'],
+                'answer' => 'shows',
+                'hint' => '(show)',
+            ],
+            [
+                'options' => ['pursue', 'pursues', 'pursuing'],
+                'answer' => 'pursue',
+                'hint' => '(pursue)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        // C1 level — Future Simple (negatives)
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'The policy committee {a2} reforms if the audit {a1} superficial issues.',
+            [
+                'options' => ['reveals', 'will reveal', 'revealed'],
+                'answer' => 'reveals',
+                'hint' => '(reveal)',
+            ],
+            [
+                'options' => ["won't enact", 'will enact', 'is enacting'],
+                'answer' => "won't enact",
+                'hint' => '(enact)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'The principal investigator {a2} the grant if the foundation {a1} prohibitive metrics.',
+            [
+                'options' => ['imposes', 'will impose', 'imposed'],
+                'answer' => 'imposes',
+                'hint' => '(impose)',
+            ],
+            [
+                'options' => ["won't accept", 'will accept', 'is accepting'],
+                'answer' => "won't accept",
+                'hint' => '(accept)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'You {a2} the acquisition if the market {a1} volatile signals.',
+            [
+                'options' => ['sends', 'will send', 'sent'],
+                'answer' => 'sends',
+                'hint' => '(send)',
+            ],
+            [
+                'options' => ["won't pursue", 'will pursue', 'are pursuing'],
+                'answer' => "won't pursue",
+                'hint' => '(pursue)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        // C1 level — Future Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will the auditors be {a2} compliance if the ministry {a1} urgent directives?',
+            [
+                'options' => ['issues', 'will issue', 'issued'],
+                'answer' => 'issues',
+                'hint' => '(issue)',
+            ],
+            [
+                'options' => ['scrutinising', 'scrutinise', 'scrutinised'],
+                'answer' => 'scrutinising',
+                'hint' => '(scrutinise)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will the legal team be {a2} amendments if parliament {a1} counterproposals?',
+            [
+                'options' => ['submits', 'will submit', 'submitted'],
+                'answer' => 'submits',
+                'hint' => '(submit)',
+            ],
+            [
+                'options' => ['drafting', 'draft', 'drafted'],
+                'answer' => 'drafting',
+                'hint' => '(draft)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will you be {a2} stakeholder briefings if the regulator {a1} revised guidance?',
+            [
+                'options' => ['publishes', 'will publish', 'published'],
+                'answer' => 'publishes',
+                'hint' => '(publish)',
+            ],
+            [
+                'options' => ['delivering', 'deliver', 'delivered'],
+                'answer' => 'delivering',
+                'hint' => '(deliver)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        // C1 level — Future Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'The auditors {a2} compliance if the ministry {a1} silent.',
+            [
+                'options' => ['remains', 'will remain', 'remained'],
+                'answer' => 'remains',
+                'hint' => '(remain)',
+            ],
+            [
+                'options' => ["won't be scrutinising", "won't scrutinise", "aren't scrutinising"],
+                'answer' => "won't be scrutinising",
+                'hint' => '(scrutinise)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'The legal team {a2} amendments if parliament {a1} the bill.',
+            [
+                'options' => ['withdraws', 'will withdraw', 'withdrew'],
+                'answer' => 'withdraws',
+                'hint' => '(withdraw)',
+            ],
+            [
+                'options' => ["won't be drafting", "won't draft", "aren't drafting"],
+                'answer' => "won't be drafting",
+                'hint' => '(draft)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'You {a2} stakeholder briefings if the regulator {a1} delays guidance.',
+            [
+                'options' => ['delays', 'will delay', 'delayed'],
+                'answer' => 'delays',
+                'hint' => '(delay)',
+            ],
+            [
+                'options' => ["won't be delivering", "won't deliver", "aren't delivering"],
+                'answer' => "won't be delivering",
+                'hint' => '(deliver)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        // C1 level — Future Perfect (questions)
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will the commission have {a2} the report if the inquiry {a1} classified files?',
+            [
+                'options' => ['unlocks', 'will unlock', 'unlocked'],
+                'answer' => 'unlocks',
+                'hint' => '(unlock)',
+            ],
+            [
+                'options' => ['compiled', 'compile', 'compiling'],
+                'answer' => 'compiled',
+                'hint' => '(compile)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will the consortium have {a2} agreements if the mediator {a1} consensus?',
+            [
+                'options' => ['builds', 'will build', 'built'],
+                'answer' => 'builds',
+                'hint' => '(build)',
+            ],
+            [
+                'options' => ['ratified', 'ratify', 'ratifying'],
+                'answer' => 'ratified',
+                'hint' => '(ratify)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will you have {a2} the strategic brief if the board {a1} final mandates?',
+            [
+                'options' => ['issues', 'will issue', 'issued'],
+                'answer' => 'issues',
+                'hint' => '(issue)',
+            ],
+            [
+                'options' => ['completed', 'complete', 'completing'],
+                'answer' => 'completed',
+                'hint' => '(complete)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        // C1 level — Future Perfect (negatives)
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'The commission {a2} the report if the inquiry {a1} the files.',
+            [
+                'options' => ['withholds', 'will withhold', 'withheld'],
+                'answer' => 'withholds',
+                'hint' => '(withhold)',
+            ],
+            [
+                'options' => ["won't have compiled", 'will have compiled', 'are compiling'],
+                'answer' => "won't have compiled",
+                'hint' => '(compile)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'The consortium {a2} agreements if the mediator {a1} consensus.',
+            [
+                'options' => ['fails', 'will fail', 'failed'],
+                'answer' => 'fails',
+                'hint' => '(fail)',
+            ],
+            [
+                'options' => ["won't have ratified", 'will have ratified', 'are ratifying'],
+                'answer' => "won't have ratified",
+                'hint' => '(ratify)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'You {a2} the strategic brief if the board {a1} mandates.',
+            [
+                'options' => ['postpones', 'will postpone', 'postponed'],
+                'answer' => 'postpones',
+                'hint' => '(postpone)',
+            ],
+            [
+                'options' => ["won't have completed", 'will have completed', 'are completing'],
+                'answer' => "won't have completed",
+                'hint' => '(complete)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        // C1 level — Future Perfect Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will the economists have been {a2} indicators if the ministry {a1} transparent data?',
+            [
+                'options' => ['releases', 'will release', 'released'],
+                'answer' => 'releases',
+                'hint' => '(release)',
+            ],
+            [
+                'options' => ['tracking', 'track', 'tracked'],
+                'answer' => 'tracking',
+                'hint' => '(track)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will the negotiation team have been {a2} scenarios if stakeholders {a1} new constraints?',
+            [
+                'options' => ['outline', 'will outline', 'outlined'],
+                'answer' => 'outline',
+                'hint' => '(outline)',
+            ],
+            [
+                'options' => ['modelling', 'model', 'modelled'],
+                'answer' => 'modelling',
+                'hint' => '(model)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'Will you have been {a2} coalition partners if the alliance {a1} progress?',
+            [
+                'options' => ['reports', 'will report', 'reported'],
+                'answer' => 'reports',
+                'hint' => '(report)',
+            ],
+            [
+                'options' => ['cultivating', 'cultivate', 'cultivated'],
+                'answer' => 'cultivating',
+                'hint' => '(cultivate)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // C1 level — Future Perfect Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'The economists {a2} indicators if the ministry {a1} opaque data.',
+            [
+                'options' => ['publishes', 'will publish', 'published'],
+                'answer' => 'publishes',
+                'hint' => '(publish)',
+            ],
+            [
+                'options' => ["won't have been tracking", 'will have been tracking', 'are tracking'],
+                'answer' => "won't have been tracking",
+                'hint' => '(track)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'The negotiation team {a2} scenarios if stakeholders {a1} silence.',
+            [
+                'options' => ['maintain', 'will maintain', 'maintained'],
+                'answer' => 'maintain',
+                'hint' => '(maintain)',
+            ],
+            [
+                'options' => ["won't have been modelling", 'will have been modelling', 'are modelling'],
+                'answer' => "won't have been modelling",
+                'hint' => '(model)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C1',
+            'You {a2} coalition partners if the alliance {a1} stagnation.',
+            [
+                'options' => ['signals', 'will signal', 'signalled'],
+                'answer' => 'signals',
+                'hint' => '(signal)',
+            ],
+            [
+                'options' => ["won't have been cultivating", 'will have been cultivating', 'are cultivating'],
+                'answer' => "won't have been cultivating",
+                'hint' => '(cultivate)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // C2 level — Future Simple (questions)
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will the international tribunal {a2} sanctions if the committee {a1} irrefutable evidence?',
+            [
+                'options' => ['presents', 'will present', 'presented'],
+                'answer' => 'presents',
+                'hint' => '(present)',
+            ],
+            [
+                'options' => ['impose', 'imposes', 'imposing'],
+                'answer' => 'impose',
+                'hint' => '(impose)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will the chief negotiator {a2} the accord if the counterpart {a1} substantive concessions?',
+            [
+                'options' => ['offers', 'will offer', 'offered'],
+                'answer' => 'offers',
+                'hint' => '(offer)',
+            ],
+            [
+                'options' => ['endorse', 'endorses', 'endorsing'],
+                'answer' => 'endorse',
+                'hint' => '(endorse)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will you {a2} the manifesto if the coalition {a1} unified priorities?',
+            [
+                'options' => ['adopts', 'will adopt', 'adopted'],
+                'answer' => 'adopts',
+                'hint' => '(adopt)',
+            ],
+            [
+                'options' => ['publish', 'publishes', 'publishing'],
+                'answer' => 'publish',
+                'hint' => '(publish)',
+                'form' => 'question',
+            ],
+            'Future Simple'
+        );
+
+        // C2 level — Future Simple (negatives)
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'The international tribunal {a2} sanctions if the committee {a1} ambiguous evidence.',
+            [
+                'options' => ['delivers', 'will deliver', 'delivered'],
+                'answer' => 'delivers',
+                'hint' => '(deliver)',
+            ],
+            [
+                'options' => ["won't impose", 'will impose', 'is imposing'],
+                'answer' => "won't impose",
+                'hint' => '(impose)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'The chief negotiator {a2} the accord if the counterpart {a1} symbolic gestures.',
+            [
+                'options' => ['offers', 'will offer', 'offered'],
+                'answer' => 'offers',
+                'hint' => '(offer)',
+            ],
+            [
+                'options' => ["won't endorse", 'will endorse', 'is endorsing'],
+                'answer' => "won't endorse",
+                'hint' => '(endorse)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'You {a2} the manifesto if the coalition {a1} fractured priorities.',
+            [
+                'options' => ['retains', 'will retain', 'retained'],
+                'answer' => 'retains',
+                'hint' => '(retain)',
+            ],
+            [
+                'options' => ["won't publish", 'will publish', 'are publishing'],
+                'answer' => "won't publish",
+                'hint' => '(publish)',
+                'form' => 'negative',
+            ],
+            'Future Simple'
+        );
+
+        // C2 level — Future Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will the investigative panel be {a2} testimony if the court {a1} closed-door hearings?',
+            [
+                'options' => ['convenes', 'will convene', 'convened'],
+                'answer' => 'convenes',
+                'hint' => '(convene)',
+            ],
+            [
+                'options' => ['examining', 'examine', 'examined'],
+                'answer' => 'examining',
+                'hint' => '(examine)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will the crisis unit be {a2} evacuations if the embassy {a1} emergency alerts?',
+            [
+                'options' => ['issues', 'will issue', 'issued'],
+                'answer' => 'issues',
+                'hint' => '(issue)',
+            ],
+            [
+                'options' => ['coordinating', 'coordinate', 'coordinated'],
+                'answer' => 'coordinating',
+                'hint' => '(coordinate)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will you be {a2} expert panels if the agency {a1} urgent mandates?',
+            [
+                'options' => ['delivers', 'will deliver', 'delivered'],
+                'answer' => 'delivers',
+                'hint' => '(deliver)',
+            ],
+            [
+                'options' => ['assembling', 'assemble', 'assembled'],
+                'answer' => 'assembling',
+                'hint' => '(assemble)',
+                'form' => 'question',
+            ],
+            'Future Continuous'
+        );
+
+        // C2 level — Future Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'The investigative panel {a2} testimony if the court {a1} proceedings.',
+            [
+                'options' => ['suspends', 'will suspend', 'suspended'],
+                'answer' => 'suspends',
+                'hint' => '(suspend)',
+            ],
+            [
+                'options' => ["won't be examining", "won't examine", "aren't examining"],
+                'answer' => "won't be examining",
+                'hint' => '(examine)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'The crisis unit {a2} evacuations if the embassy {a1} warnings.',
+            [
+                'options' => ['rescinds', 'will rescind', 'rescinded'],
+                'answer' => 'rescinds',
+                'hint' => '(rescind)',
+            ],
+            [
+                'options' => ["won't be coordinating", "won't coordinate", "aren't coordinating"],
+                'answer' => "won't be coordinating",
+                'hint' => '(coordinate)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'You {a2} expert panels if the agency {a1} mandates.',
+            [
+                'options' => ['delays', 'will delay', 'delayed'],
+                'answer' => 'delays',
+                'hint' => '(delay)',
+            ],
+            [
+                'options' => ["won't be assembling", "won't assemble", "aren't assembling"],
+                'answer' => "won't be assembling",
+                'hint' => '(assemble)',
+                'form' => 'negative',
+            ],
+            'Future Continuous'
+        );
+
+        // C2 level — Future Perfect (questions)
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will the oversight board have {a2} the ruling if the panel {a1} encrypted transcripts?',
+            [
+                'options' => ['releases', 'will release', 'released'],
+                'answer' => 'releases',
+                'hint' => '(release)',
+            ],
+            [
+                'options' => ['finalised', 'finalise', 'finalising'],
+                'answer' => 'finalised',
+                'hint' => '(finalise)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will the diplomatic corps have {a2} accords if the summit {a1} consensus?',
+            [
+                'options' => ['secures', 'will secure', 'secured'],
+                'answer' => 'secures',
+                'hint' => '(secure)',
+            ],
+            [
+                'options' => ['brokered', 'broker', 'brokering'],
+                'answer' => 'brokered',
+                'hint' => '(broker)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will you have {a2} the policy blueprint if the legislature {a1} final readings?',
+            [
+                'options' => ['completes', 'will complete', 'completed'],
+                'answer' => 'completes',
+                'hint' => '(complete)',
+            ],
+            [
+                'options' => ['prepared', 'prepare', 'preparing'],
+                'answer' => 'prepared',
+                'hint' => '(prepare)',
+                'form' => 'question',
+            ],
+            'Future Perfect'
+        );
+
+        // C2 level — Future Perfect (negatives)
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'The oversight board {a2} the ruling if the panel {a1} transcripts.',
+            [
+                'options' => ['withholds', 'will withhold', 'withheld'],
+                'answer' => 'withholds',
+                'hint' => '(withhold)',
+            ],
+            [
+                'options' => ["won't have finalised", 'will have finalised', 'are finalising'],
+                'answer' => "won't have finalised",
+                'hint' => '(finalise)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'The diplomatic corps {a2} accords if the summit {a1} consensus.',
+            [
+                'options' => ['evades', 'will evade', 'evaded'],
+                'answer' => 'evades',
+                'hint' => '(evade)',
+            ],
+            [
+                'options' => ["won't have brokered", 'will have brokered', 'are brokering'],
+                'answer' => "won't have brokered",
+                'hint' => '(broker)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'You {a2} the policy blueprint if the legislature {a1} debate.',
+            [
+                'options' => ['stalls', 'will stall', 'stalled'],
+                'answer' => 'stalls',
+                'hint' => '(stall)',
+            ],
+            [
+                'options' => ["won't have prepared", 'will have prepared', 'are preparing'],
+                'answer' => "won't have prepared",
+                'hint' => '(prepare)',
+                'form' => 'negative',
+            ],
+            'Future Perfect'
+        );
+
+        // C2 level — Future Perfect Continuous (questions)
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will the humanitarian task force have been {a2} aid routes if the border {a1} clearances?',
+            [
+                'options' => ['grants', 'will grant', 'granted'],
+                'answer' => 'grants',
+                'hint' => '(grant)',
+            ],
+            [
+                'options' => ['mapping', 'map', 'mapped'],
+                'answer' => 'mapping',
+                'hint' => '(map)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will the ethics board have been {a2} disclosures if the consortium {a1} sensitive data?',
+            [
+                'options' => ['shares', 'will share', 'shared'],
+                'answer' => 'shares',
+                'hint' => '(share)',
+            ],
+            [
+                'options' => ['scrutinising', 'scrutinise', 'scrutinised'],
+                'answer' => 'scrutinising',
+                'hint' => '(scrutinise)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'Will you have been {a2} diplomatic channels if the envoy {a1} overtures?',
+            [
+                'options' => ['extends', 'will extend', 'extended'],
+                'answer' => 'extends',
+                'hint' => '(extend)',
+            ],
+            [
+                'options' => ['cultivating', 'cultivate', 'cultivated'],
+                'answer' => 'cultivating',
+                'hint' => '(cultivate)',
+                'form' => 'question',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // C2 level — Future Perfect Continuous (negatives)
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'The humanitarian task force {a2} aid routes if the border {a1} permissions.',
+            [
+                'options' => ['denies', 'will deny', 'denied'],
+                'answer' => 'denies',
+                'hint' => '(deny)',
+            ],
+            [
+                'options' => ["won't have been mapping", 'will have been mapping', 'are mapping'],
+                'answer' => "won't have been mapping",
+                'hint' => '(map)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'The ethics board {a2} disclosures if the consortium {a1} cooperation.',
+            [
+                'options' => ['refuses', 'will refuse', 'refused'],
+                'answer' => 'refuses',
+                'hint' => '(refuse)',
+            ],
+            [
+                'options' => ["won't have been scrutinising", 'will have been scrutinising', 'are scrutinising'],
+                'answer' => "won't have been scrutinising",
+                'hint' => '(scrutinise)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        $questions[] = $this->makeQuestion(
+            'C2',
+            'You {a2} diplomatic channels if the envoy {a1} overtures.',
+            [
+                'options' => ['withdraws', 'will withdraw', 'withdrew'],
+                'answer' => 'withdraws',
+                'hint' => '(withdraw)',
+            ],
+            [
+                'options' => ["won't have been cultivating", 'will have been cultivating', 'are cultivating'],
+                'answer' => "won't have been cultivating",
+                'hint' => '(cultivate)',
+                'form' => 'negative',
+            ],
+            'Future Perfect Continuous'
+        );
+
+        // Additional levels will be appended below.
+
+        return $questions;
+    }
+
+    private function makeQuestion(string $level, string $question, array $condition, array $result, string $tense): array
+    {
+        return [
+            'question' => $question,
+            'level' => $level,
+            'tense_tags' => ['First Conditional', $tense],
+            'markers' => [
+                'a1' => [
+                    'options' => $condition['options'],
+                    'answer' => $condition['answer'],
+                    'hint' => $condition['hint'] ?? null,
+                    'meta' => ['role' => 'condition'],
+                ],
+                'a2' => [
+                    'options' => $result['options'],
+                    'answer' => $result['answer'],
+                    'hint' => $result['hint'] ?? null,
+                    'meta' => [
+                        'role' => 'result',
+                        'tense' => $tense,
+                        'form' => $result['form'] ?? 'question',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function buildHintForClause(array $meta, ?string $verbHint, string $example): string
+    {
+        $description = $this->describeStructure($meta);
+
+        if ($verbHint) {
+            $description .= ' Дієслово: ' . $verbHint . '.';
+        }
+
+        return $description . ' Приклад: *' . $example . '*.';
+    }
+
+    private function buildExplanationsForClause(array $meta, array $options, string $answer, string $example): array
+    {
+        $structure = $this->describeStructure($meta);
+
+        $result = [];
+        foreach ($options as $option) {
+            if ($option === $answer) {
+                $result[$option] = '✅ «' . $option . '» — відповідає структурі: ' . $structure . '. Приклад: *' . $example . '*.';
+                continue;
+            }
+
+            $result[$option] = '❌ «' . $option . '» не відповідає структурі: ' . $structure . '. Зверни увагу на приклад: *' . $example . '*.';
+        }
+
+        return $result;
+    }
+
+    private function describeStructure(array $meta): string
+    {
+        if (($meta['role'] ?? 'condition') === 'condition') {
+            return 'If-clause → Present Simple без will';
+        }
+
+        $tense = $meta['tense'] ?? 'Future Simple';
+        $form = $meta['form'] ?? 'question';
+
+        return match ($tense) {
+            'Future Continuous' => $form === 'negative'
+                ? 'Main clause → Future Continuous (won\'t be + V-ing)'
+                : 'Main clause → Future Continuous (will + підмет + be + V-ing)',
+            'Future Perfect' => $form === 'negative'
+                ? 'Main clause → Future Perfect (won\'t have + V3)'
+                : 'Main clause → Future Perfect (will + підмет + have + V3)',
+            'Future Perfect Continuous' => $form === 'negative'
+                ? 'Main clause → Future Perfect Continuous (won\'t have been + V-ing)'
+                : 'Main clause → Future Perfect Continuous (will + підмет + have been + V-ing)',
+            default => $form === 'negative'
+                ? 'Main clause → Future Simple (won\'t + V1)'
+                : 'Main clause → Future Simple (will + підмет + V1)',
+        };
+    }
+
+    private function prepareOptionSets(array $options, array $answers): array
+    {
+        if ($this->isAssoc($options)) {
+            $result = [];
+            foreach ($options as $marker => $choices) {
+                $result[$marker] = array_map(fn ($value) => $this->normalizeValue((string) $value), (array) $choices);
+            }
+
+            return $result;
+        }
+
+        $marker = array_key_first($answers);
+        if ($marker === null) {
+            return [];
+        }
+
+        return [
+            $marker => array_map(fn ($value) => $this->normalizeValue((string) $value), $options),
+        ];
+    }
+
+    private function flattenOptions(array $optionSets): array
+    {
+        $all = [];
+        foreach ($optionSets as $options) {
+            foreach ($options as $option) {
+                $all[] = $option;
+            }
+        }
+
+        return array_values(array_unique($all));
+    }
+
+    private function buildExample(string $question, array $answers): string
+    {
+        $result = $question;
+        foreach ($answers as $marker => $answer) {
+            $result = str_replace('{' . $marker . '}', $answer, $result);
+        }
+
+        $result = preg_replace('/\s+/', ' ', trim($result));
+
+        $first = mb_substr($result, 0, 1, 'UTF-8');
+        $rest = mb_substr($result, 1, null, 'UTF-8');
+
+        return mb_strtoupper($first, 'UTF-8') . $rest;
+    }
+
+    private function normalizeValue(string $value): string
+    {
+        $value = str_replace(['’', '‘', '‛', 'ʻ'], "'", $value);
+        $value = preg_replace('/\s+/', ' ', $value);
+
+        return trim($value);
+    }
+
+    private function isAssoc(array $array): bool
+    {
+        if ($array === []) {
+            return false;
+        }
+
+        return array_keys($array) !== range(0, count($array) - 1);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Seeder;
 use Database\Seeders\Ai\NegativePresentPerfectHabitsTestSeeder;
 use Database\Seeders\V2\PastTimeClausesMixedTestSeeder;
 use Database\Seeders\V2\FutureTensesPracticeV2Seeder;
+use Database\Seeders\V2\FirstConditionalPracticeV2Seeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -97,6 +98,7 @@ class DatabaseSeeder extends Seeder
             PastPerfectSimpleVsContinuousCTestSeeder::class,
             PastTimeClausesMixedTestSeeder::class,
             FutureTensesPracticeV2Seeder::class,
+            FirstConditionalPracticeV2Seeder::class,
             PagesSeeder::class,
             IrregularVerbsSeeder::class,
             FutureSimpleFutureContinuousFuturePerfectTestSeeder::class,
@@ -109,6 +111,7 @@ class DatabaseSeeder extends Seeder
             Ai\FutureTensesComprehensiveAiSeeder::class,
             Ai\FutureTensesPracticeComprehensiveAiSeeder::class,
             Ai\DoDoesIsAreFormsComprehensiveAiSeeder::class,
+            Ai\FirstConditionalFutureFormsAiSeeder::class,
 
         ]);
     }

--- a/database/seeders/V2/FirstConditionalPracticeV2Seeder.php
+++ b/database/seeders/V2/FirstConditionalPracticeV2Seeder.php
@@ -1,0 +1,503 @@
+<?php
+
+namespace Database\Seeders\V2;
+
+use App\Models\Category;
+use App\Models\Source;
+use App\Models\Tag;
+use Database\Seeders\QuestionSeeder;
+
+class FirstConditionalPracticeV2Seeder extends QuestionSeeder
+{
+    public function run(): void
+    {
+        $categoryId = Category::firstOrCreate(['name' => 'Conditionals'])->id;
+        $sourceId = Source::firstOrCreate(['name' => 'Custom: First Conditional Practice V2'])->id;
+
+        $themeTagId = Tag::firstOrCreate(
+            ['name' => 'First Conditional Practice'],
+            ['category' => 'English Grammar Theme']
+        )->id;
+
+        $structureTagId = Tag::firstOrCreate(
+            ['name' => 'First Conditional Sentences'],
+            ['category' => 'English Grammar Structure']
+        )->id;
+
+        $tenseTagId = Tag::firstOrCreate(['name' => 'First Conditional'], ['category' => 'Tenses'])->id;
+
+        $levelDifficulty = [
+            'A1' => 1,
+            'A2' => 2,
+            'B1' => 3,
+            'B2' => 4,
+            'C1' => 5,
+            'C2' => 5,
+        ];
+
+        $questions = [
+            [
+                'question' => 'If it {a1} tomorrow, we {a2} indoors.',
+                'verb_hint' => ['a1' => '(rain)', 'a2' => '(stay)'],
+                'options' => [
+                    'a1' => ['rains', 'will rain', 'is raining'],
+                    'a2' => ['will stay', 'stays', 'are staying'],
+                ],
+                'answers' => ['a1' => 'rains', 'a2' => 'will stay'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If she {a1} hard, she {a2} the exam.',
+                'verb_hint' => ['a1' => '(study)', 'a2' => '(pass)'],
+                'options' => [
+                    'a1' => ['studies', 'will study', 'is studying'],
+                    'a2' => ['will pass', 'passes', 'is passing'],
+                ],
+                'answers' => ['a1' => 'studies', 'a2' => 'will pass'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'I will call you if I {a1} my work early.',
+                'verb_hint' => ['a1' => '(finish)'],
+                'options' => ['finish', 'will finish', 'am finishing'],
+                'answers' => ['a1' => 'finish'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If they {a1} the bus, they {a2} late for school.',
+                'verb_hint' => ['a1' => '(miss)', 'a2' => '(be)'],
+                'options' => [
+                    'a1' => ['miss', 'will miss', 'are missing'],
+                    'a2' => ['will be', 'are', 'is being'],
+                ],
+                'answers' => ['a1' => 'miss', 'a2' => 'will be'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If you {a1} too much, you {a2} sick.',
+                'verb_hint' => ['a1' => '(eat)', 'a2' => '(feel)'],
+                'options' => [
+                    'a1' => ['eat', 'will eat', 'are eating'],
+                    'a2' => ['will feel', 'feel', 'are feeling'],
+                ],
+                'answers' => ['a1' => 'eat', 'a2' => 'will feel'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'We {a1} to the beach if it {a2} cold.',
+                'verb_hint' => ['a1' => '(not go)', 'a2' => '(be)'],
+                'options' => [
+                    'a1' => ["won't go", "don't go", "aren't going"],
+                    'a2' => ['is', 'will be', 'was'],
+                ],
+                'answers' => ['a1' => "won't go", 'a2' => 'is'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If he {a1} late, he {a2} the meeting.',
+                'verb_hint' => ['a1' => '(work)', 'a2' => '(not attend)'],
+                'options' => [
+                    'a1' => ['works', 'is working', 'will work'],
+                    'a2' => ["won't attend", "doesn't attend", "is not attending"],
+                ],
+                'answers' => ['a1' => 'works', 'a2' => "won't attend"],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If the price {a1}, people {a2} less.',
+                'verb_hint' => ['a1' => '(rise)', 'a2' => '(buy)'],
+                'options' => [
+                    'a1' => ['rises', 'will rise', 'is rising'],
+                    'a2' => ['will buy', 'buy', 'are buying'],
+                ],
+                'answers' => ['a1' => 'rises', 'a2' => 'will buy'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'She {a1} upset if you {a2}.',
+                'verb_hint' => ['a1' => '(not be)', 'a2' => '(apologize)'],
+                'options' => [
+                    'a1' => ["won't be", "isn't", 'will not be'],
+                    'a2' => ['apologize', 'will apologize', 'are apologizing'],
+                ],
+                'answers' => ['a1' => "won't be", 'a2' => 'apologize'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If you {a1} regularly, you {a2} healthier.',
+                'verb_hint' => ['a1' => '(exercise)', 'a2' => '(be)'],
+                'options' => [
+                    'a1' => ['exercise', 'will exercise', 'are exercising'],
+                    'a2' => ['will be', 'are', 'be'],
+                ],
+                'answers' => ['a1' => 'exercise', 'a2' => 'will be'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If the traffic {a1} heavy, we {a2} a different route.',
+                'verb_hint' => ['a1' => '(be)', 'a2' => '(take)'],
+                'options' => [
+                    'a1' => ['is', 'will be', 'was'],
+                    'a2' => ['will take', 'take', 'are taking'],
+                ],
+                'answers' => ['a1' => 'is', 'a2' => 'will take'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If they {a1}, they {a2} the train.',
+                'verb_hint' => ['a1' => '(not hurry)', 'a2' => '(miss)'],
+                'options' => [
+                    'a1' => ["don't hurry", "won't hurry", "aren't hurrying"],
+                    'a2' => ['will miss', 'miss', 'are missing'],
+                ],
+                'answers' => ['a1' => "don't hurry", 'a2' => 'will miss'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If I {a1} her, I {a2} her the news.',
+                'verb_hint' => ['a1' => '(see)', 'a2' => '(tell)'],
+                'options' => [
+                    'a1' => ['see', 'will see', 'am seeing'],
+                    'a2' => ['will tell', 'tell', 'am telling'],
+                ],
+                'answers' => ['a1' => 'see', 'a2' => 'will tell'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If the car {a1} down, we {a2} for help.',
+                'verb_hint' => ['a1' => '(break)', 'a2' => '(call)'],
+                'options' => [
+                    'a1' => ['breaks', 'will break', 'is breaking'],
+                    'a2' => ['will call', 'call', 'are calling'],
+                ],
+                'answers' => ['a1' => 'breaks', 'a2' => 'will call'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'We {a1} for a picnic if it {a2}.',
+                'verb_hint' => ['a1' => '(not go)', 'a2' => '(rain)'],
+                'options' => [
+                    'a1' => ["won't go", "don't go", "aren't going"],
+                    'a2' => ['rains', 'will rain', 'is raining'],
+                ],
+                'answers' => ['a1' => "won't go", 'a2' => 'rains'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If he {a1} more, he {a2} better grades.',
+                'verb_hint' => ['a1' => '(study)', 'a2' => '(get)'],
+                'options' => [
+                    'a1' => ['studies', 'will study', 'is studying'],
+                    'a2' => ['will get', 'gets', 'is getting'],
+                ],
+                'answers' => ['a1' => 'studies', 'a2' => 'will get'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+            [
+                'question' => 'If you {a1} the plants, they {a2}.',
+                'verb_hint' => ['a1' => '(not water)', 'a2' => '(die)'],
+                'options' => [
+                    'a1' => ["don't water", "won't water", "aren't watering"],
+                    'a2' => ['will die', 'die', 'are dying'],
+                ],
+                'answers' => ['a1' => "don't water", 'a2' => 'will die'],
+                'tense' => ['First Conditional'],
+                'level' => 'A2',
+            ],
+        ];
+
+        $items = [];
+        $meta = [];
+
+        foreach ($questions as $index => $question) {
+            $answersMap = [];
+            foreach ($question['answers'] as $marker => $value) {
+                $answersMap[$marker] = $this->normalizeValue($value);
+            }
+
+            $optionSets = $this->prepareOptionSets($question['options'], $answersMap);
+            $flattenedOptions = $this->flattenOptions($optionSets);
+
+            $verbHints = [];
+            foreach ($answersMap as $marker => $value) {
+                $hintSource = $question['verb_hint'][$marker] ?? null;
+                $verbHints[$marker] = $this->normalizeHint($hintSource);
+            }
+
+            $example = $this->buildExample($question['question'], $answersMap);
+
+            $answers = [];
+            foreach ($answersMap as $marker => $answer) {
+                $answers[] = [
+                    'marker' => $marker,
+                    'answer' => $answer,
+                    'verb_hint' => $verbHints[$marker] ?? null,
+                ];
+            }
+
+            $hints = [];
+            $explanations = [];
+            $optionMarkerMap = [];
+
+            foreach ($optionSets as $marker => $options) {
+                foreach ($options as $option) {
+                    if (! isset($optionMarkerMap[$option])) {
+                        $optionMarkerMap[$option] = $marker;
+                    }
+                }
+
+                $clauseType = $this->detectClauseType($question['question'], $marker);
+                $hints[$marker] = $this->buildHintForClause($clauseType, $verbHints[$marker] ?? null, $example);
+
+                $explanations = array_merge(
+                    $explanations,
+                    $this->buildExplanationsForClause(
+                        $clauseType,
+                        $options,
+                        $answersMap[$marker],
+                        $example
+                    )
+                );
+            }
+
+            $tagIds = [$themeTagId, $structureTagId, $tenseTagId];
+            foreach ($question['tense'] as $tenseName) {
+                $tagIds[] = Tag::firstOrCreate(['name' => $tenseName], ['category' => 'Tenses'])->id;
+            }
+
+            $uuid = $this->generateQuestionUuid($index + 1, $question['question']);
+
+            $items[] = [
+                'uuid' => $uuid,
+                'question' => $question['question'],
+                'category_id' => $categoryId,
+                'difficulty' => $levelDifficulty[$question['level']] ?? 3,
+                'source_id' => $sourceId,
+                'flag' => 0,
+                'level' => $question['level'],
+                'tag_ids' => array_values(array_unique($tagIds)),
+                'answers' => $answers,
+                'options' => $flattenedOptions,
+                'variants' => [$question['question']],
+            ];
+
+            $meta[] = [
+                'uuid' => $uuid,
+                'answers' => $answersMap,
+                'option_markers' => $optionMarkerMap,
+                'hints' => $hints,
+                'explanations' => $explanations,
+            ];
+        }
+
+        $this->seedQuestionData($items, $meta);
+    }
+
+    private function prepareOptionSets(array $options, array $answers): array
+    {
+        if ($this->isAssoc($options)) {
+            $result = [];
+            foreach ($options as $marker => $choices) {
+                $result[$marker] = array_map(fn ($value) => $this->normalizeValue((string) $value), (array) $choices);
+            }
+
+            return $result;
+        }
+
+        $marker = array_key_first($answers);
+        if ($marker === null) {
+            return [];
+        }
+
+        return [
+            $marker => array_map(fn ($value) => $this->normalizeValue((string) $value), $options),
+        ];
+    }
+
+    private function flattenOptions(array $optionSets): array
+    {
+        $all = [];
+        foreach ($optionSets as $options) {
+            foreach ($options as $option) {
+                $all[] = $option;
+            }
+        }
+
+        return array_values(array_unique($all));
+    }
+
+    private function detectClauseType(string $question, string $marker): string
+    {
+        $placeholder = '{' . $marker . '}';
+        $position = mb_stripos($question, $placeholder);
+
+        if ($position === false) {
+            return 'result';
+        }
+
+        $before = mb_substr($question, 0, $position);
+        $beforeLower = mb_strtolower($before);
+
+        if (mb_strripos($beforeLower, 'if') !== false) {
+            return 'condition';
+        }
+
+        return 'result';
+    }
+
+    private function buildHintForClause(string $clauseType, ?string $verbHint, string $example): string
+    {
+        $base = $clauseType === 'condition'
+            ? 'If-clause → Present Simple (без will).'
+            : "Main clause → will + V1 / won't + V1 для результату.";
+
+        if ($verbHint) {
+            $base .= ' Дієслово: ' . $verbHint . '.';
+        }
+
+        return $base . ' Приклад: *' . $example . '*.';
+    }
+
+    private function buildExplanationsForClause(string $clauseType, array $options, string $answer, string $example): array
+    {
+        $result = [];
+        foreach ($options as $option) {
+            if ($option === $answer) {
+                $result[$option] = $this->buildCorrectExplanation($clauseType, $option, $example);
+            } else {
+                $result[$option] = $this->buildWrongExplanation($clauseType, $option, $answer, $example);
+            }
+        }
+
+        return $result;
+    }
+
+    private function buildCorrectExplanation(string $clauseType, string $answer, string $example): string
+    {
+        if ($clauseType === 'condition') {
+            return '✅ «' . $answer . '» — правильна форма Present Simple у частині з if. Приклад: *' . $example . '*.';
+        }
+
+        return '✅ «' . $answer . '» — коректна форма Future Simple у головному реченні. Приклад: *' . $example . '*.';
+    }
+
+    private function buildWrongExplanation(string $clauseType, string $option, string $answer, string $example): string
+    {
+        $type = $this->classifyOption($option);
+
+        if ($clauseType === 'condition') {
+            return match ($type) {
+                'future' => '❌ У підрядній частині першого умовного не вживаємо will/won\'t. Дивись приклад: *' . $example . '*.',
+                'continuous' => '❌ If-clause вимагає Present Simple, а не тривалий час. Правильний приклад: *' . $example . '*.',
+                'past' => '❌ Перший умовний після if використовує теперішній час, не минулий. Приклад: *' . $example . '*.',
+                'perfect' => '❌ Потрібна проста форма, без have + V3. Орієнтуйся на приклад: *' . $example . '*.',
+                default => '❌ Спробуй Present Simple у частині з if. Правильний приклад: *' . $example . '*.',
+            };
+        }
+
+        if ($type === 'future' && $this->isFullNegativeVariant($option, $answer)) {
+            return '❌ «' . $option . '» граматично можливо, але завдання очікує скорочення «' . $answer . '». Приклад: *' . $example . '*.';
+        }
+
+        return match ($type) {
+            'future' => '❌ Форма «' . $option . '» не відповідає потрібній моделі will + правильне дієслово. Подивись: *' . $example . '*.',
+            'continuous' => '❌ У головному реченні потрібне will + V1 (або won\'t + V1), а не тривалий час. Правильний приклад: *' . $example . '*.',
+            'do' => '❌ Заперечення з do/does не підходить; потрібне will/won\'t. Подивись на приклад: *' . $example . '*.',
+            'past' => '❌ Результат у першому умовному будуємо через will, не минулий час. Приклад: *' . $example . '*.',
+            'perfect' => '❌ Не використовуй have + V3 у результаті; потрібна проста форма з will. Приклад: *' . $example . '*.',
+            'be_negative' => '❌ Краще використати will/won\'t + be, як у прикладі: *' . $example . '*.',
+            default => '❌ Основне речення має містити will або won\'t. Орієнтуйся на приклад: *' . $example . '*.',
+        };
+    }
+
+    private function classifyOption(string $option): string
+    {
+        $value = mb_strtolower($option);
+
+        if (str_contains($value, 'will have')) {
+            return 'perfect';
+        }
+
+        if (str_contains($value, "won't") || preg_match('/\bwill\b/', $value)) {
+            return 'future';
+        }
+
+        if (preg_match('/\b(am|is|are|was|were)\b[^a-z]*[a-z]+ing/', $value)) {
+            return 'continuous';
+        }
+
+        if (preg_match('/\b(did|was|were)\b/', $value)) {
+            return 'past';
+        }
+
+        if (preg_match("/\b(do|does|don't|doesn't)\b/", $value)) {
+            return 'do';
+        }
+
+        if (preg_match("/\b(has|have|had)\b/", $value)) {
+            return 'perfect';
+        }
+
+        if (preg_match("/\b(isn't|aren't)\b/", $value)) {
+            return 'be_negative';
+        }
+
+        return 'present_simple';
+    }
+
+    private function isFullNegativeVariant(string $option, string $answer): bool
+    {
+        $optionNormalized = str_replace(' ', '', mb_strtolower($option));
+        $answerNormalized = str_replace(' ', '', mb_strtolower($answer));
+
+        return str_contains($optionNormalized, 'willnot') && str_contains($answerNormalized, "won't");
+    }
+
+    private function buildExample(string $question, array $answers): string
+    {
+        $result = $question;
+        foreach ($answers as $marker => $answer) {
+            $result = str_replace('{' . $marker . '}', $answer, $result);
+        }
+
+        $result = preg_replace('/\s+/', ' ', trim($result));
+
+        $first = mb_substr($result, 0, 1, 'UTF-8');
+        $rest = mb_substr($result, 1, null, 'UTF-8');
+
+        return mb_strtoupper($first, 'UTF-8') . $rest;
+    }
+
+    private function normalizeValue(string $value): string
+    {
+        $value = str_replace(['’', '‘', '‛', 'ʻ'], "'", $value);
+        $value = preg_replace('/\s+/', ' ', $value);
+
+        return trim($value);
+    }
+
+    private function isAssoc(array $array): bool
+    {
+        if ($array === []) {
+            return false;
+        }
+
+        return array_keys($array) !== range(0, count($array) - 1);
+    }
+}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Вхід до адмін-панелі</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center p-4">
+    <div class="w-full max-w-md bg-white shadow rounded-lg p-8">
+        <h1 class="text-2xl font-semibold text-center text-gray-800 mb-6">Вхід до адмін-панелі</h1>
+
+        @if(session('status'))
+            <div class="mb-4 p-3 rounded bg-green-100 text-green-700 text-sm">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        <form method="POST" action="{{ route('login.perform') }}" class="space-y-5">
+            @csrf
+
+            <div>
+                <label for="username" class="block text-sm font-medium text-gray-700">Логін</label>
+                <input
+                    id="username"
+                    type="text"
+                    name="username"
+                    value="{{ old('username') }}"
+                    required
+                    autofocus
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                >
+                @error('username')
+                    <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="password" class="block text-sm font-medium text-gray-700">Пароль</label>
+                <input
+                    id="password"
+                    type="password"
+                    name="password"
+                    required
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                >
+                @error('password')
+                    <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div class="flex items-center">
+                <label for="remember" class="flex items-center text-sm text-gray-600">
+                    <input
+                        id="remember"
+                        type="checkbox"
+                        name="remember"
+                        value="1"
+                        class="mr-2 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        @checked(old('remember'))
+                    >
+                    Запам'ятати мене
+                </label>
+            </div>
+
+            <button
+                type="submit"
+                class="w-full py-2 px-4 text-white font-semibold bg-blue-600 hover:bg-blue-700 rounded-md shadow"
+            >
+                Увійти
+            </button>
+        </form>
+    </div>
+</body>
+</html>

--- a/resources/views/engram/catalog-tests-cards.blade.php
+++ b/resources/views/engram/catalog-tests-cards.blade.php
@@ -4,7 +4,21 @@
 
 @section('content')
 <div class="flex flex-col md:flex-row gap-6">
-    <aside class="md:w-48 w-full md:shrink-0">
+    <div class="md:hidden">
+        <button type="button" id="filter-toggle" class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-border text-sm font-medium">
+            <span>Фільтр</span>
+            <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M3.5 5a.75.75 0 01.75-.75h11.5a.75.75 0 01.53 1.28L12 10.06v4.19a.75.75 0 01-1.13.65l-2.5-1.5a.75.75 0 01-.37-.65v-2.69L3.97 5.53A.75.75 0 013.5 5z" clip-rule="evenodd" />
+            </svg>
+        </button>
+    </div>
+    <aside id="filters" class="md:w-48 w-full md:shrink-0 hidden md:block md:sticky md:top-20 md:self-start bg-card md:bg-transparent md:p-0 p-4 rounded-2xl shadow-soft md:shadow-none">
+        <div class="flex justify-between items-center md:hidden mb-4">
+            <h2 class="text-base font-semibold">Фільтр</h2>
+            <button type="button" id="filter-close" class="text-sm text-primary underline">
+                Закрити
+            </button>
+        </div>
         <form id="tag-filter" action="{{ route('catalog-tests.cards') }}" method="GET">
             @if(isset($availableLevels) && $availableLevels->count())
                 <div class="mb-4">
@@ -103,6 +117,19 @@
             const hidden = tags.style.display === 'none';
             tags.style.display = hidden ? '' : 'none';
             toggleBtn.textContent = hidden ? 'Hide' : 'Show';
+        });
+    }
+    const filterToggle = document.getElementById('filter-toggle');
+    const filterClose = document.getElementById('filter-close');
+    const filters = document.getElementById('filters');
+    if (filterToggle && filters) {
+        filterToggle.addEventListener('click', () => {
+            filters.classList.toggle('hidden');
+        });
+    }
+    if (filterClose && filters) {
+        filterClose.addEventListener('click', () => {
+            filters.classList.add('hidden');
         });
     }
 </script>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -45,6 +45,14 @@
                     <a href="{{ url('/grammar-test/v2') }}" class="hover:text-blue-500 transition">Граматика v2</a>
                     <a href="{{ url('/tests') }}" class="hover:text-blue-500 transition">Збережені тести</a>
                     <a href="{{ url('/') }}" class="hover:text-blue-500 transition">До публічної частини</a>
+                    @if(session('admin_authenticated'))
+                        <form method="POST" action="{{ route('logout') }}">
+                            @csrf
+                            <button type="submit" class="text-red-500 hover:text-red-600 transition">Вийти</button>
+                        </form>
+                    @else
+                        <a href="{{ route('login.show') }}" class="hover:text-blue-500 transition">Увійти</a>
+                    @endif
                 </div>
             </div>
             <div
@@ -56,6 +64,14 @@
                 <a href="{{ url('/grammar-test/v2') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">Граматика v2</a>
                 <a href="{{ url('/tests') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">Збережені тести</a>
                 <a href="{{ url('/') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">До публічної частини</a>
+                @if(session('admin_authenticated'))
+                    <form method="POST" action="{{ route('logout') }}" class="px-2 py-2">
+                        @csrf
+                        <button type="submit" class="w-full text-left text-red-500 hover:text-red-600">Вийти</button>
+                    </form>
+                @else
+                    <a href="{{ route('login.show') }}" class="block px-2 py-2 rounded-lg hover:bg-blue-50">Увійти</a>
+                @endif
             </div>
         </div>
     </nav>

--- a/resources/views/layouts/engram.blade.php
+++ b/resources/views/layouts/engram.blade.php
@@ -118,24 +118,22 @@
   <!-- HEADER / NAV -->
   <header class="sticky top-0 z-40 border-b border-border/70 backdrop-blur bg-background/80">
     <div class="container mx-auto px-4">
-      <div class="flex h-16 items-center justify-between gap-4">
-        <div class="flex items-center gap-3">
+      <div class="flex flex-wrap items-center justify-between gap-4 py-4 md:h-16 md:flex-nowrap">
+        <div class="flex items-center gap-3 flex-shrink-0">
           <div class="h-9 w-9 rounded-2xl bg-primary text-primary-foreground grid place-items-center font-bold">E</div>
           <span class="text-lg font-semibold tracking-tight">Engram</span>
           <span class="ml-2 inline-flex items-center rounded-lg bg-accent text-accent-foreground px-2 py-0.5 text-xs font-medium">beta</span>
         </div>
-        <nav class="hidden md:flex items-center gap-6 text-sm">
+        <nav class="order-3 w-full flex flex-wrap items-center gap-4 text-sm md:order-none md:w-auto md:flex-nowrap md:gap-6">
           <a class="text-muted-foreground hover:text-foreground" href="{{ route('catalog-tests.cards') }}">Тести</a>
           <a class="text-muted-foreground hover:text-foreground" href="{{ route('pages.index') }}">Теорія</a>
         </nav>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 order-2 ml-auto md:order-none md:ml-0">
           <form action="{{ route('site.search') }}" method="GET" class="hidden md:block relative">
             <input type="search" name="q" id="search-box" autocomplete="off" placeholder="Пошук..." class="w-48 rounded-xl border border-input bg-background px-3 py-2 text-sm" />
             <div id="search-box-list" class="absolute left-0 mt-1 w-full bg-background border border-border rounded-xl shadow-soft text-sm hidden z-50"></div>
           </form>
           <button id="mobile-search-btn" class="md:hidden rounded-xl border border-border p-2 text-sm">🔍</button>
-          <button id="theme-toggle" class="hidden sm:inline-flex rounded-xl border border-border px-3 py-2 text-sm">🌙 Тема</button>
-          <button class="rounded-2xl bg-primary px-4 py-2 text-primary-foreground text-sm">Реєстрація</button>
         </div>
       </div>
       <div id="mobile-search" class="md:hidden hidden pb-3">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,17 +1,25 @@
 <?php
 
+use App\Http\Controllers\AiTestController;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\ChatGPTExplanationController;
 use App\Http\Controllers\GrammarTestController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\PageController;
-use App\Http\Controllers\QuestionHelpController;
 use App\Http\Controllers\QuestionAnswerController;
+use App\Http\Controllers\QuestionController;
+use App\Http\Controllers\QuestionHelpController;
 use App\Http\Controllers\QuestionHintController;
 use App\Http\Controllers\QuestionOptionController;
+use App\Http\Controllers\QuestionReviewController;
+use App\Http\Controllers\QuestionReviewResultController;
 use App\Http\Controllers\QuestionVariantController;
-use App\Http\Controllers\ChatGPTExplanationController;
-use App\Http\Controllers\TrainController;
-use App\Http\Controllers\WordSearchController;
+use App\Http\Controllers\SentenceTranslationTestController;
 use App\Http\Controllers\SiteSearchController;
+use App\Http\Controllers\TrainController;
+use App\Http\Controllers\VerbHintController;
+use App\Http\Controllers\WordSearchController;
+use App\Http\Controllers\WordsTestController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -25,140 +33,135 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('set-locale', function (\Illuminate\Http\Request $request) {
-    $lang = $request->input('lang', 'en');
-    if (! in_array($lang, ['en', 'uk', 'pl'])) {
-        $lang = 'en';
-    }
-    session(['locale' => $lang]);
-    app()->setLocale($lang);
+Route::get('/login', [AuthController::class, 'showLoginForm'])->name('login.show');
+Route::post('/login', [AuthController::class, 'login'])->name('login.perform');
+Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
 
-    return redirect()->back();
-})->name('setlocale');
+Route::middleware('auth.admin')->group(function () {
+    Route::get('set-locale', function (\Illuminate\Http\Request $request) {
+        $lang = $request->input('lang', 'en');
+        if (! in_array($lang, ['en', 'uk', 'pl'])) {
+            $lang = 'en';
+        }
+        session(['locale' => $lang]);
+        app()->setLocale($lang);
 
-Route::get('/', [HomeController::class, 'index'])->name('home');
+        return redirect()->back();
+    })->name('setlocale');
 
-Route::get('/train/{topic?}', [TrainController::class, 'index'])->name('train');
+    Route::get('/', [HomeController::class, 'index'])->name('home');
 
-Route::get('/theory', [PageController::class, 'index'])->name('pages.index');
-Route::get('/theory/{slug}', [PageController::class, 'show'])->name('pages.show');
+    Route::get('/train/{topic?}', [TrainController::class, 'index'])->name('train');
 
-use App\Http\Controllers\SentenceTranslationTestController;
-use App\Http\Controllers\WordsTestController;
-
-Route::get('/words/test', [WordsTestController::class, 'index'])->name('words.test');
-Route::post('/words/test/check', [WordsTestController::class, 'check'])->name('words.test.check');
-Route::post('/words/test/reset', function () {
-    session()->forget('words_test_stats');
-
-    return redirect()->route('words.test');
-})->name('words.test.reset');
-
-Route::get('/translate/test', [SentenceTranslationTestController::class, 'index'])->name('translate.test');
-Route::post('/translate/test/check', [SentenceTranslationTestController::class, 'check'])->name('translate.test.check');
-Route::post('/translate/test/reset', [SentenceTranslationTestController::class, 'reset'])->name('translate.test.reset');
-Route::get('/translate/test2', [SentenceTranslationTestController::class, 'indexV2'])->name('translate.test2');
-Route::post('/translate/test2/check', [SentenceTranslationTestController::class, 'checkV2'])->name('translate.test2.check');
-Route::post('/translate/test2/reset', [SentenceTranslationTestController::class, 'resetV2'])->name('translate.test2.reset');
-
-Route::get('/grammar-test', [GrammarTestController::class, 'index'])->name('grammar-test');
-Route::post('/grammar-test', [GrammarTestController::class, 'generate'])->name('grammar-test.generate');
-Route::get('/grammar-test/v2', [GrammarTestController::class, 'indexV2'])->name('grammar-test.v2');
-Route::post('/grammar-test/v2', [GrammarTestController::class, 'generateV2'])->name('grammar-test-v2.generate');
-Route::post('/grammar-test-check', [GrammarTestController::class, 'check'])->name('grammar-test.check');
-Route::get('/grammar-test-autocomplete', [GrammarTestController::class, 'autocomplete'])->name('grammar-test.autocomplete');
-Route::post('/grammar-test-check-answer', [GrammarTestController::class, 'checkOneAnswer'])->name('grammar-test.checkOne');
-
-Route::post('/grammar-test-save', [GrammarTestController::class, 'save'])->name('grammar-test.save');
-Route::post('/grammar-test-v2-save', [GrammarTestController::class, 'saveV2'])->name('grammar-test-v2.save');
-Route::post('/test/{slug}/js/state', [GrammarTestController::class, 'storeSavedTestJsState'])->name('saved-test.js.state');
-Route::get('/test/{slug}/js/questions', [GrammarTestController::class, 'fetchSavedTestJsQuestions'])->name('saved-test.js.questions');
-Route::get('/test/{slug}/js', [GrammarTestController::class, 'showSavedTestJs'])->name('saved-test.js');
-Route::get('/test/{slug}/js/step', [GrammarTestController::class, 'showSavedTestJsStep'])->name('saved-test.js.step');
-Route::get('/test/{slug}/js/manual', [GrammarTestController::class, 'showSavedTestJsManual'])->name('saved-test.js.manual');
-Route::get('/test/{slug}/js/step/manual', [GrammarTestController::class, 'showSavedTestJsStepManual'])->name('saved-test.js.step-manual');
-Route::get('/test/{slug}/js/step/input', [GrammarTestController::class, 'showSavedTestJsStepInput'])->name('saved-test.js.step-input');
-Route::get('/test/{slug}/js/input', [GrammarTestController::class, 'showSavedTestJsInput'])->name('saved-test.js.input');
-Route::get('/test/{slug}/js/step/select', [GrammarTestController::class, 'showSavedTestJsStepSelect'])->name('saved-test.js.step-select');
-Route::get('/test/{slug}/js/select', [GrammarTestController::class, 'showSavedTestJsSelect'])->name('saved-test.js.select');
-Route::get('/test/{slug}/tech', [GrammarTestController::class, 'showSavedTestTech'])->name('saved-test.tech');
-Route::post('/test/{slug}/questions', [GrammarTestController::class, 'storeSavedTestQuestion'])->name('saved-test.questions.store');
-Route::delete('/test/{slug}/questions', [GrammarTestController::class, 'deleteAllQuestions'])->name('saved-test.questions.destroy-all');
-Route::get('/test/{slug}', [GrammarTestController::class, 'showSavedTest'])->name('saved-test.show');
-Route::get('/test/{slug}/random', [GrammarTestController::class, 'showSavedTestRandom'])->name('saved-test.random');
-Route::get('/test/{slug}/step', [GrammarTestController::class, 'showSavedTestStep'])->name('saved-test.step');
-Route::post('/test/{slug}/refresh-description', [GrammarTestController::class, 'refreshDescription'])->name('saved-test.refresh');
-Route::post('/test/{slug}/refresh-description-gemini', [GrammarTestController::class, 'refreshDescriptionGemini'])->name('saved-test.refresh-gemini');
-Route::post('/test/{slug}/step/check', [GrammarTestController::class, 'checkSavedTestStep'])->name('saved-test.step.check');
-Route::post('/test/{slug}/step/reset', [GrammarTestController::class, 'resetSavedTestStep'])->name('saved-test.step.reset');
-Route::post('/test/{slug}/step/determine-tense', [GrammarTestController::class, 'determineTense'])->name('saved-test.step.determine-tense');
-Route::post('/test/{slug}/step/determine-tense-gemini', [GrammarTestController::class, 'determineTenseGemini'])->name('saved-test.step.determine-tense-gemini');
-Route::post('/test/{slug}/step/determine-level', [GrammarTestController::class, 'determineLevel'])->name('saved-test.step.determine-level');
-Route::post('/test/{slug}/step/determine-level-gemini', [GrammarTestController::class, 'determineLevelGemini'])->name('saved-test.step.determine-level-gemini');
-Route::post('/test/{slug}/step/set-level', [GrammarTestController::class, 'setLevel'])->name('saved-test.step.set-level');
-Route::post('/test/{slug}/step/add-tag', [GrammarTestController::class, 'addTag'])->name('saved-test.step.add-tag');
-Route::delete('/test/{slug}/step/remove-tag', [GrammarTestController::class, 'removeTag'])->name('saved-test.step.remove-tag');
-Route::delete('/test/{slug}/question/{question}', [GrammarTestController::class, 'deleteQuestion'])->name('saved-test.question.destroy');
-Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
-Route::delete('/tests/{slug}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
-Route::get('/tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('saved-tests.cards');
-Route::get('/catalog-tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('catalog-tests.cards');
-
-Route::get('/words', [WordSearchController::class, 'search'])->name('words.search');
-
-Route::get('/search', SiteSearchController::class)->name('site.search');
-
-use App\Http\Controllers\AiTestController;
-
-Route::get('/ai-test', [AiTestController::class, 'form'])->name('ai-test.form');
-Route::post('/ai-test/start', [AiTestController::class, 'start'])->name('ai-test.start');
-Route::get('/ai-test/step', [AiTestController::class, 'step'])->name('ai-test.step');
-Route::get('/ai-test/next', [AiTestController::class, 'next'])->name('ai-test.next');
-Route::post('/ai-test/check', [AiTestController::class, 'check'])->name('ai-test.check');
-Route::post('/ai-test/skip', [AiTestController::class, 'skip'])->name('ai-test.skip');
-Route::post('/ai-test/reset', [AiTestController::class, 'reset'])->name('ai-test.reset');
-Route::post('/ai-test/provider', [AiTestController::class, 'provider'])->name('ai-test.provider');
-Route::post('/ai-test/step/determine-tense', [AiTestController::class, 'determineTense'])->name('ai-test.step.determine-tense');
-Route::post('/ai-test/step/determine-tense-gemini', [AiTestController::class, 'determineTenseGemini'])->name('ai-test.step.determine-tense-gemini');
-Route::post('/ai-test/step/determine-level', [AiTestController::class, 'determineLevel'])->name('ai-test.step.determine-level');
-Route::post('/ai-test/step/determine-level-gemini', [AiTestController::class, 'determineLevelGemini'])->name('ai-test.step.determine-level-gemini');
-Route::post('/ai-test/step/set-level', [AiTestController::class, 'setLevel'])->name('ai-test.step.set-level');
-Route::post('/ai-test/step/add-tag', [AiTestController::class, 'addTag'])->name('ai-test.step.add-tag');
-Route::delete('/ai-test/step/remove-tag', [AiTestController::class, 'removeTag'])->name('ai-test.step.remove-tag');
-
-use App\Http\Controllers\QuestionReviewController;
-
-Route::get('/question-review', [QuestionReviewController::class, 'index'])->name('question-review.index');
-Route::post('/question-review', [QuestionReviewController::class, 'store'])->name('question-review.store');
-Route::get('/question-review/{question}', [QuestionReviewController::class, 'edit'])->name('question-review.edit');
-
-use App\Http\Controllers\QuestionController;
-use App\Http\Controllers\QuestionReviewResultController;
-use App\Http\Controllers\VerbHintController;
-
-Route::get('/question-review-results', [QuestionReviewResultController::class, 'index'])->name('question-review-results.index');
-
-Route::post('/verb-hints', [VerbHintController::class, 'store'])->name('verb-hints.store');
-Route::put('/verb-hints/{verbHint}', [VerbHintController::class, 'update'])->name('verb-hints.update');
-Route::delete('/verb-hints/{verbHint}', [VerbHintController::class, 'destroy'])->name('verb-hints.destroy');
-Route::put('/questions/{question}', [QuestionController::class, 'update'])->name('questions.update');
-Route::post('/questions/{question}/export', [QuestionController::class, 'export'])->name('questions.export');
-Route::post('/questions/export/by-uuid', [QuestionController::class, 'exportByUuid'])->name('questions.export-by-uuid');
-Route::post('/questions/restore/from-dumps', [QuestionController::class, 'restoreFromDumps'])->name('questions.restore-from-dumps');
-Route::post('/questions/restore/by-uuid', [QuestionController::class, 'restoreByUuid'])->name('questions.restore-by-uuid');
-Route::post('/question-answers', [QuestionAnswerController::class, 'store'])->name('question-answers.store');
-Route::put('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'update'])->name('question-answers.update');
-Route::delete('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'destroy'])->name('question-answers.destroy');
-Route::post('/questions/{question}/options', [QuestionOptionController::class, 'store'])->name('questions.options.store');
-Route::put('/questions/{question}/options/{option}', [QuestionOptionController::class, 'update'])->name('questions.options.update');
-Route::delete('/questions/{question}/options/{option}', [QuestionOptionController::class, 'destroy'])->name('questions.options.destroy');
-Route::put('/question-variants/{questionVariant}', [QuestionVariantController::class, 'update'])->name('question-variants.update');
-Route::delete('/question-variants/{questionVariant}', [QuestionVariantController::class, 'destroy'])->name('question-variants.destroy');
-Route::post('/question-hints', [QuestionHintController::class, 'store'])->name('question-hints.store');
-Route::put('/question-hints/{questionHint}', [QuestionHintController::class, 'update'])->name('question-hints.update');
-Route::delete('/question-hints/{questionHint}', [QuestionHintController::class, 'destroy'])->name('question-hints.destroy');
-Route::post('/chatgpt-explanations', [ChatGPTExplanationController::class, 'store'])->name('chatgpt-explanations.store');
-Route::delete('/chatgpt-explanations/{chatGPTExplanation}', [ChatGPTExplanationController::class, 'destroy'])->name('chatgpt-explanations.destroy');
-
-Route::post('/question-hint', [QuestionHelpController::class, 'hint'])->name('question.hint');
-Route::post('/question-explain', [QuestionHelpController::class, 'explain'])->name('question.explain');
+    Route::get('/theory', [PageController::class, 'index'])->name('pages.index');
+    Route::get('/theory/{slug}', [PageController::class, 'show'])->name('pages.show');
+    
+    Route::get('/words/test', [WordsTestController::class, 'index'])->name('words.test');
+    Route::post('/words/test/check', [WordsTestController::class, 'check'])->name('words.test.check');
+    Route::post('/words/test/reset', function () {
+        session()->forget('words_test_stats');
+    
+        return redirect()->route('words.test');
+    })->name('words.test.reset');
+    
+    Route::get('/translate/test', [SentenceTranslationTestController::class, 'index'])->name('translate.test');
+    Route::post('/translate/test/check', [SentenceTranslationTestController::class, 'check'])->name('translate.test.check');
+    Route::post('/translate/test/reset', [SentenceTranslationTestController::class, 'reset'])->name('translate.test.reset');
+    Route::get('/translate/test2', [SentenceTranslationTestController::class, 'indexV2'])->name('translate.test2');
+    Route::post('/translate/test2/check', [SentenceTranslationTestController::class, 'checkV2'])->name('translate.test2.check');
+    Route::post('/translate/test2/reset', [SentenceTranslationTestController::class, 'resetV2'])->name('translate.test2.reset');
+    
+    Route::get('/grammar-test', [GrammarTestController::class, 'index'])->name('grammar-test');
+    Route::post('/grammar-test', [GrammarTestController::class, 'generate'])->name('grammar-test.generate');
+    Route::get('/grammar-test/v2', [GrammarTestController::class, 'indexV2'])->name('grammar-test.v2');
+    Route::post('/grammar-test/v2', [GrammarTestController::class, 'generateV2'])->name('grammar-test-v2.generate');
+    Route::post('/grammar-test-check', [GrammarTestController::class, 'check'])->name('grammar-test.check');
+    Route::get('/grammar-test-autocomplete', [GrammarTestController::class, 'autocomplete'])->name('grammar-test.autocomplete');
+    Route::post('/grammar-test-check-answer', [GrammarTestController::class, 'checkOneAnswer'])->name('grammar-test.checkOne');
+    
+    Route::post('/grammar-test-save', [GrammarTestController::class, 'save'])->name('grammar-test.save');
+    Route::post('/grammar-test-v2-save', [GrammarTestController::class, 'saveV2'])->name('grammar-test-v2.save');
+    Route::post('/test/{slug}/js/state', [GrammarTestController::class, 'storeSavedTestJsState'])->name('saved-test.js.state');
+    Route::get('/test/{slug}/js/questions', [GrammarTestController::class, 'fetchSavedTestJsQuestions'])->name('saved-test.js.questions');
+    Route::get('/test/{slug}/js', [GrammarTestController::class, 'showSavedTestJs'])->name('saved-test.js');
+    Route::get('/test/{slug}/js/step', [GrammarTestController::class, 'showSavedTestJsStep'])->name('saved-test.js.step');
+    Route::get('/test/{slug}/js/manual', [GrammarTestController::class, 'showSavedTestJsManual'])->name('saved-test.js.manual');
+    Route::get('/test/{slug}/js/step/manual', [GrammarTestController::class, 'showSavedTestJsStepManual'])->name('saved-test.js.step-manual');
+    Route::get('/test/{slug}/js/step/input', [GrammarTestController::class, 'showSavedTestJsStepInput'])->name('saved-test.js.step-input');
+    Route::get('/test/{slug}/js/input', [GrammarTestController::class, 'showSavedTestJsInput'])->name('saved-test.js.input');
+    Route::get('/test/{slug}/js/step/select', [GrammarTestController::class, 'showSavedTestJsStepSelect'])->name('saved-test.js.step-select');
+    Route::get('/test/{slug}/js/select', [GrammarTestController::class, 'showSavedTestJsSelect'])->name('saved-test.js.select');
+    Route::get('/test/{slug}/tech', [GrammarTestController::class, 'showSavedTestTech'])->name('saved-test.tech');
+    Route::post('/test/{slug}/questions', [GrammarTestController::class, 'storeSavedTestQuestion'])->name('saved-test.questions.store');
+    Route::delete('/test/{slug}/questions', [GrammarTestController::class, 'deleteAllQuestions'])->name('saved-test.questions.destroy-all');
+    Route::get('/test/{slug}', [GrammarTestController::class, 'showSavedTest'])->name('saved-test.show');
+    Route::get('/test/{slug}/random', [GrammarTestController::class, 'showSavedTestRandom'])->name('saved-test.random');
+    Route::get('/test/{slug}/step', [GrammarTestController::class, 'showSavedTestStep'])->name('saved-test.step');
+    Route::post('/test/{slug}/refresh-description', [GrammarTestController::class, 'refreshDescription'])->name('saved-test.refresh');
+    Route::post('/test/{slug}/refresh-description-gemini', [GrammarTestController::class, 'refreshDescriptionGemini'])->name('saved-test.refresh-gemini');
+    Route::post('/test/{slug}/step/check', [GrammarTestController::class, 'checkSavedTestStep'])->name('saved-test.step.check');
+    Route::post('/test/{slug}/step/reset', [GrammarTestController::class, 'resetSavedTestStep'])->name('saved-test.step.reset');
+    Route::post('/test/{slug}/step/determine-tense', [GrammarTestController::class, 'determineTense'])->name('saved-test.step.determine-tense');
+    Route::post('/test/{slug}/step/determine-tense-gemini', [GrammarTestController::class, 'determineTenseGemini'])->name('saved-test.step.determine-tense-gemini');
+    Route::post('/test/{slug}/step/determine-level', [GrammarTestController::class, 'determineLevel'])->name('saved-test.step.determine-level');
+    Route::post('/test/{slug}/step/determine-level-gemini', [GrammarTestController::class, 'determineLevelGemini'])->name('saved-test.step.determine-level-gemini');
+    Route::post('/test/{slug}/step/set-level', [GrammarTestController::class, 'setLevel'])->name('saved-test.step.set-level');
+    Route::post('/test/{slug}/step/add-tag', [GrammarTestController::class, 'addTag'])->name('saved-test.step.add-tag');
+    Route::delete('/test/{slug}/step/remove-tag', [GrammarTestController::class, 'removeTag'])->name('saved-test.step.remove-tag');
+    Route::delete('/test/{slug}/question/{question}', [GrammarTestController::class, 'deleteQuestion'])->name('saved-test.question.destroy');
+    Route::get('/tests', [\App\Http\Controllers\GrammarTestController::class, 'list'])->name('saved-tests.list');
+    Route::delete('/tests/{slug}', [\App\Http\Controllers\GrammarTestController::class, 'destroy'])->name('saved-tests.destroy');
+    Route::get('/tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('saved-tests.cards');
+    Route::get('/catalog-tests/cards', [\App\Http\Controllers\GrammarTestController::class, 'catalog'])->name('catalog-tests.cards');
+    
+    Route::get('/words', [WordSearchController::class, 'search'])->name('words.search');
+    
+    Route::get('/search', SiteSearchController::class)->name('site.search');
+    
+    Route::get('/ai-test', [AiTestController::class, 'form'])->name('ai-test.form');
+    Route::post('/ai-test/start', [AiTestController::class, 'start'])->name('ai-test.start');
+    Route::get('/ai-test/step', [AiTestController::class, 'step'])->name('ai-test.step');
+    Route::get('/ai-test/next', [AiTestController::class, 'next'])->name('ai-test.next');
+    Route::post('/ai-test/check', [AiTestController::class, 'check'])->name('ai-test.check');
+    Route::post('/ai-test/skip', [AiTestController::class, 'skip'])->name('ai-test.skip');
+    Route::post('/ai-test/reset', [AiTestController::class, 'reset'])->name('ai-test.reset');
+    Route::post('/ai-test/provider', [AiTestController::class, 'provider'])->name('ai-test.provider');
+    Route::post('/ai-test/step/determine-tense', [AiTestController::class, 'determineTense'])->name('ai-test.step.determine-tense');
+    Route::post('/ai-test/step/determine-tense-gemini', [AiTestController::class, 'determineTenseGemini'])->name('ai-test.step.determine-tense-gemini');
+    Route::post('/ai-test/step/determine-level', [AiTestController::class, 'determineLevel'])->name('ai-test.step.determine-level');
+    Route::post('/ai-test/step/determine-level-gemini', [AiTestController::class, 'determineLevelGemini'])->name('ai-test.step.determine-level-gemini');
+    Route::post('/ai-test/step/set-level', [AiTestController::class, 'setLevel'])->name('ai-test.step.set-level');
+    Route::post('/ai-test/step/add-tag', [AiTestController::class, 'addTag'])->name('ai-test.step.add-tag');
+    Route::delete('/ai-test/step/remove-tag', [AiTestController::class, 'removeTag'])->name('ai-test.step.remove-tag');
+    
+    Route::get('/question-review', [QuestionReviewController::class, 'index'])->name('question-review.index');
+    Route::post('/question-review', [QuestionReviewController::class, 'store'])->name('question-review.store');
+    Route::get('/question-review/{question}', [QuestionReviewController::class, 'edit'])->name('question-review.edit');
+    
+    Route::get('/question-review-results', [QuestionReviewResultController::class, 'index'])->name('question-review-results.index');
+    
+    Route::post('/verb-hints', [VerbHintController::class, 'store'])->name('verb-hints.store');
+    Route::put('/verb-hints/{verbHint}', [VerbHintController::class, 'update'])->name('verb-hints.update');
+    Route::delete('/verb-hints/{verbHint}', [VerbHintController::class, 'destroy'])->name('verb-hints.destroy');
+    Route::put('/questions/{question}', [QuestionController::class, 'update'])->name('questions.update');
+    Route::post('/questions/{question}/export', [QuestionController::class, 'export'])->name('questions.export');
+    Route::post('/questions/export/by-uuid', [QuestionController::class, 'exportByUuid'])->name('questions.export-by-uuid');
+    Route::post('/questions/restore/from-dumps', [QuestionController::class, 'restoreFromDumps'])->name('questions.restore-from-dumps');
+    Route::post('/questions/restore/by-uuid', [QuestionController::class, 'restoreByUuid'])->name('questions.restore-by-uuid');
+    Route::post('/question-answers', [QuestionAnswerController::class, 'store'])->name('question-answers.store');
+    Route::put('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'update'])->name('question-answers.update');
+    Route::delete('/question-answers/{questionAnswer}', [QuestionAnswerController::class, 'destroy'])->name('question-answers.destroy');
+    Route::post('/questions/{question}/options', [QuestionOptionController::class, 'store'])->name('questions.options.store');
+    Route::put('/questions/{question}/options/{option}', [QuestionOptionController::class, 'update'])->name('questions.options.update');
+    Route::delete('/questions/{question}/options/{option}', [QuestionOptionController::class, 'destroy'])->name('questions.options.destroy');
+    Route::put('/question-variants/{questionVariant}', [QuestionVariantController::class, 'update'])->name('question-variants.update');
+    Route::delete('/question-variants/{questionVariant}', [QuestionVariantController::class, 'destroy'])->name('question-variants.destroy');
+    Route::post('/question-hints', [QuestionHintController::class, 'store'])->name('question-hints.store');
+    Route::put('/question-hints/{questionHint}', [QuestionHintController::class, 'update'])->name('question-hints.update');
+    Route::delete('/question-hints/{questionHint}', [QuestionHintController::class, 'destroy'])->name('question-hints.destroy');
+    Route::post('/chatgpt-explanations', [ChatGPTExplanationController::class, 'store'])->name('chatgpt-explanations.store');
+    Route::delete('/chatgpt-explanations/{chatGPTExplanation}', [ChatGPTExplanationController::class, 'destroy'])->name('chatgpt-explanations.destroy');
+    
+    Route::post('/question-hint', [QuestionHelpController::class, 'hint'])->name('question.hint');
+    Route::post('/question-explain', [QuestionHelpController::class, 'explain'])->name('question.explain');
+});


### PR DESCRIPTION
## Summary
- add the FirstConditionalFutureFormsAiSeeder to generate 24-question first-conditional future tense practice sets for each CEFR level with structured hints and explanations
- register the new AI seeder in DatabaseSeeder so it runs with the rest of the suite

## Testing
- php -l database/seeders/Ai/FirstConditionalFutureFormsAiSeeder.php
- php -l database/seeders/DatabaseSeeder.php

------
https://chatgpt.com/codex/tasks/task_e_68dc2ee258bc832ab644077fcb2f1393