### PR TITLE
Align page seeder namespaces with folder casing

### DIFF
--- a/database/seeders/Ai/FirstConditionalAiFormsV2Seeder.php
+++ b/database/seeders/Ai/FirstConditionalAiFormsV2Seeder.php
@@ -1,0 +1,342 @@
+<?php
+
+namespace Database\Seeders\Ai;
+
+use App\Models\Category;
+use App\Models\Source;
+use App\Models\Tag;
+use Database\Seeders\QuestionSeeder;
+use JsonException;
+
+class FirstConditionalAiFormsV2Seeder extends QuestionSeeder
+{
+    public function run(): void
+    {
+        $categoryId = Category::firstOrCreate(['name' => 'Conditionals'])->id;
+
+        $sourceMap = [
+            'negative_past' => Source::firstOrCreate(['name' => 'AI: First Conditional Negative — Past Context'])->id,
+            'negative_present' => Source::firstOrCreate(['name' => 'AI: First Conditional Negative — Present Context'])->id,
+            'negative_future' => Source::firstOrCreate(['name' => 'AI: First Conditional Negative — Future Context'])->id,
+            'interrogative_past' => Source::firstOrCreate(['name' => 'AI: First Conditional Questions — Past Context'])->id,
+            'interrogative_present' => Source::firstOrCreate(['name' => 'AI: First Conditional Questions — Present Context'])->id,
+            'interrogative_future' => Source::firstOrCreate(['name' => 'AI: First Conditional Questions — Future Context'])->id,
+        ];
+
+        $themeTagId = Tag::firstOrCreate(
+            ['name' => 'First Conditional Practice'],
+            ['category' => 'English Grammar Theme']
+        )->id;
+
+        $structureTagId = Tag::firstOrCreate(
+            ['name' => 'First Conditional Sentences'],
+            ['category' => 'English Grammar Structure']
+        )->id;
+
+        $tenseTagId = Tag::firstOrCreate(['name' => 'First Conditional'], ['category' => 'Tenses'])->id;
+
+        $levelDifficulty = [
+            'A1' => 1,
+            'A2' => 2,
+            'B1' => 3,
+            'B2' => 4,
+            'C1' => 5,
+            'C2' => 5,
+        ];
+
+        $dataPath = __DIR__ . '/data/first_conditional_ai_forms.json';
+        $json = file_get_contents($dataPath);
+
+        if ($json === false) {
+            return;
+        }
+
+        try {
+            $questions = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            return;
+        }
+
+        if (! is_array($questions) || $questions === []) {
+            return;
+        }
+
+        $items = [];
+        $meta = [];
+
+        foreach ($questions as $index => $question) {
+            $answersMap = [];
+            foreach ($question['answers'] as $marker => $value) {
+                $answersMap[$marker] = $this->normalizeValue($value);
+            }
+
+            $optionSets = $this->prepareOptionSets($question['options'], $answersMap);
+            $flattenedOptions = $this->flattenOptions($optionSets);
+
+            $verbHints = [];
+            foreach ($answersMap as $marker => $value) {
+                $hintSource = $question['verb_hint'][$marker] ?? null;
+                $verbHints[$marker] = $this->normalizeHint($hintSource);
+            }
+
+            $example = $this->buildExample($question['question'], $answersMap);
+
+            $answers = [];
+            foreach ($answersMap as $marker => $answer) {
+                $answers[] = [
+                    'marker' => $marker,
+                    'answer' => $answer,
+                    'verb_hint' => $verbHints[$marker] ?? null,
+                ];
+            }
+
+            $hints = [];
+            $explanations = [];
+            $optionMarkerMap = [];
+
+            foreach ($optionSets as $marker => $options) {
+                foreach ($options as $option) {
+                    if (! isset($optionMarkerMap[$option])) {
+                        $optionMarkerMap[$option] = $marker;
+                    }
+                }
+
+                $clauseType = $this->detectClauseType($question['question'], $marker);
+                $hints[$marker] = $this->buildHintForClause($clauseType, $verbHints[$marker] ?? null, $example);
+
+                $explanations = array_merge(
+                    $explanations,
+                    $this->buildExplanationsForClause(
+                        $clauseType,
+                        $options,
+                        $answersMap[$marker],
+                        $example
+                    )
+                );
+            }
+
+            $tagIds = [$themeTagId, $structureTagId, $tenseTagId];
+            foreach ($question['tense'] as $tenseName) {
+                $tagIds[] = Tag::firstOrCreate(['name' => $tenseName], ['category' => 'Tenses'])->id;
+            }
+
+            $uuid = $this->generateQuestionUuid($index + 1, $question['question']);
+
+            $items[] = [
+                'uuid' => $uuid,
+                'question' => $question['question'],
+                'category_id' => $categoryId,
+                'difficulty' => $levelDifficulty[$question['level']] ?? 3,
+                'source_id' => $sourceMap[$question['source_key']] ?? null,
+                'flag' => 2,
+                'level' => $question['level'],
+                'tag_ids' => array_values(array_unique($tagIds)),
+                'answers' => $answers,
+                'options' => $flattenedOptions,
+                'variants' => [$question['question']],
+            ];
+
+            $meta[] = [
+                'uuid' => $uuid,
+                'answers' => $answersMap,
+                'option_markers' => $optionMarkerMap,
+                'hints' => $hints,
+                'explanations' => $explanations,
+            ];
+        }
+
+        $this->seedQuestionData($items, $meta);
+    }
+
+    private function prepareOptionSets(array $options, array $answers): array
+    {
+        if ($this->isAssoc($options)) {
+            $result = [];
+            foreach ($options as $marker => $choices) {
+                $result[$marker] = array_map(fn ($value) => $this->normalizeValue((string) $value), (array) $choices);
+            }
+
+            return $result;
+        }
+
+        $marker = array_key_first($answers);
+        if ($marker === null) {
+            return [];
+        }
+
+        return [
+            $marker => array_map(fn ($value) => $this->normalizeValue((string) $value), $options),
+        ];
+    }
+
+    private function flattenOptions(array $optionSets): array
+    {
+        $all = [];
+        foreach ($optionSets as $options) {
+            foreach ($options as $option) {
+                $all[] = $option;
+            }
+        }
+
+        return array_values(array_unique($all));
+    }
+
+    private function detectClauseType(string $question, string $marker): string
+    {
+        $placeholder = '{' . $marker . '}';
+        $position = mb_stripos($question, $placeholder);
+
+        if ($position === false) {
+            return 'result';
+        }
+
+        $before = mb_substr($question, 0, $position);
+        $beforeLower = mb_strtolower($before);
+
+        if (mb_strripos($beforeLower, 'if') !== false) {
+            return 'condition';
+        }
+
+        return 'result';
+    }
+
+    private function buildHintForClause(string $clauseType, ?string $verbHint, string $example): string
+    {
+        $base = $clauseType === 'condition'
+            ? 'If-clause → Present Simple/Perfect (без will).'
+            : "Main clause → will/won't + V1 для результату.";
+
+        if ($verbHint) {
+            $base .= ' Дієслово: ' . $verbHint . '.';
+        }
+
+        return $base . ' Приклад: *' . $example . '*.';
+    }
+
+    private function buildExplanationsForClause(string $clauseType, array $options, string $answer, string $example): array
+    {
+        $result = [];
+        foreach ($options as $option) {
+            if ($option === $answer) {
+                $result[$option] = $this->buildCorrectExplanation($clauseType, $option, $example);
+            } else {
+                $result[$option] = $this->buildWrongExplanation($clauseType, $option, $answer, $example);
+            }
+        }
+
+        return $result;
+    }
+
+    private function buildCorrectExplanation(string $clauseType, string $answer, string $example): string
+    {
+        if ($clauseType === 'condition') {
+            return '✅ «' . $answer . '» — доречна форма теперішнього часу в частині з if. Приклад: *' . $example . '*.';
+        }
+
+        return '✅ «' . $answer . '» — правильна форма will/won\'t у головному реченні. Приклад: *' . $example . '*.';
+    }
+
+    private function buildWrongExplanation(string $clauseType, string $option, string $answer, string $example): string
+    {
+        $type = $this->classifyOption($option);
+
+        if ($clauseType === 'condition') {
+            return match ($type) {
+                'future' => '❌ У підрядній частині першого умовного не вживаємо will/won\'t. Приклад: *' . $example . '*.',
+                'continuous' => '❌ If-clause вимагає просту форму, а не тривалий час. Правильний приклад: *' . $example . '*.',
+                'past' => '❌ Перший умовний використовує теперішні форми після if, не минулий час. Приклад: *' . $example . '*.',
+                'perfect' => '❌ Вживаємо без have + V3, якщо потрібно Present Simple. Орієнтуйся на приклад: *' . $example . '*.',
+                default => '❌ Спробуй просту теперішню форму в if-clause. Правильний приклад: *' . $example . '*.',
+            };
+        }
+
+        if ($type === 'future' && $this->isFullNegativeVariant($option, $answer)) {
+            return '❌ «' . $option . '» граматично можливо, але потрібно коротка форма «' . $answer . '». Приклад: *' . $example . '*.';
+        }
+
+        return match ($type) {
+            'future' => '❌ Варіант «' . $option . '» не відповідає моделі will/won\'t + V1. Подивись: *' . $example . '*.',
+            'continuous' => '❌ У головному реченні потрібна форма will + V1, а не тривалий час. Правильний приклад: *' . $example . '*.',
+            'do' => '❌ Заперечення з do/does не пасує; потрібна конструкція з will. Подивись на приклад: *' . $example . '*.',
+            'past' => '❌ Результат першого умовного будується через will, не минулий час. Приклад: *' . $example . '*.',
+            'perfect' => '❌ Не використовуй have + V3 у результаті; краще will + V1. Приклад: *' . $example . '*.',
+            'be_negative' => '❌ Краще вжити will/won\'t + be, як у прикладі: *' . $example . '*.',
+            default => '❌ Основне речення має містити will або won\'t. Орієнтуйся на приклад: *' . $example . '*.',
+        };
+    }
+
+    private function classifyOption(string $option): string
+    {
+        $value = mb_strtolower($option);
+
+        if (str_contains($value, 'will have')) {
+            return 'perfect';
+        }
+
+        if (str_contains($value, "won't") || preg_match('/\bwill\b/', $value)) {
+            return 'future';
+        }
+
+        if (preg_match('/\b(am|is|are|was|were)\b[^a-z]*[a-z]+ing/', $value)) {
+            return 'continuous';
+        }
+
+        if (preg_match('/\b(did|was|were)\b/', $value)) {
+            return 'past';
+        }
+
+        if (preg_match("/\b(do|does|don't|doesn't)\b/", $value)) {
+            return 'do';
+        }
+
+        if (preg_match("/\b(has|have|had)\b/", $value)) {
+            return 'perfect';
+        }
+
+        if (preg_match("/\b(isn't|aren't)\b/", $value)) {
+            return 'be_negative';
+        }
+
+        return 'present_simple';
+    }
+
+    private function isFullNegativeVariant(string $option, string $answer): bool
+    {
+        $optionNormalized = str_replace(' ', '', mb_strtolower($option));
+        $answerNormalized = str_replace(' ', '', mb_strtolower($answer));
+
+        return str_contains($optionNormalized, 'willnot') && str_contains($answerNormalized, "won't");
+    }
+
+    private function buildExample(string $question, array $answers): string
+    {
+        $result = $question;
+        foreach ($answers as $marker => $answer) {
+            $result = str_replace('{' . $marker . '}', $answer, $result);
+        }
+
+        $result = preg_replace('/\s+/', ' ', trim($result));
+
+        $first = mb_substr($result, 0, 1, 'UTF-8');
+        $rest = mb_substr($result, 1, null, 'UTF-8');
+
+        return mb_strtoupper($first, 'UTF-8') . $rest;
+    }
+
+    private function normalizeValue(string $value): string
+    {
+        $value = str_replace(['’', '‘', '‛', 'ʻ'], "'", $value);
+        $value = preg_replace('/\s+/', ' ', $value);
+
+        return trim($value);
+    }
+
+    private function isAssoc(array $array): bool
+    {
+        if ($array === []) {
+            return false;
+        }
+
+        return array_keys($array) !== range(0, count($array) - 1);
+    }
+}

--- a/database/seeders/Ai/data/first_conditional_ai_forms.json
+++ b/database/seeders/Ai/data/first_conditional_ai_forms.json
@@ -1,0 +1,3026 @@
+[
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If Mia {a1} her keys since yesterday, she won't panic before school.",
+    "answers": {
+      "a1": "hasn't lost"
+    },
+    "options": [
+      "hasn't lost",
+      "didn't lose",
+      "won't lose"
+    ],
+    "verb_hint": {
+      "a1": "(not lose)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the kids {a1} their lunchboxes since the trip, they won't feel hungry today.",
+    "answers": {
+      "a1": "haven't misplaced"
+    },
+    "options": [
+      "haven't misplaced",
+      "didn't misplace",
+      "won't misplace"
+    ],
+    "verb_hint": {
+      "a1": "(not misplace)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If our dog {a1} his collar since last weekend, we won't search for a new one.",
+    "answers": {
+      "a1": "hasn't chewed"
+    },
+    "options": [
+      "hasn't chewed",
+      "didn't chew",
+      "won't chew"
+    ],
+    "verb_hint": {
+      "a1": "(not chew)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If Ben {a1} his homework since Monday, he won't worry tonight.",
+    "answers": {
+      "a1": "hasn't forgotten"
+    },
+    "options": [
+      "hasn't forgotten",
+      "didn't forget",
+      "won't forget"
+    ],
+    "verb_hint": {
+      "a1": "(not forget)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If Lisa {a1} her music too loudly today, the baby will sleep better.",
+    "answers": {
+      "a1": "doesn't play"
+    },
+    "options": [
+      "doesn't play",
+      "didn't play",
+      "won't play"
+    ],
+    "verb_hint": {
+      "a1": "(not play)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If you {a1} breakfast in the mornings, you will feel tired in class.",
+    "answers": {
+      "a1": "don't eat"
+    },
+    "options": [
+      "don't eat",
+      "didn't eat",
+      "won't eat"
+    ],
+    "verb_hint": {
+      "a1": "(not eat)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the bus {a1} late today, we will arrive on time.",
+    "answers": {
+      "a1": "doesn't arrive"
+    },
+    "options": [
+      "doesn't arrive",
+      "didn't arrive",
+      "won't arrive"
+    ],
+    "verb_hint": {
+      "a1": "(not arrive)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If Mark {a1} his coat at school, he will stay warm outside.",
+    "answers": {
+      "a1": "doesn't forget"
+    },
+    "options": [
+      "doesn't forget",
+      "didn't forget",
+      "won't forget"
+    ],
+    "verb_hint": {
+      "a1": "(not forget)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If you pack the snacks, we {a1} late for the picnic tomorrow.",
+    "answers": {
+      "a1": "won't be"
+    },
+    "options": [
+      "won't be",
+      "aren't",
+      "weren't"
+    ],
+    "verb_hint": {
+      "a1": "(be)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If they tidy the room tonight, their parents {a1} upset in the morning.",
+    "answers": {
+      "a1": "won't be"
+    },
+    "options": [
+      "won't be",
+      "aren't",
+      "weren't"
+    ],
+    "verb_hint": {
+      "a1": "(be)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If I finish my homework early, I {a1} stay up too late tomorrow.",
+    "answers": {
+      "a1": "won't have to"
+    },
+    "options": [
+      "won't have to",
+      "don't have",
+      "didn't have to"
+    ],
+    "verb_hint": {
+      "a1": "(not have to)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If Nina brings extra water, the team {a1} worry about the heat tomorrow.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "doesn't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the courier {a1} since yesterday, will the office open the packages now?",
+    "answers": {
+      "a1": "has arrived"
+    },
+    "options": [
+      "has arrived",
+      "arrived",
+      "will arrive"
+    ],
+    "verb_hint": {
+      "a1": "(arrive)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the coach {a1} the plan since Monday, will the team follow it today?",
+    "answers": {
+      "a1": "has updated"
+    },
+    "options": [
+      "has updated",
+      "updated",
+      "will update"
+    ],
+    "verb_hint": {
+      "a1": "(update)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If Emma {a1} her lines since last week, will the play start on time?",
+    "answers": {
+      "a1": "has practised"
+    },
+    "options": [
+      "has practised",
+      "practised",
+      "will practise"
+    ],
+    "verb_hint": {
+      "a1": "(practice)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the baker {a1} enough bread this morning, will the shop open early?",
+    "answers": {
+      "a1": "has baked"
+    },
+    "options": [
+      "has baked",
+      "baked",
+      "will bake"
+    ],
+    "verb_hint": {
+      "a1": "(bake)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If Leo {a1} his chores today, will his dad let him play games?",
+    "answers": {
+      "a1": "finishes"
+    },
+    "options": [
+      "finishes",
+      "finished",
+      "will finish"
+    ],
+    "verb_hint": {
+      "a1": "(finish)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the bus {a1} on time today, will we reach class before the bell?",
+    "answers": {
+      "a1": "arrives"
+    },
+    "options": [
+      "arrives",
+      "arrived",
+      "will arrive"
+    ],
+    "verb_hint": {
+      "a1": "(arrive)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If you {a1} the answer now, will you tell the group?",
+    "answers": {
+      "a1": "know"
+    },
+    "options": [
+      "know",
+      "knew",
+      "will know"
+    ],
+    "verb_hint": {
+      "a1": "(know)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If Sara {a1} the door today, will the cat stay inside?",
+    "answers": {
+      "a1": "closes"
+    },
+    "options": [
+      "closes",
+      "closed",
+      "will close"
+    ],
+    "verb_hint": {
+      "a1": "(close)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If they start early tomorrow, will the group {a1} by noon?",
+    "answers": {
+      "a1": "finish"
+    },
+    "options": [
+      "finish",
+      "finished",
+      "will finish"
+    ],
+    "verb_hint": {
+      "a1": "(finish)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If I bring snacks tomorrow, will your friends {a1} them after practice?",
+    "answers": {
+      "a1": "share"
+    },
+    "options": [
+      "share",
+      "shared",
+      "will share"
+    ],
+    "verb_hint": {
+      "a1": "(share)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If we arrive before the gates open tomorrow, will the guide {a1} us inside?",
+    "answers": {
+      "a1": "let"
+    },
+    "options": [
+      "let",
+      "let in",
+      "will let"
+    ],
+    "verb_hint": {
+      "a1": "(let)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If Nina brings her violin tomorrow, will the band {a1} a new song?",
+    "answers": {
+      "a1": "play"
+    },
+    "options": [
+      "play",
+      "played",
+      "will play"
+    ],
+    "verb_hint": {
+      "a1": "(play)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If Clara {a1} any rehearsals since last week, she won't feel nervous tonight.",
+    "answers": {
+      "a1": "hasn't missed"
+    },
+    "options": [
+      "hasn't missed",
+      "didn't miss",
+      "won't miss"
+    ],
+    "verb_hint": {
+      "a1": "(not miss)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the volunteers {a1} the flyers since yesterday, the event won't start late.",
+    "answers": {
+      "a1": "haven't forgotten"
+    },
+    "options": [
+      "haven't forgotten",
+      "didn't forget",
+      "won't forget"
+    ],
+    "verb_hint": {
+      "a1": "(not forget)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If our neighbours {a1} their car since Monday, we won't have to park farther away.",
+    "answers": {
+      "a1": "haven't moved"
+    },
+    "options": [
+      "haven't moved",
+      "didn't move",
+      "won't move"
+    ],
+    "verb_hint": {
+      "a1": "(not move)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the chef {a1} the soup recipe since last month, the taste won't surprise anyone.",
+    "answers": {
+      "a1": "hasn't changed"
+    },
+    "options": [
+      "hasn't changed",
+      "didn't change",
+      "won't change"
+    ],
+    "verb_hint": {
+      "a1": "(not change)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If your team {a1} the rules today, the referee will stay calm.",
+    "answers": {
+      "a1": "doesn't break"
+    },
+    "options": [
+      "doesn't break",
+      "didn't break",
+      "won't break"
+    ],
+    "verb_hint": {
+      "a1": "(not break)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the children {a1} their helmets on the ride, their parents will worry.",
+    "answers": {
+      "a1": "don't wear"
+    },
+    "options": [
+      "don't wear",
+      "didn't wear",
+      "won't wear"
+    ],
+    "verb_hint": {
+      "a1": "(not wear)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If we {a1} the door tonight, the wind will blow in.",
+    "answers": {
+      "a1": "don't lock"
+    },
+    "options": [
+      "don't lock",
+      "didn't lock",
+      "won't lock"
+    ],
+    "verb_hint": {
+      "a1": "(not lock)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If Marta {a1} the directions carefully, she will get lost.",
+    "answers": {
+      "a1": "doesn't read"
+    },
+    "options": [
+      "doesn't read",
+      "didn't read",
+      "won't read"
+    ],
+    "verb_hint": {
+      "a1": "(not read)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If you call ahead, the manager {a1} confused about your booking tomorrow.",
+    "answers": {
+      "a1": "won't be"
+    },
+    "options": [
+      "won't be",
+      "isn't",
+      "wasn't"
+    ],
+    "verb_hint": {
+      "a1": "(be)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the gardeners water the new plants, they {a1} wilt in the heat next week.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "don't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If I print the schedule tonight, I {a1} search for it in the morning.",
+    "answers": {
+      "a1": "won't have to"
+    },
+    "options": [
+      "won't have to",
+      "don't have",
+      "didn't have to"
+    ],
+    "verb_hint": {
+      "a1": "(not have to)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the train arrives early, we {a1} miss our connection tomorrow.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "don't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the museum {a1} its doors earlier today, will the queue move faster now?",
+    "answers": {
+      "a1": "has opened"
+    },
+    "options": [
+      "has opened",
+      "opened",
+      "will open"
+    ],
+    "verb_hint": {
+      "a1": "(open)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If Diego {a1} his assignment since Monday, will the teacher praise him today?",
+    "answers": {
+      "a1": "has completed"
+    },
+    "options": [
+      "has completed",
+      "completed",
+      "will complete"
+    ],
+    "verb_hint": {
+      "a1": "(complete)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the nurses {a1} extra masks since yesterday, will the ward run smoothly?",
+    "answers": {
+      "a1": "have prepared"
+    },
+    "options": [
+      "have prepared",
+      "prepared",
+      "will prepare"
+    ],
+    "verb_hint": {
+      "a1": "(prepare)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If Lena {a1} her speech since last week, will the audience enjoy it tonight?",
+    "answers": {
+      "a1": "has rehearsed"
+    },
+    "options": [
+      "has rehearsed",
+      "rehearsed",
+      "will rehearse"
+    ],
+    "verb_hint": {
+      "a1": "(rehearse)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the library {a1} the new study room today, will students use it this afternoon?",
+    "answers": {
+      "a1": "opens"
+    },
+    "options": [
+      "opens",
+      "opened",
+      "will open"
+    ],
+    "verb_hint": {
+      "a1": "(open)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If you {a1} the train on time today, will you message me?",
+    "answers": {
+      "a1": "catch"
+    },
+    "options": [
+      "catch",
+      "caught",
+      "will catch"
+    ],
+    "verb_hint": {
+      "a1": "(catch)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the weather {a1} better today, will the coach start practice outside?",
+    "answers": {
+      "a1": "stays"
+    },
+    "options": [
+      "stays",
+      "stayed",
+      "will stay"
+    ],
+    "verb_hint": {
+      "a1": "(stay)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If Amir {a1} his chores now, will his sister help later?",
+    "answers": {
+      "a1": "finishes"
+    },
+    "options": [
+      "finishes",
+      "finished",
+      "will finish"
+    ],
+    "verb_hint": {
+      "a1": "(finish)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If we submit the draft tomorrow, will the editor {a1} feedback by Friday?",
+    "answers": {
+      "a1": "send"
+    },
+    "options": [
+      "send",
+      "sent",
+      "will send"
+    ],
+    "verb_hint": {
+      "a1": "(send)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If Laura brings her guitar tomorrow, will the group {a1} a new arrangement?",
+    "answers": {
+      "a1": "try"
+    },
+    "options": [
+      "try",
+      "tried",
+      "will try"
+    ],
+    "verb_hint": {
+      "a1": "(try)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If they arrive at the airport early tomorrow, will security {a1} them through quickly?",
+    "answers": {
+      "a1": "let"
+    },
+    "options": [
+      "let",
+      "let in",
+      "will let"
+    ],
+    "verb_hint": {
+      "a1": "(let)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "A2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If the chef tests the menu tomorrow, will the diners {a1} the specials next week?",
+    "answers": {
+      "a1": "enjoy"
+    },
+    "options": [
+      "enjoy",
+      "enjoyed",
+      "will enjoy"
+    ],
+    "verb_hint": {
+      "a1": "(enjoy)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the marketing team {a1} the campaign since last month, the launch won't face delays.",
+    "answers": {
+      "a1": "hasn't revised"
+    },
+    "options": [
+      "hasn't revised",
+      "didn't revise",
+      "won't revise"
+    ],
+    "verb_hint": {
+      "a1": "(not revise)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the interns {a1} their reports since Monday, the manager won't call a late meeting.",
+    "answers": {
+      "a1": "haven't skipped"
+    },
+    "options": [
+      "haven't skipped",
+      "didn't skip",
+      "won't skip"
+    ],
+    "verb_hint": {
+      "a1": "(not skip)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the technicians {a1} the lights on since yesterday, the bill won't shock us.",
+    "answers": {
+      "a1": "haven't left"
+    },
+    "options": [
+      "haven't left",
+      "didn't leave",
+      "won't leave"
+    ],
+    "verb_hint": {
+      "a1": "(not leave)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the committee {a1} any files since the audit, the review won't stall this week.",
+    "answers": {
+      "a1": "hasn't lost"
+    },
+    "options": [
+      "hasn't lost",
+      "didn't lose",
+      "won't lose"
+    ],
+    "verb_hint": {
+      "a1": "(not lose)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the speaker {a1} the slides clear today, the audience will lose interest.",
+    "answers": {
+      "a1": "doesn't keep"
+    },
+    "options": [
+      "doesn't keep",
+      "didn't keep",
+      "won't keep"
+    ],
+    "verb_hint": {
+      "a1": "(not keep)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If you {a1} your files now, the system will erase them.",
+    "answers": {
+      "a1": "don't save"
+    },
+    "options": [
+      "don't save",
+      "didn't save",
+      "won't save"
+    ],
+    "verb_hint": {
+      "a1": "(not save)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the council {a1} the budget today, investors will hesitate.",
+    "answers": {
+      "a1": "doesn't approve"
+    },
+    "options": [
+      "doesn't approve",
+      "didn't approve",
+      "won't approve"
+    ],
+    "verb_hint": {
+      "a1": "(not approve)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the chef {a1} the sauce today, the dish will taste bland.",
+    "answers": {
+      "a1": "doesn't taste"
+    },
+    "options": [
+      "doesn't taste",
+      "didn't taste",
+      "won't taste"
+    ],
+    "verb_hint": {
+      "a1": "(not taste)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the engineers test the bridge tomorrow, it {a1} close for maintenance next week.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "doesn't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If you send the invoice tonight, the client {a1} question the charges tomorrow.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "doesn't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the volunteers finish early, they {a1} stay in the hall all evening.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "don't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If we confirm the hotel today, we {a1} hunt for rooms tomorrow.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "don't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the analysts {a1} the data since yesterday, will the board review it tonight?",
+    "answers": {
+      "a1": "have gathered"
+    },
+    "options": [
+      "have gathered",
+      "gathered",
+      "will gather"
+    ],
+    "verb_hint": {
+      "a1": "(gather)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the editor {a1} the facts since Monday, will the article go live today?",
+    "answers": {
+      "a1": "has checked"
+    },
+    "options": [
+      "has checked",
+      "checked",
+      "will check"
+    ],
+    "verb_hint": {
+      "a1": "(check)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the scientists {a1} the sensors since last week, will the experiment start on time?",
+    "answers": {
+      "a1": "have calibrated"
+    },
+    "options": [
+      "have calibrated",
+      "calibrated",
+      "will calibrate"
+    ],
+    "verb_hint": {
+      "a1": "(calibrate)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the musicians {a1} the new arrangement since last weekend, will the concert sound polished tonight?",
+    "answers": {
+      "a1": "have practised"
+    },
+    "options": [
+      "have practised",
+      "practised",
+      "will practise"
+    ],
+    "verb_hint": {
+      "a1": "(practice)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the driver {a1} at the station on time today, will the commuters catch the connection?",
+    "answers": {
+      "a1": "arrives"
+    },
+    "options": [
+      "arrives",
+      "arrived",
+      "will arrive"
+    ],
+    "verb_hint": {
+      "a1": "(arrive)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If you {a1} the door closed today, will the room stay warm?",
+    "answers": {
+      "a1": "keep"
+    },
+    "options": [
+      "keep",
+      "kept",
+      "will keep"
+    ],
+    "verb_hint": {
+      "a1": "(keep)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the manager {a1} the schedule today, will the team relax?",
+    "answers": {
+      "a1": "approves"
+    },
+    "options": [
+      "approves",
+      "approved",
+      "will approve"
+    ],
+    "verb_hint": {
+      "a1": "(approve)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the students {a1} their drafts today, will the tutor send feedback tomorrow?",
+    "answers": {
+      "a1": "submit"
+    },
+    "options": [
+      "submit",
+      "submitted",
+      "will submit"
+    ],
+    "verb_hint": {
+      "a1": "(submit)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If we deliver the prototype tomorrow, will the investor {a1} the agreement next week?",
+    "answers": {
+      "a1": "sign"
+    },
+    "options": [
+      "sign",
+      "signed",
+      "will sign"
+    ],
+    "verb_hint": {
+      "a1": "(sign)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If the weather clears tomorrow, will the pilots {a1} the flights?",
+    "answers": {
+      "a1": "resume"
+    },
+    "options": [
+      "resume",
+      "resumed",
+      "will resume"
+    ],
+    "verb_hint": {
+      "a1": "(resume)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If Mira sends the invitations tomorrow, will the guests {a1} their seats by Friday?",
+    "answers": {
+      "a1": "confirm"
+    },
+    "options": [
+      "confirm",
+      "confirmed",
+      "will confirm"
+    ],
+    "verb_hint": {
+      "a1": "(confirm)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If the software passes testing tomorrow, will the company {a1} the update on Monday?",
+    "answers": {
+      "a1": "release"
+    },
+    "options": [
+      "release",
+      "released",
+      "will release"
+    ],
+    "verb_hint": {
+      "a1": "(release)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the research team {a1} any variables since the trial began, the results won't be questioned.",
+    "answers": {
+      "a1": "hasn't overlooked"
+    },
+    "options": [
+      "hasn't overlooked",
+      "didn't overlook",
+      "won't overlook"
+    ],
+    "verb_hint": {
+      "a1": "(not overlook)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the logistics crew {a1} shipments this quarter, the warehouse won't escalate the issue.",
+    "answers": {
+      "a1": "haven't misrouted"
+    },
+    "options": [
+      "haven't misrouted",
+      "didn't misroute",
+      "won't misroute"
+    ],
+    "verb_hint": {
+      "a1": "(not misroute)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the finance department {a1} the audit files since last week, the board won't postpone the vote.",
+    "answers": {
+      "a1": "hasn't delayed"
+    },
+    "options": [
+      "hasn't delayed",
+      "didn't delay",
+      "won't delay"
+    ],
+    "verb_hint": {
+      "a1": "(not delay)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the curator {a1} the exhibit layout since the preview, the guide won't rewrite her notes.",
+    "answers": {
+      "a1": "hasn't altered"
+    },
+    "options": [
+      "hasn't altered",
+      "didn't alter",
+      "won't alter"
+    ],
+    "verb_hint": {
+      "a1": "(not alter)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the contractor {a1} with the safety checklist today, the inspectors will shut the site.",
+    "answers": {
+      "a1": "doesn't comply"
+    },
+    "options": [
+      "doesn't comply",
+      "didn't comply",
+      "won't comply"
+    ],
+    "verb_hint": {
+      "a1": "(not comply)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the trainees {a1} the updated protocol, the supervisor will intervene.",
+    "answers": {
+      "a1": "don't follow"
+    },
+    "options": [
+      "don't follow",
+      "didn't follow",
+      "won't follow"
+    ],
+    "verb_hint": {
+      "a1": "(not follow)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the consultant {a1} client emails today, the partnership will suffer.",
+    "answers": {
+      "a1": "doesn't answer"
+    },
+    "options": [
+      "doesn't answer",
+      "didn't answer",
+      "won't answer"
+    ],
+    "verb_hint": {
+      "a1": "(not answer)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the lab assistants {a1} the scales today, the measurements will be unreliable.",
+    "answers": {
+      "a1": "don't calibrate"
+    },
+    "options": [
+      "don't calibrate",
+      "didn't calibrate",
+      "won't calibrate"
+    ],
+    "verb_hint": {
+      "a1": "(not calibrate)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the programmers deploy the patch tonight, users {a1} encounter the glitch tomorrow.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "don't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If we sign the vendor agreement today, we {a1} renegotiate fees next month.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "don't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the airlines confirm the schedule tomorrow, passengers {a1} seek refunds next week.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "don't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the festival secures sponsorship today, it {a1} cancel headline acts later.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "doesn't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the auditors {a1} the contracts since Monday, will the merger finalize this week?",
+    "answers": {
+      "a1": "have reviewed"
+    },
+    "options": [
+      "have reviewed",
+      "reviewed",
+      "will review"
+    ],
+    "verb_hint": {
+      "a1": "(review)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the design team {a1} revisions since yesterday, will the client approve them tonight?",
+    "answers": {
+      "a1": "has submitted"
+    },
+    "options": [
+      "has submitted",
+      "submitted",
+      "will submit"
+    ],
+    "verb_hint": {
+      "a1": "(submit)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the engineers {a1} the sensors since the last storm, will the dam hold safely now?",
+    "answers": {
+      "a1": "have monitored"
+    },
+    "options": [
+      "have monitored",
+      "monitored",
+      "will monitor"
+    ],
+    "verb_hint": {
+      "a1": "(monitor)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the negotiators {a1} the terms since the last session, will the partners sign today?",
+    "answers": {
+      "a1": "have clarified"
+    },
+    "options": [
+      "have clarified",
+      "clarified",
+      "will clarify"
+    ],
+    "verb_hint": {
+      "a1": "(clarify)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the moderator {a1} the debate respectful today, will viewers stay tuned?",
+    "answers": {
+      "a1": "keeps"
+    },
+    "options": [
+      "keeps",
+      "kept",
+      "will keep"
+    ],
+    "verb_hint": {
+      "a1": "(keep)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the shareholders {a1} the motion today, will the board implement it immediately?",
+    "answers": {
+      "a1": "support"
+    },
+    "options": [
+      "support",
+      "supported",
+      "will support"
+    ],
+    "verb_hint": {
+      "a1": "(support)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the chef {a1} local produce today, will the diners appreciate the menu?",
+    "answers": {
+      "a1": "sources"
+    },
+    "options": [
+      "sources",
+      "sourced",
+      "will source"
+    ],
+    "verb_hint": {
+      "a1": "(source)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the runners {a1} their pace today, will the coach extend practice?",
+    "answers": {
+      "a1": "maintain"
+    },
+    "options": [
+      "maintain",
+      "maintained",
+      "will maintain"
+    ],
+    "verb_hint": {
+      "a1": "(maintain)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If we submit the grant proposal tomorrow, will the committee {a1} funding next month?",
+    "answers": {
+      "a1": "announce"
+    },
+    "options": [
+      "announce",
+      "announced",
+      "will announce"
+    ],
+    "verb_hint": {
+      "a1": "(announce)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If Helena books the venue tomorrow, will the organizers {a1} the lineup by Friday?",
+    "answers": {
+      "a1": "confirm"
+    },
+    "options": [
+      "confirm",
+      "confirmed",
+      "will confirm"
+    ],
+    "verb_hint": {
+      "a1": "(confirm)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If the lab completes the prototype tomorrow, will investors {a1} funds next quarter?",
+    "answers": {
+      "a1": "release"
+    },
+    "options": [
+      "release",
+      "released",
+      "will release"
+    ],
+    "verb_hint": {
+      "a1": "(release)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "B2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If the council resolves the dispute tomorrow, will residents {a1} services next week?",
+    "answers": {
+      "a1": "receive"
+    },
+    "options": [
+      "receive",
+      "received",
+      "will receive"
+    ],
+    "verb_hint": {
+      "a1": "(receive)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the policy committee {a1} stakeholder feedback since the consultation, the proposal won't trigger objections.",
+    "answers": {
+      "a1": "hasn't neglected"
+    },
+    "options": [
+      "hasn't neglected",
+      "didn't neglect",
+      "won't neglect"
+    ],
+    "verb_hint": {
+      "a1": "(not neglect)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the compliance team {a1} reporting deadlines this quarter, regulators won't impose fines.",
+    "answers": {
+      "a1": "haven't violated"
+    },
+    "options": [
+      "haven't violated",
+      "didn't violate",
+      "won't violate"
+    ],
+    "verb_hint": {
+      "a1": "(not violate)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the editorial board {a1} sources since publication, the journal won't lose credibility.",
+    "answers": {
+      "a1": "hasn't retracted"
+    },
+    "options": [
+      "hasn't retracted",
+      "didn't retract",
+      "won't retract"
+    ],
+    "verb_hint": {
+      "a1": "(not retract)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the expedition leader {a1} the terrain since the last briefing, the crew won't request delays.",
+    "answers": {
+      "a1": "hasn't underestimated"
+    },
+    "options": [
+      "hasn't underestimated",
+      "didn't underestimate",
+      "won't underestimate"
+    ],
+    "verb_hint": {
+      "a1": "(not underestimate)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the strategist {a1} today's pitch with the client's metrics, the negotiation will falter.",
+    "answers": {
+      "a1": "doesn't align"
+    },
+    "options": [
+      "doesn't align",
+      "didn't align",
+      "won't align"
+    ],
+    "verb_hint": {
+      "a1": "(not align)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the curator {a1} new acquisitions today, the archive will remain incomplete.",
+    "answers": {
+      "a1": "doesn't document"
+    },
+    "options": [
+      "doesn't document",
+      "didn't document",
+      "won't document"
+    ],
+    "verb_hint": {
+      "a1": "(not document)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the analyst {a1} anomalies today, investors will question the forecast.",
+    "answers": {
+      "a1": "doesn't verify"
+    },
+    "options": [
+      "doesn't verify",
+      "didn't verify",
+      "won't verify"
+    ],
+    "verb_hint": {
+      "a1": "(not verify)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the orchestra {a1} dynamics today, the premiere will lack nuance.",
+    "answers": {
+      "a1": "doesn't rehearse"
+    },
+    "options": [
+      "doesn't rehearse",
+      "didn't rehearse",
+      "won't rehearse"
+    ],
+    "verb_hint": {
+      "a1": "(not rehearse)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the board approves the contingency plan today, the company {a1} resort to layoffs next month.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "doesn't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the developers freeze new features tonight, the release {a1} slip into winter.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "doesn't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the ambassadors sign the accord tomorrow, the region {a1} spiral back into conflict.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "doesn't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the research lab secures grants today, the project {a1} shut down mid-year.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "doesn't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the legal team {a1} clauses since last session, will the partners finalize the merger now?",
+    "answers": {
+      "a1": "has negotiated"
+    },
+    "options": [
+      "has negotiated",
+      "negotiated",
+      "will negotiate"
+    ],
+    "verb_hint": {
+      "a1": "(negotiate)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the task force {a1} the outbreak since Monday, will the ministry lift restrictions tonight?",
+    "answers": {
+      "a1": "has tracked"
+    },
+    "options": [
+      "has tracked",
+      "tracked",
+      "will track"
+    ],
+    "verb_hint": {
+      "a1": "(track)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the producers {a1} the scenes since the preview, will the critics revise their reviews?",
+    "answers": {
+      "a1": "have reshot"
+    },
+    "options": [
+      "have reshot",
+      "reshot",
+      "will reshoot"
+    ],
+    "verb_hint": {
+      "a1": "(reshoot)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the restoration crew {a1} artifacts since spring, will the museum unveil the exhibit this week?",
+    "answers": {
+      "a1": "has catalogued"
+    },
+    "options": [
+      "has catalogued",
+      "catalogued",
+      "will catalogue"
+    ],
+    "verb_hint": {
+      "a1": "(catalogue)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the chairperson {a1} the debate fairly today, will the delegates endorse the resolution?",
+    "answers": {
+      "a1": "moderates"
+    },
+    "options": [
+      "moderates",
+      "moderated",
+      "will moderate"
+    ],
+    "verb_hint": {
+      "a1": "(moderate)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the campaign {a1} sustainable targets today, will donors expand their pledges?",
+    "answers": {
+      "a1": "highlights"
+    },
+    "options": [
+      "highlights",
+      "highlighted",
+      "will highlight"
+    ],
+    "verb_hint": {
+      "a1": "(highlight)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the think tank {a1} data today, will policymakers respond immediately?",
+    "answers": {
+      "a1": "publishes"
+    },
+    "options": [
+      "publishes",
+      "published",
+      "will publish"
+    ],
+    "verb_hint": {
+      "a1": "(publish)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the negotiator {a1} the tone conciliatory today, will the rival firm soften its stance?",
+    "answers": {
+      "a1": "keeps"
+    },
+    "options": [
+      "keeps",
+      "kept",
+      "will keep"
+    ],
+    "verb_hint": {
+      "a1": "(keep)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If we circulate the white paper tomorrow, will the regulators {a1} guidance next quarter?",
+    "answers": {
+      "a1": "issue"
+    },
+    "options": [
+      "issue",
+      "issued",
+      "will issue"
+    ],
+    "verb_hint": {
+      "a1": "(issue)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If Leila files the patent tomorrow, will competitors {a1} the claim this summer?",
+    "answers": {
+      "a1": "challenge"
+    },
+    "options": [
+      "challenge",
+      "challenged",
+      "will challenge"
+    ],
+    "verb_hint": {
+      "a1": "(challenge)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If the bank locks in rates tomorrow, will borrowers {a1} applications next week?",
+    "answers": {
+      "a1": "accelerate"
+    },
+    "options": [
+      "accelerate",
+      "accelerated",
+      "will accelerate"
+    ],
+    "verb_hint": {
+      "a1": "(accelerate)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C1",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If the creative team storyboards tomorrow, will the studio {a1} production by August?",
+    "answers": {
+      "a1": "greenlight"
+    },
+    "options": [
+      "greenlight",
+      "greenlit",
+      "will greenlight"
+    ],
+    "verb_hint": {
+      "a1": "(greenlight)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the oversight panel {a1} systemic weaknesses since the audit commenced, the reforms won't encounter dissent.",
+    "answers": {
+      "a1": "hasn't overlooked"
+    },
+    "options": [
+      "hasn't overlooked",
+      "didn't overlook",
+      "won't overlook"
+    ],
+    "verb_hint": {
+      "a1": "(not overlook)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the biotech consortium {a1} trial signals this semester, investors won't withdraw capital.",
+    "answers": {
+      "a1": "haven't misinterpreted"
+    },
+    "options": [
+      "haven't misinterpreted",
+      "didn't misinterpret",
+      "won't misinterpret"
+    ],
+    "verb_hint": {
+      "a1": "(not misinterpret)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the diplomatic corps {a1} protocol since the summit convened, rival states won't lodge complaints.",
+    "answers": {
+      "a1": "hasn't breached"
+    },
+    "options": [
+      "hasn't breached",
+      "didn't breach",
+      "won't breach"
+    ],
+    "verb_hint": {
+      "a1": "(not breach)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "past",
+    "source_key": "negative_past",
+    "question": "If the data ethics council {a1} transparency reports since the last revision, watchdogs won't escalate inquiries.",
+    "answers": {
+      "a1": "hasn't diluted"
+    },
+    "options": [
+      "hasn't diluted",
+      "didn't dilute",
+      "won't dilute"
+    ],
+    "verb_hint": {
+      "a1": "(not dilute)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the venture architect {a1} today's roadmap with stakeholder mandates, the rollout will collapse.",
+    "answers": {
+      "a1": "doesn't harmonize"
+    },
+    "options": [
+      "doesn't harmonize",
+      "didn't harmonize",
+      "won't harmonize"
+    ],
+    "verb_hint": {
+      "a1": "(not harmonize)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the editorial syndicate {a1} conflicting narratives today, the readership will fracture.",
+    "answers": {
+      "a1": "doesn't reconcile"
+    },
+    "options": [
+      "doesn't reconcile",
+      "didn't reconcile",
+      "won't reconcile"
+    ],
+    "verb_hint": {
+      "a1": "(not reconcile)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the compliance officer {a1} grey areas today, regulators will seize the initiative.",
+    "answers": {
+      "a1": "doesn't address"
+    },
+    "options": [
+      "doesn't address",
+      "didn't address",
+      "won't address"
+    ],
+    "verb_hint": {
+      "a1": "(not address)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "present",
+    "source_key": "negative_present",
+    "question": "If the research fellows {a1} cross-checks today, the publication will forfeit credibility.",
+    "answers": {
+      "a1": "don't conduct"
+    },
+    "options": [
+      "don't conduct",
+      "didn't conduct",
+      "won't conduct"
+    ],
+    "verb_hint": {
+      "a1": "(not conduct)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the treasury secures currency swaps tomorrow, the economy {a1} spiral during the quarter.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "doesn't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the consortium ratifies the climate charter today, emission targets {a1} languish unfulfilled.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "don't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the judiciary releases the report tomorrow, confidence {a1} erode across the markets.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "doesn't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "negative",
+    "tense_group": "future",
+    "source_key": "negative_future",
+    "question": "If the humanitarian coalition coordinates flights today, aid corridors {a1} remain blocked next week.",
+    "answers": {
+      "a1": "won't"
+    },
+    "options": [
+      "won't",
+      "don't",
+      "didn't"
+    ],
+    "verb_hint": {
+      "a1": "(not)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the arbitration board {a1} the evidence since Monday, will the ruling withstand appeals tonight?",
+    "answers": {
+      "a1": "has vetted"
+    },
+    "options": [
+      "has vetted",
+      "vetted",
+      "will vet"
+    ],
+    "verb_hint": {
+      "a1": "(vet)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the epidemiologists {a1} the mutations since last briefing, will the vaccine rollout accelerate now?",
+    "answers": {
+      "a1": "have sequenced"
+    },
+    "options": [
+      "have sequenced",
+      "sequenced",
+      "will sequence"
+    ],
+    "verb_hint": {
+      "a1": "(sequence)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the media council {a1} the disinformation since dawn, will public sentiment stabilize today?",
+    "answers": {
+      "a1": "has corrected"
+    },
+    "options": [
+      "has corrected",
+      "corrected",
+      "will correct"
+    ],
+    "verb_hint": {
+      "a1": "(correct)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "past",
+    "source_key": "interrogative_past",
+    "question": "If the urban planners {a1} evacuation routes since the drill, will the mayor authorize expansion this week?",
+    "answers": {
+      "a1": "have modelled"
+    },
+    "options": [
+      "have modelled",
+      "modelled",
+      "will model"
+    ],
+    "verb_hint": {
+      "a1": "(model)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the central bank {a1} restraint today, will currency traders moderate speculation?",
+    "answers": {
+      "a1": "signals"
+    },
+    "options": [
+      "signals",
+      "signalled",
+      "will signal"
+    ],
+    "verb_hint": {
+      "a1": "(signal)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the ethics committee {a1} donations today, will the candidates adjust their messaging?",
+    "answers": {
+      "a1": "scrutinizes"
+    },
+    "options": [
+      "scrutinizes",
+      "scrutinized",
+      "will scrutinize"
+    ],
+    "verb_hint": {
+      "a1": "(scrutinize)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the renewable task force {a1} tiered incentives today, will parliament debate the bill immediately?",
+    "answers": {
+      "a1": "proposes"
+    },
+    "options": [
+      "proposes",
+      "proposed",
+      "will propose"
+    ],
+    "verb_hint": {
+      "a1": "(propose)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "present",
+    "source_key": "interrogative_present",
+    "question": "If the diplomatic envoy {a1} transparency today, will the alliance reaffirm commitments?",
+    "answers": {
+      "a1": "maintains"
+    },
+    "options": [
+      "maintains",
+      "maintained",
+      "will maintain"
+    ],
+    "verb_hint": {
+      "a1": "(maintain)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If we tender the satellite contract tomorrow, will the agency {a1} launch windows next season?",
+    "answers": {
+      "a1": "authorize"
+    },
+    "options": [
+      "authorize",
+      "authorized",
+      "will authorize"
+    ],
+    "verb_hint": {
+      "a1": "(authorize)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If the biotech firm files the dossier tomorrow, will regulators {a1} emergency approval next month?",
+    "answers": {
+      "a1": "expedite"
+    },
+    "options": [
+      "expedite",
+      "expedited",
+      "will expedite"
+    ],
+    "verb_hint": {
+      "a1": "(expedite)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If the cultural fund releases grants tomorrow, will curators {a1} pop-up exhibits by autumn?",
+    "answers": {
+      "a1": "stage"
+    },
+    "options": [
+      "stage",
+      "staged",
+      "will stage"
+    ],
+    "verb_hint": {
+      "a1": "(stage)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  },
+  {
+    "level": "C2",
+    "type": "interrogative",
+    "tense_group": "future",
+    "source_key": "interrogative_future",
+    "question": "If the cybersecurity division deploys safeguards tomorrow, will the consortium {a1} cascading breaches next quarter?",
+    "answers": {
+      "a1": "avert"
+    },
+    "options": [
+      "avert",
+      "averted",
+      "will avert"
+    ],
+    "verb_hint": {
+      "a1": "(avert)"
+    },
+    "tense": [
+      "First Conditional"
+    ]
+  }
+]

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,9 +6,12 @@ namespace Database\Seeders;
 use App\Models\Category;
 use Illuminate\Database\Seeder;
 use Database\Seeders\Ai\NegativePresentPerfectHabitsTestSeeder;
+use Database\Seeders\Ai\FirstConditionalAiFormsV2Seeder;
 use Database\Seeders\V2\PastTimeClausesMixedTestSeeder;
 use Database\Seeders\V2\FutureTensesPracticeV2Seeder;
 use Database\Seeders\V2\FirstConditionalPracticeV2Seeder;
+use Database\Seeders\pages\PagesSeeder;
+use Database\Seeders\pages\TheoryPageSeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -99,7 +102,9 @@ class DatabaseSeeder extends Seeder
             PastTimeClausesMixedTestSeeder::class,
             FutureTensesPracticeV2Seeder::class,
             FirstConditionalPracticeV2Seeder::class,
+            FirstConditionalAiFormsV2Seeder::class,
             PagesSeeder::class,
+            TheoryPageSeeder::class,
             IrregularVerbsSeeder::class,
             FutureSimpleFutureContinuousFuturePerfectTestSeeder::class,
             FutureSimpleOrFutureContinuousSeeder::class,

--- a/database/seeders/pages/PagesSeeder.php
+++ b/database/seeders/pages/PagesSeeder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Database\Seeders;
+namespace Database\Seeders\pages;
 
 use Illuminate\Database\Seeder;
 use App\Models\Page;

--- a/database/seeders/pages/TheoryPageSeeder.php
+++ b/database/seeders/pages/TheoryPageSeeder.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Database\Seeders\pages;
+
+use Illuminate\Database\Seeder;
+use App\Models\Page;
+
+class TheoryPageSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Page::firstOrCreate(
+            ['slug' => 'theory'],
+            [
+                'title' => 'Conditionals — Умовні речення (If-clauses)',
+                'text' => <<<'HTML'
+<section class="grammar-card" lang="uk">
+  <style>
+    /* СТИЛІ ЛИШЕ ДЛЯ ЦЬОГО БЛОКУ */
+    .grammar-card { --bg:#ffffff; --text:#1f2937; --muted:#6b7280; --accent:#2563eb; --chip:#f3f4f6; --ok:#10b981; --warn:#f59e0b;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
+      color: var(--text); background: var(--bg); border: 1px solid #e5e7eb; border-radius: 16px; padding: 16px; max-width: 1100px; margin: 0 auto 24px; box-shadow: 0 6px 18px rgba(0,0,0,.04);
+    }
+    .grammar-card * { box-sizing: border-box; }
+    .gw-title { font-size: 24px; line-height: 1.2; margin: 0 0 10px; }
+    .gw-sub { color: var(--muted); margin: 0 0 18px; font-size: 15px; }
+    .gw-grid { display: grid; grid-template-columns: 1fr; gap: 16px; }
+    .gw-col { display: flex; flex-direction: column; gap: 16px; }
+    .gw-box { border: 1px solid #e5e7eb; border-radius: 12px; padding: 14px; background: #fff; }
+    .gw-box h3 { margin: 0 0 8px; font-size: 17px; }
+    .gw-list { margin: 8px 0 0 18px; }
+    .gw-list li { margin: 6px 0; }
+    .gw-formula { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: #0b1220; color: #e5e7eb; border-radius: 10px; padding: 12px; font-size: 13px; overflow:auto;
+    }
+    .gw-code-badge { display: inline-block; font-size: 12px; color:#d1d5db; border:1px solid #334155; padding:2px 8px; border-radius:999px; margin-bottom:8px; }
+    .gw-ex { background: #f9fafb; border-left: 4px solid var(--accent); padding: 10px 12px; border-radius: 8px; margin-top: 10px; font-size: 14px; }
+    .gw-en { font-weight: 600; }
+    .gw-ua { color: var(--muted); }
+    .gw-chips { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; }
+    .gw-chip { background: var(--chip); border:1px solid #e5e7eb; padding:6px 10px; border-radius:999px; font-size:13px; }
+    .gw-table { width: 100%; border-collapse: collapse; font-size: 14px; display: block; overflow-x: auto; }
+    .gw-table th, .gw-table td { border: 1px solid #e5e7eb; padding: 8px; vertical-align: top; }
+    .gw-table th { background:#f8fafc; text-align:left; }
+    .gw-hint { display:flex; gap:10px; align-items:flex-start; background:#f8fafc; border:1px dashed #cbd5e1; padding:10px 12px; border-radius:10px; font-size: 14px; }
+    .gw-emoji { font-size: 18px; }
+    .tag-ok { color: var(--ok); font-weight: 700; }
+    .tag-warn { color: var(--warn); font-weight: 700; }
+
+    /* Inversion box адаптивність */
+    .gw-inversion {
+      max-width: 100%;
+      overflow-x: auto;
+      white-space: normal;
+    }
+    .gw-inversion pre {
+      max-width: 100%;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    /* Адаптивність */
+    @media (min-width: 640px) {
+      .gw-title { font-size: 26px; }
+      .gw-sub { font-size: 16px; }
+      .gw-box h3 { font-size: 18px; }
+      .gw-formula { font-size: 14px; }
+    }
+    @media (min-width: 860px) {
+      .gw-grid { grid-template-columns: 1.15fr 1fr; }
+    }
+    @media (min-width: 1024px) {
+      .gw-title { font-size: 30px; }
+      .gw-sub { font-size: 17px; }
+      .gw-formula { font-size: 15px; }
+      .gw-box { padding: 18px; }
+    }
+  </style>
+
+  <header>
+    <h2 class="gw-title">Conditionals — Умовні речення (If-clauses)</h2>
+    <p class="gw-sub">Моделі речень, де <strong>результат</strong> залежить від <strong>умови</strong>. Тип залежить від часу та реальності ситуації.</p>
+  </header>
+
+  <div class="gw-grid">
+    <!-- ЛІВА КОЛОНКА -->
+    <div class="gw-col">
+      <div class="gw-box">
+        <h3>Коли вживати?</h3>
+        <ul class="gw-list">
+          <li><strong>Zero Conditional</strong> — загальні істини, правила, рутини.</li>
+          <li><strong>First Conditional</strong> — реальні/ймовірні наслідки у майбутньому.</li>
+          <li><strong>Second Conditional</strong> — малоймовірні/уявні ситуації зараз або в майбутньому.</li>
+          <li><strong>Third Conditional</strong> — уявні (нереальні) минулі ситуації та їх наслідки.</li>
+          <li><strong>Mixed Conditionals</strong> — змішання часу умови та наслідку (минуле ↔ теперішнє/майбутнє).</li>
+        </ul>
+
+        <div class="gw-ex">
+          <div class="gw-en">If it rains, the ground gets wet. (Zero)</div>
+          <div class="gw-ua">Якщо йде дощ, земля намокає. (загальний факт)</div>
+        </div>
+      </div>
+
+      <div class="gw-box">
+        <h3>Маркери та варіанти сполучників</h3>
+        <div class="gw-chips">
+          <span class="gw-chip">if — якщо</span>
+          <span class="gw-chip">unless — якщо не</span>
+          <span class="gw-chip">as long as — за умови що</span>
+          <span class="gw-chip">provided (that) — за умови що</span>
+          <span class="gw-chip">in case — про всяк випадок</span>
+          <span class="gw-chip">when — коли (для Zero)</span>
+        </div>
+
+        <div class="gw-ex">
+          <div class="gw-en">You can go out <strong>as long as</strong> you finish your homework.</div>
+          <div class="gw-ua">Можеш вийти, <strong>якщо</strong> закінчиш домашнє завдання.</div>
+        </div>
+      </div>
+
+      <div class="gw-box">
+        <h3>Важливо про часи в if-клаузі</h3>
+        <div class="gw-hint">
+          <div class="gw-emoji">🧠</div>
+          <div>
+            <p><strong>Умовна частина не вживає will/would.</strong> Майбутнє виражається теперішнім часом у підрядній частині.</p>
+            <p class="gw-ua"><em>Правильно:</em> If it <u>rains</u>, we <u>will stay</u> home. <br><em>Неправильно:</em> If it <u>will rain</u>, we will stay home.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="gw-box">
+        <h3>Zero & First — формули</h3>
+        <div class="gw-code-badge">Zero Conditional (правила/факти)</div>
+        <pre class="gw-formula">If + Present Simple, Present Simple
+When/If water <span style="color:#86efac">reaches</span> 100°C, it <span style="color:#86efac">boils</span>.</pre>
+
+        <div class="gw-code-badge">First Conditional (реальне майбутнє)</div>
+        <pre class="gw-formula">If + Present Simple, <span style="color:#93c5fd">will</span> + V1
+If it <span style="color:#86efac">rains</span>, we <span style="color:#93c5fd">will stay</span> at home.</pre>
+
+        <div class="gw-ex">
+          <div class="gw-en">If you study, you will pass.</div>
+          <div class="gw-ua">Якщо ти будеш вчитися, ти складеш іспит.</div>
+        </div>
+      </div>
+       <div class="gw-box gw-inversion">
+        <h3>Inversion (формальніший варіант без if)</h3>
+
+        <div class="gw-code-badge">Другий тип</div>
+        <pre class="gw-formula">Were I you, I would reconsider.  (= If I were you, ...)</pre>
+
+        <div class="gw-code-badge">Третій тип</div>
+        <pre class="gw-formula">Had we left earlier, we would have arrived on time.  (= If we had left, ...)</pre>
+
+        <div class="gw-code-badge">Перший тип (рідше)</div>
+        <pre class="gw-formula">Should you need help, call me.  (= If you need help, ...)</pre>
+      </div>
+    </div>
+
+    <!-- ПРАВА КОЛОНКА -->
+    <div class="gw-col">
+      <div class="gw-box">
+        <h3>Second, Third & Mixed — формули</h3>
+
+        <div class="gw-code-badge">Second Conditional (уявне теперіш./майбутнє)</div>
+        <pre class="gw-formula">If + Past Simple, <span style="color:#93c5fd">would</span> + V1
+If I <span style="color:#86efac">had</span> more time, I <span style="color:#93c5fd">would travel</span> more.</pre>
+
+        <div class="gw-code-badge">Third Conditional (нереальне минуле)</div>
+        <pre class="gw-formula">If + Past Perfect (<span style="color:#86efac">had + V3</span>), <span style="color:#93c5fd">would have</span> + V3
+If she <span style="color:#86efac">had left</span> earlier, she <span style="color:#93c5fd">would have caught</span> the train.</pre>
+
+        <div class="gw-code-badge">Mixed (минуле → теперішній наслідок)</div>
+        <pre class="gw-formula">If + Past Perfect, <span style="color:#93c5fd">would</span> + V1
+If I <span style="color:#86efac">had studied</span> medicine, I <span style="color:#93c5fd">would be</span> a doctor now.</pre>
+
+        <div class="gw-ex">
+          <div class="gw-en">If I were you, I would take the offer.</div>
+          <div class="gw-ua">На твоєму місці я б прийняв пропозицію. (формальне: “were” для всіх осіб)</div>
+        </div>
+      </div>
+
+      <div class="gw-box">
+        <h3>Порівняння типів</h3>
+        <table class="gw-table" aria-label="Порівняння типів умовних речень">
+          <thead>
+            <tr>
+              <th>Тип</th>
+              <th>Значення</th>
+              <th>Формула</th>
+              <th>Приклад</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Zero</strong></td>
+              <td>Загальний факт/рутина</td>
+              <td>If + Present, Present</td>
+              <td class="gw-en">If people <strong>don’t drink</strong>, they <strong>get</strong> thirsty.</td>
+            </tr>
+            <tr>
+              <td><strong>First</strong></td>
+              <td>Реальний наслідок у майбутньому</td>
+              <td>If + Present, will + V1</td>
+              <td class="gw-en">If you <strong>hurry</strong>, you <strong>will catch</strong> the bus.</td>
+            </tr>
+            <tr>
+              <td><strong>Second</strong></td>
+              <td>Малоймовірне/уявне теперіш./майбутнє</td>
+              <td>If + Past, would + V1</td>
+              <td class="gw-en">If I <strong>won</strong> the lottery, I <strong>would move</strong> abroad.</td>
+            </tr>
+            <tr>
+              <td><strong>Third</strong></td>
+              <td>Нереальне минуле</td>
+              <td>If + Past Perfect, would have + V3</td>
+              <td class="gw-en">If we <strong>had left</strong> earlier, we <strong>would have arrived</strong> on time.</td>
+            </tr>
+            <tr>
+              <td><strong>Mixed</strong></td>
+              <td>Минуле → теперішній/майб. наслідок</td>
+              <td>If + Past Perfect, would + V1</td>
+              <td class="gw-en">If she <strong>had studied</strong> art, she <strong>would be</strong> a designer now.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="gw-box">
+        <h3>Типові помилки</h3>
+        <ul class="gw-list">
+          <li><span class="tag-warn">✗</span> Вживати <em>will/would</em> у підрядній частині: <em>If it <u>will</u> rain</em>. <span class="tag-ok">✓</span> Правильно: <em>If it rains, …</em></li>
+          <li><span class="tag-warn">✗</span> Плутати Second і Third: теперішня уява ≠ минуле, якого вже не змінити.</li>
+          <li><span class="tag-warn">✗</span> Невірний порядок слів у наслідку: <em>would have + V3</em> лише для минулих нереальних наслідків.</li>
+          <li><span class="tag-ok">✓</span> Пам’ятай: <strong>кома</strong> ставиться, якщо if-клаузу ставимо на початку: <em>If you call, I’ll answer.</em></li>
+        </ul>
+      </div>
+
+     
+    </div>
+  </div>
+</section>
+HTML,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- switch the page seeder namespaces to use the lowercase `pages` segment so they match the directory name
- update the database seeder imports to reference the new lowercase namespaces

## Testing
- php -l database/seeders/pages/PagesSeeder.php
- php -l database/seeders/pages/TheoryPageSeeder.php
- php -l database/seeders/DatabaseSeeder.php

------
https://chatgpt.com/codex/tasks/task_e_68de4996904c832a982b86d365719a12