### PR TITLE
Log executed seeders to seed_runs table

### DIFF
--- a/app/Support/Database/Seeder.php
+++ b/app/Support/Database/Seeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Support\Database;
+
+use Illuminate\Database\Seeder as BaseSeeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+abstract class Seeder extends BaseSeeder
+{
+    public function __invoke()
+    {
+        $this->logRun();
+
+        return parent::__invoke();
+    }
+
+    protected function logRun(): void
+    {
+        if (!Schema::hasTable('seed_runs')) {
+            return;
+        }
+
+        DB::table('seed_runs')->insert([
+            'class_name' => static::class,
+            'ran_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2025_10_05_190829_create_seed_runs_table.php
+++ b/database/migrations/2025_10_05_190829_create_seed_runs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('seed_runs', function (Blueprint $table) {
+            $table->id();
+            $table->string('class_name');
+            $table->timestamp('ran_at')->useCurrent();
+            $table->index('class_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('seed_runs');
+    }
+};

--- a/database/seeders/AAnSomeAnyTestSeeder.php
+++ b/database/seeders/AAnSomeAnyTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/AAnTheTest2Seeder.php
+++ b/database/seeders/AAnTheTest2Seeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/AAnTheTestSeeder.php
+++ b/database/seeders/AAnTheTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/Ai/MixedPerfectTenseDetailedSeeder.php
+++ b/database/seeders/Ai/MixedPerfectTenseDetailedSeeder.php
@@ -9,7 +9,7 @@ use App\Models\QuestionHint;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 

--- a/database/seeders/Ai/NegativePresentPerfectHabitsTestSeeder.php
+++ b/database/seeders/Ai/NegativePresentPerfectHabitsTestSeeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class NegativePresentPerfectHabitsTestSeeder extends Seeder

--- a/database/seeders/Ai/PastPerfectComprehensiveAiSeeder.php
+++ b/database/seeders/Ai/PastPerfectComprehensiveAiSeeder.php
@@ -9,7 +9,7 @@ use App\Models\QuestionHint;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Ramsey\Uuid\Uuid;
 
 class PastPerfectComprehensiveAiSeeder extends Seeder

--- a/database/seeders/CanCantAbilityExercise2Seeder.php
+++ b/database/seeders/CanCantAbilityExercise2Seeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class CanCantAbilityExercise2Seeder extends Seeder

--- a/database/seeders/CanCantAbilityExercise3Seeder.php
+++ b/database/seeders/CanCantAbilityExercise3Seeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class CanCantAbilityExercise3Seeder extends Seeder

--- a/database/seeders/CanCantAbilitySeeder.php
+++ b/database/seeders/CanCantAbilitySeeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class CanCantAbilitySeeder extends Seeder

--- a/database/seeders/ChatGPTExplanationsSeeder.php
+++ b/database/seeders/ChatGPTExplanationsSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
 class ChatGPTExplanationsSeeder extends Seeder

--- a/database/seeders/ChatGPTTranslationChecksSeeder.php
+++ b/database/seeders/ChatGPTTranslationChecksSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
 class ChatGPTTranslationChecksSeeder extends Seeder

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,7 +4,7 @@ namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use App\Models\Category;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Database\Seeders\Ai\FirstConditionalAiFormsV2Seeder;
 use Database\Seeders\Ai\FirstConditionalChooseABCAiSeeder;
 use Database\Seeders\Ai\NegativePresentPerfectHabitsTestSeeder;

--- a/database/seeders/DoDoesIsAreSeeder.php
+++ b/database/seeders/DoDoesIsAreSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/FutConImageTestSeeder.php
+++ b/database/seeders/FutConImageTestSeeder.php
@@ -4,7 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\{Category, Source, Tag, Test};
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class FutConImageTestSeeder extends Seeder

--- a/database/seeders/FuturePerfectVsFutureContinuousExercise1Seeder.php
+++ b/database/seeders/FuturePerfectVsFutureContinuousExercise1Seeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/FutureSimpleFutureContinuousFuturePerfectTestSeeder.php
+++ b/database/seeders/FutureSimpleFutureContinuousFuturePerfectTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/FutureSimpleOrFutureContinuousSeeder.php
+++ b/database/seeders/FutureSimpleOrFutureContinuousSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/FutureSimpleTest1Seeder.php
+++ b/database/seeders/FutureSimpleTest1Seeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/GrammarQuizPastSimpleSeeder.php
+++ b/database/seeders/GrammarQuizPastSimpleSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/GrammarTestAISeeder.php
+++ b/database/seeders/GrammarTestAISeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/GrammarTestSeeder.php
+++ b/database/seeders/GrammarTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 use App\Models\Category;
 use App\Services\QuestionSeedingService;

--- a/database/seeders/HaveGotExercise2Seeder.php
+++ b/database/seeders/HaveGotExercise2Seeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class HaveGotExercise2Seeder extends Seeder

--- a/database/seeders/HaveGotExercise3Seeder.php
+++ b/database/seeders/HaveGotExercise3Seeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class HaveGotExercise3Seeder extends Seeder

--- a/database/seeders/HaveGotHasGotSeeder.php
+++ b/database/seeders/HaveGotHasGotSeeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class HaveGotHasGotSeeder extends Seeder

--- a/database/seeders/IrregularVerbsSeeder.php
+++ b/database/seeders/IrregularVerbsSeeder.php
@@ -4,7 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Translate;
 use App\Models\Word;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
 class IrregularVerbsSeeder extends Seeder

--- a/database/seeders/MixedTenseUsageAiSeeder.php
+++ b/database/seeders/MixedTenseUsageAiSeeder.php
@@ -9,7 +9,7 @@ use App\Models\QuestionHint;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 

--- a/database/seeders/PastContinuousTenseTestSeeder.php
+++ b/database/seeders/PastContinuousTenseTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PastPerfectA2TestSeeder.php
+++ b/database/seeders/PastPerfectA2TestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PastPerfectSimpleVsContinuousCTestSeeder.php
+++ b/database/seeders/PastPerfectSimpleVsContinuousCTestSeeder.php
@@ -9,7 +9,7 @@ use App\Models\QuestionHint;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Ramsey\Uuid\Uuid;
 
 class PastPerfectSimpleVsContinuousCTestSeeder extends Seeder

--- a/database/seeders/PastPerfectVsPastSimpleTestSeeder.php
+++ b/database/seeders/PastPerfectVsPastSimpleTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/PastPresFutContinuousSeeder.php
+++ b/database/seeders/PastPresFutContinuousSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 use App\Models\{Category, Source, Tag};
 use App\Services\QuestionSeedingService;

--- a/database/seeders/PastSimpleContinuousImageTestSeeder.php
+++ b/database/seeders/PastSimpleContinuousImageTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 use App\Models\{Category, Source, Tag, Test};
 use App\Services\QuestionSeedingService;

--- a/database/seeders/PastSimpleContinuousSentencesTestSeeder.php
+++ b/database/seeders/PastSimpleContinuousSentencesTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\{Category, Source, Tag};
 use Illuminate\Support\Str;

--- a/database/seeders/PastSimpleContinuousStorySeeder.php
+++ b/database/seeders/PastSimpleContinuousStorySeeder.php
@@ -5,7 +5,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class PastSimpleContinuousStorySeeder extends Seeder

--- a/database/seeders/PastSimpleOrPastContinuousTestSeeder.php
+++ b/database/seeders/PastSimpleOrPastContinuousTestSeeder.php
@@ -7,7 +7,7 @@ use App\Models\Source;
 use App\Models\Tag;
 use App\Models\Test;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class PastSimpleOrPastContinuousTestSeeder extends Seeder

--- a/database/seeders/PastSimpleOrPastPerfectTestSeeder.php
+++ b/database/seeders/PastSimpleOrPastPerfectTestSeeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class PastSimpleOrPastPerfectTestSeeder extends Seeder

--- a/database/seeders/PastSimpleOrPresentPerfectEx4Seeder.php
+++ b/database/seeders/PastSimpleOrPresentPerfectEx4Seeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PastSimplePresentPerfectPastPerfectTestSeeder.php
+++ b/database/seeders/PastSimplePresentPerfectPastPerfectTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PastSimplePresentPerfectSimpleTestSeeder.php
+++ b/database/seeders/PastSimplePresentPerfectSimpleTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PastSimpleRegularVerbsFullSeeder.php
+++ b/database/seeders/PastSimpleRegularVerbsFullSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/PastSimpleVsPresentPerfectMultipleChoiceSeeder.php
+++ b/database/seeders/PastSimpleVsPresentPerfectMultipleChoiceSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PcImageTestSeeder.php
+++ b/database/seeders/PcImageTestSeeder.php
@@ -4,7 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\{Category, Source, Tag, Test};
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class PcImageTestSeeder extends Seeder

--- a/database/seeders/PresentContinuousDialogueSeeder.php
+++ b/database/seeders/PresentContinuousDialogueSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PresentContinuousPastSimpleTestSeeder.php
+++ b/database/seeders/PresentContinuousPastSimpleTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PresentContinuousShortAnswersSeeder.php
+++ b/database/seeders/PresentContinuousShortAnswersSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PresentContinuousShortFormsSeeder.php
+++ b/database/seeders/PresentContinuousShortFormsSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PresentPastRevisionSeeder.php
+++ b/database/seeders/PresentPastRevisionSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/PresentPerfectExercisesSeeder.php
+++ b/database/seeders/PresentPerfectExercisesSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PresentPerfectOrPresentPerfectContinuousExercise03Seeder.php
+++ b/database/seeders/PresentPerfectOrPresentPerfectContinuousExercise03Seeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class PresentPerfectOrPresentPerfectContinuousExercise03Seeder extends Seeder

--- a/database/seeders/PresentPerfectOrPresentPerfectContinuousExercise04Seeder.php
+++ b/database/seeders/PresentPerfectOrPresentPerfectContinuousExercise04Seeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class PresentPerfectOrPresentPerfectContinuousExercise04Seeder extends Seeder

--- a/database/seeders/PresentPerfectPastSimpleTestSeeder.php
+++ b/database/seeders/PresentPerfectPastSimpleTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PresentSimpleExercisesSeeder.php
+++ b/database/seeders/PresentSimpleExercisesSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/PresentSimpleOrContinuousSeeder.php
+++ b/database/seeders/PresentSimpleOrContinuousSeeder.php
@@ -1,7 +1,7 @@
 <?php
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\{Category, Source, Tag};
 use Illuminate\Support\Str;

--- a/database/seeders/PresentSimpleSeeder.php
+++ b/database/seeders/PresentSimpleSeeder.php
@@ -1,7 +1,7 @@
 <?php
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/PronounWordsSeeder.php
+++ b/database/seeders/PronounWordsSeeder.php
@@ -5,7 +5,7 @@ namespace Database\Seeders;
 use App\Models\Tag;
 use App\Models\Translate;
 use App\Models\Word;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
 class PronounWordsSeeder extends Seeder

--- a/database/seeders/QuestionLevelSeeder.php
+++ b/database/seeders/QuestionLevelSeeder.php
@@ -3,7 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Question;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class QuestionLevelSeeder extends Seeder

--- a/database/seeders/QuestionSeeder.php
+++ b/database/seeders/QuestionSeeder.php
@@ -6,7 +6,7 @@ use App\Models\ChatGPTExplanation;
 use App\Models\Question;
 use App\Models\QuestionHint;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 abstract class QuestionSeeder extends Seeder

--- a/database/seeders/QuestionTenseAssignmentSeeder.php
+++ b/database/seeders/QuestionTenseAssignmentSeeder.php
@@ -1,7 +1,7 @@
 <?php
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Models\Question;
 use App\Models\Tag;
 

--- a/database/seeders/QuizPresentSimpleSeeder.php
+++ b/database/seeders/QuizPresentSimpleSeeder.php
@@ -1,7 +1,7 @@
 <?php
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/RevisionTensesFullSeeder.php
+++ b/database/seeders/RevisionTensesFullSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/SentenceTranslationSeeder.php
+++ b/database/seeders/SentenceTranslationSeeder.php
@@ -3,7 +3,7 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Models\Sentence;
 use Illuminate\Support\Str;
 

--- a/database/seeders/ShortAnswersSeeder.php
+++ b/database/seeders/ShortAnswersSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/SimplePresentPastSeeder.php
+++ b/database/seeders/SimplePresentPastSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/SomeAnyTest2Seeder.php
+++ b/database/seeders/SomeAnyTest2Seeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/SomeAnyTestSeeder.php
+++ b/database/seeders/SomeAnyTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/TenseTagsSeeder.php
+++ b/database/seeders/TenseTagsSeeder.php
@@ -1,7 +1,7 @@
 <?php
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Models\Tag;
 
 class TenseTagsSeeder extends Seeder

--- a/database/seeders/TestContiniusesSeeder.php
+++ b/database/seeders/TestContiniusesSeeder.php
@@ -7,7 +7,7 @@ use App\Models\Source;
 use App\Models\Tag;
 use App\Models\Test;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class TestContiniusesSeeder extends Seeder

--- a/database/seeders/TestsSqlSeeder.php
+++ b/database/seeders/TestsSqlSeeder.php
@@ -1,7 +1,7 @@
 <?php
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
 class TestsSqlSeeder extends Seeder

--- a/database/seeders/ThereIsThereAreImageTestSeeder.php
+++ b/database/seeders/ThereIsThereAreImageTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\{Category, Source, Tag};
 use Illuminate\Support\Str;

--- a/database/seeders/ThereIsThereAreSeeder.php
+++ b/database/seeders/ThereIsThereAreSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/ThereIsThereAreTestSeeder.php
+++ b/database/seeders/ThereIsThereAreTestSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Source;
 use App\Models\Tag;

--- a/database/seeders/ThereIsThereAreWorksheetSeeder.php
+++ b/database/seeders/ThereIsThereAreWorksheetSeeder.php
@@ -6,7 +6,7 @@ use App\Models\Category;
 use App\Models\Source;
 use App\Models\Tag;
 use App\Services\QuestionSeedingService;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Str;
 
 class ThereIsThereAreWorksheetSeeder extends Seeder

--- a/database/seeders/ThisThatTheseThoseExercise2Seeder.php
+++ b/database/seeders/ThisThatTheseThoseExercise2Seeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/ThisThatTheseThoseExercise3Seeder.php
+++ b/database/seeders/ThisThatTheseThoseExercise3Seeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/ThisThatTheseThoseSeeder.php
+++ b/database/seeders/ThisThatTheseThoseSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/ToBeTenseSeeder.php
+++ b/database/seeders/ToBeTenseSeeder.php
@@ -1,7 +1,7 @@
 <?php 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Services\QuestionSeedingService;
 use App\Models\Category;
 use App\Models\Source;

--- a/database/seeders/WordsFromOptionsSeeder.php
+++ b/database/seeders/WordsFromOptionsSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Models\{QuestionOption, Word};
 
 class WordsFromOptionsSeeder extends Seeder

--- a/database/seeders/WordsFromSentencesSeeder.php
+++ b/database/seeders/WordsFromSentencesSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use App\Models\{Question, Sentence, Word};
 
 class WordsFromSentencesSeeder extends Seeder

--- a/database/seeders/WordsWithTranslationsSeeder.php
+++ b/database/seeders/WordsWithTranslationsSeeder.php
@@ -5,7 +5,7 @@ namespace Database\Seeders;
 use App\Models\Tag;
 use App\Models\Translate;
 use App\Models\Word;
-use Illuminate\Database\Seeder;
+use App\Support\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
 class WordsWithTranslationsSeeder extends Seeder


### PR DESCRIPTION
## Summary
- add a `seed_runs` table to record when seeders run
- introduce a base seeder that logs each execution into the tracking table
- update all project seeders to use the logging base class

## Testing
- php artisan migrate --database=sqlite --path=database/migrations/2025_10_05_190829_create_seed_runs_table.php --force

------
https://chatgpt.com/codex/tasks/task_e_68e2c1e76c94832a985ced47466bb250