### PR TITLE
Add management UI for structured pages v2

### DIFF
--- a/app/Http/Controllers/PageV2ManageController.php
+++ b/app/Http/Controllers/PageV2ManageController.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Page;
+use App\Models\TextBlock;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class PageV2ManageController extends Controller
+{
+    public function index()
+    {
+        $pages = Page::query()->orderBy('title')->get();
+
+        return view('engram.pages.v2.manage.index', [
+            'pages' => $pages,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('engram.pages.v2.manage.create', [
+            'page' => new Page(),
+            'blockPayloads' => old('blocks', []),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $this->validatedData($request);
+
+        $page = Page::create([
+            'title' => $validated['title'],
+            'slug' => $validated['slug'],
+            'text' => $validated['text'] ?? '',
+        ]);
+
+        $this->syncBlocks($page, $validated['blocks'] ?? []);
+
+        return redirect()
+            ->route('pages-v2.manage.edit', $page)
+            ->with('status', 'Сторінку створено.');
+    }
+
+    public function edit(Page $page)
+    {
+        $blocks = $page->textBlocks()->orderBy('sort_order')->get();
+        $page->setRelation('textBlocks', $blocks);
+
+        $payloads = $blocks->map(function (TextBlock $block) {
+            return [
+                'id' => $block->id,
+                'locale' => $block->locale,
+                'type' => $block->type,
+                'column' => $block->column,
+                'heading' => $block->heading,
+                'css_class' => $block->css_class,
+                'sort_order' => $block->sort_order,
+                'body' => $block->body,
+            ];
+        })->values()->toArray();
+
+        return view('engram.pages.v2.manage.edit', [
+            'page' => $page,
+            'blockPayloads' => old('blocks', $payloads),
+        ]);
+    }
+
+    public function update(Request $request, Page $page): RedirectResponse
+    {
+        $validated = $this->validatedData($request, $page);
+
+        $page->fill([
+            'title' => $validated['title'],
+            'slug' => $validated['slug'],
+            'text' => $validated['text'] ?? '',
+        ])->save();
+
+        $this->syncBlocks($page, $validated['blocks'] ?? []);
+
+        return back()->with('status', 'Зміни збережено.');
+    }
+
+    public function destroy(Page $page): RedirectResponse
+    {
+        $page->delete();
+
+        return redirect()
+            ->route('pages-v2.manage.index')
+            ->with('status', 'Сторінку видалено.');
+    }
+
+    protected function validatedData(Request $request, ?Page $page = null): array
+    {
+        $pageId = $page?->getKey();
+
+        return $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('pages', 'slug')->ignore($pageId),
+            ],
+            'text' => ['nullable', 'string'],
+            'blocks' => ['sometimes', 'array'],
+            'blocks.*.id' => ['nullable', 'integer', 'exists:text_blocks,id'],
+            'blocks.*.locale' => ['nullable', 'string', 'max:8'],
+            'blocks.*.type' => ['nullable', 'string', 'max:32'],
+            'blocks.*.column' => ['nullable', 'string', Rule::in(['left', 'right', ''])],
+            'blocks.*.heading' => ['nullable', 'string', 'max:255'],
+            'blocks.*.css_class' => ['nullable', 'string', 'max:255'],
+            'blocks.*.sort_order' => ['nullable', 'integer', 'min:0'],
+            'blocks.*.body' => ['nullable', 'string'],
+        ]);
+    }
+
+    protected function syncBlocks(Page $page, array $blocks): void
+    {
+        $persistedIds = [];
+
+        foreach ($blocks as $block) {
+            $attributes = [
+                'locale' => $block['locale'] ?? 'uk',
+                'type' => ($block['type'] ?? '') ?: 'box',
+                'column' => ($block['column'] ?? '') ?: null,
+                'heading' => $block['heading'] ?? null,
+                'css_class' => $block['css_class'] ?? null,
+                'sort_order' => $block['sort_order'] ?? 0,
+                'body' => $block['body'] ?? null,
+            ];
+
+            $shouldSkip = empty($block['id'])
+                && empty(trim((string) $attributes['heading']))
+                && empty(trim((string) $attributes['body']));
+
+            if ($shouldSkip) {
+                continue;
+            }
+
+            if (! empty($block['id'])) {
+                $model = $page->textBlocks()->whereKey($block['id'])->first();
+                if ($model) {
+                    $model->update($attributes);
+                    $persistedIds[] = $model->id;
+                }
+                continue;
+            }
+
+            $model = $page->textBlocks()->create($attributes);
+            $persistedIds[] = $model->id;
+        }
+
+        if (! empty($persistedIds)) {
+            $page->textBlocks()->whereNotIn('id', $persistedIds)->delete();
+        } else {
+            $page->textBlocks()->delete();
+        }
+    }
+}

--- a/resources/views/engram/pages/v2/manage/create.blade.php
+++ b/resources/views/engram/pages/v2/manage/create.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.engram')
+
+@section('title', 'Створити сторінку')
+
+@section('content')
+    @php
+        $normalizedBlocks = collect($blockPayloads ?? [])->map(function ($block, $index) {
+            return [
+                'id' => $block['id'] ?? null,
+                'locale' => $block['locale'] ?? 'uk',
+                'type' => $block['type'] ?? 'box',
+                'column' => $block['column'] ?? 'left',
+                'heading' => $block['heading'] ?? '',
+                'css_class' => $block['css_class'] ?? '',
+                'sort_order' => $block['sort_order'] ?? (($index + 1) * 10),
+                'body' => $block['body'] ?? '',
+            ];
+        })->values()->toArray();
+    @endphp
+
+    @include('engram.pages.v2.manage.partials.form', [
+        'heading' => 'Нова сторінка',
+        'description' => 'Створіть структуру сторінки та додайте блоки контенту.',
+        'formAction' => route('pages-v2.manage.store'),
+        'formMethod' => 'POST',
+        'submitLabel' => 'Створити сторінку',
+        'page' => $page,
+        'initialBlocks' => $normalizedBlocks,
+        'defaultLocale' => app()->getLocale(),
+    ])
+@endsection

--- a/resources/views/engram/pages/v2/manage/edit.blade.php
+++ b/resources/views/engram/pages/v2/manage/edit.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.engram')
+
+@section('title', 'Редагувати сторінку')
+
+@section('content')
+    @php
+        $normalizedBlocks = collect($blockPayloads ?? [])->map(function ($block, $index) {
+            return [
+                'id' => $block['id'] ?? null,
+                'locale' => $block['locale'] ?? 'uk',
+                'type' => $block['type'] ?? 'box',
+                'column' => $block['column'] ?? 'left',
+                'heading' => $block['heading'] ?? '',
+                'css_class' => $block['css_class'] ?? '',
+                'sort_order' => $block['sort_order'] ?? (($index + 1) * 10),
+                'body' => $block['body'] ?? '',
+            ];
+        })->values()->toArray();
+    @endphp
+
+    @include('engram.pages.v2.manage.partials.form', [
+        'heading' => 'Редагування: ' . $page->title,
+        'description' => 'Оновіть контент блоків та метадані сторінки.',
+        'formAction' => route('pages-v2.manage.update', $page),
+        'formMethod' => 'PUT',
+        'submitLabel' => 'Зберегти зміни',
+        'page' => $page,
+        'initialBlocks' => $normalizedBlocks,
+        'defaultLocale' => $page->textBlocks->first()->locale ?? app()->getLocale(),
+    ])
+@endsection

--- a/resources/views/engram/pages/v2/manage/index.blade.php
+++ b/resources/views/engram/pages/v2/manage/index.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.engram')
+
+@section('title', 'Сторінки v2 — керування')
+
+@section('content')
+    <div class="max-w-6xl mx-auto space-y-6">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold">Сторінки v2</h1>
+                <p class="text-muted-foreground">Керуйте сторінками, редагуйте та оновлюйте блоки контенту.</p>
+            </div>
+            <a href="{{ route('pages-v2.manage.create') }}" class="inline-flex items-center rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-soft">+ Нова сторінка</a>
+        </div>
+
+        @if (session('status'))
+            <div class="rounded-xl border border-success/30 bg-success/10 p-4 text-sm text-success">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        <div class="overflow-hidden rounded-2xl border border-border bg-card shadow-soft">
+            <table class="min-w-full divide-y divide-border/70 text-sm">
+                <thead class="bg-muted/50 text-muted-foreground">
+                    <tr>
+                        <th class="px-4 py-3 text-left font-medium">Назва</th>
+                        <th class="px-4 py-3 text-left font-medium">Slug</th>
+                        <th class="px-4 py-3 text-left font-medium">Оновлено</th>
+                        <th class="px-4 py-3 text-right font-medium">Дії</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-border/60">
+                    @forelse ($pages as $page)
+                        <tr class="hover:bg-muted/40">
+                            <td class="px-4 py-3 font-medium">
+                                <a href="{{ route('pages-v2.show', $page->slug) }}" class="hover:underline" target="_blank" rel="noopener">{{ $page->title }}</a>
+                            </td>
+                            <td class="px-4 py-3 text-muted-foreground">{{ $page->slug }}</td>
+                            <td class="px-4 py-3 text-muted-foreground">{{ $page->updated_at?->diffForHumans() }}</td>
+                            <td class="px-4 py-3">
+                                <div class="flex justify-end gap-2">
+                                    <a href="{{ route('pages-v2.manage.edit', $page) }}" class="rounded-lg border border-border px-3 py-1 text-sm">Редагувати</a>
+                                    <form action="{{ route('pages-v2.manage.destroy', $page) }}" method="POST" onsubmit="return confirm('Видалити сторінку?');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-1 text-sm text-destructive">Видалити</button>
+                                    </form>
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="4" class="px-4 py-6 text-center text-muted-foreground">Ще немає сторінок. Створіть першу сторінку.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+@endsection

--- a/resources/views/engram/pages/v2/manage/partials/form.blade.php
+++ b/resources/views/engram/pages/v2/manage/partials/form.blade.php
@@ -1,0 +1,177 @@
+<div class="max-w-6xl mx-auto space-y-6" x-data="pageEditor({
+    initialBlocks: @json($initialBlocks),
+    defaultLocale: '{{ $defaultLocale }}',
+})">
+    <div class="flex items-center justify-between">
+        <div>
+            <h1 class="text-2xl font-semibold">{{ $heading }}</h1>
+            <p class="text-muted-foreground">{{ $description }}</p>
+        </div>
+        <a href="{{ route('pages-v2.manage.index') }}" class="inline-flex items-center rounded-xl border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground">← До списку</a>
+    </div>
+
+    @if ($errors->any())
+        <div class="rounded-xl border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+            <div class="font-semibold mb-2">Перевірте форму:</div>
+            <ul class="list-disc space-y-1 pl-5">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    @if (session('status'))
+        <div class="rounded-xl border border-success/30 bg-success/10 p-4 text-sm text-success">
+            {{ session('status') }}
+        </div>
+    @endif
+
+    <form method="POST" action="{{ $formAction }}" class="space-y-8">
+        @csrf
+        @if ($formMethod === 'PUT')
+            @method('PUT')
+        @endif
+
+        <section class="rounded-2xl border border-border bg-card p-6 shadow-soft space-y-6">
+            <header>
+                <h2 class="text-xl font-semibold">Основна інформація</h2>
+                <p class="text-sm text-muted-foreground">Назва, slug та короткий опис для картки.</p>
+            </header>
+
+            <div class="grid gap-6 md:grid-cols-2">
+                <label class="space-y-2">
+                    <span class="text-sm font-medium">Заголовок</span>
+                    <input type="text" name="title" value="{{ old('title', $page->title) }}" required class="w-full rounded-xl border border-input bg-background px-3 py-2" />
+                </label>
+                <label class="space-y-2">
+                    <span class="text-sm font-medium">Slug</span>
+                    <input type="text" name="slug" value="{{ old('slug', $page->slug) }}" required class="w-full rounded-xl border border-input bg-background px-3 py-2" />
+                </label>
+            </div>
+
+            <label class="space-y-2 block">
+                <span class="text-sm font-medium">Короткий опис</span>
+                <textarea name="text" rows="3" class="w-full rounded-xl border border-input bg-background px-3 py-2">{{ old('text', $page->text) }}</textarea>
+                <p class="text-xs text-muted-foreground">Використовується у списку сторінок.</p>
+            </label>
+        </section>
+
+        <section class="space-y-4 rounded-2xl border border-border bg-card p-6 shadow-soft">
+            <header class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <h2 class="text-xl font-semibold">Блоки сторінки</h2>
+                    <p class="text-sm text-muted-foreground">Додайте інформаційні блоки, підзаголовок та інші елементи.</p>
+                </div>
+                <div class="flex gap-2">
+                    <button type="button" class="inline-flex items-center rounded-xl border border-border px-3 py-2 text-sm font-medium" @click="addBlock('subtitle')">+ Підзаголовок</button>
+                    <button type="button" class="inline-flex items-center rounded-xl bg-primary px-3 py-2 text-sm font-medium text-primary-foreground" @click="addBlock('box')">+ Додати блок</button>
+                </div>
+            </header>
+
+            <template x-if="!blocks.length">
+                <p class="text-sm text-muted-foreground">Поки що немає блоків. Додайте перший, щоб почати.</p>
+            </template>
+
+            <div class="space-y-4">
+                <template x-for="(block, index) in blocks" :key="block.uid">
+                    <div class="rounded-2xl border border-border/70 bg-background p-4 space-y-4">
+                        <div class="flex flex-wrap items-center justify-between gap-3">
+                            <div class="flex items-center gap-2 text-sm">
+                                <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-muted font-semibold" x-text="index + 1"></span>
+                                <span class="font-medium" x-text="block.type === 'subtitle' ? 'Підзаголовок' : 'Контентний блок'"></span>
+                            </div>
+                            <div class="flex items-center gap-2 text-sm text-muted-foreground">
+                                <button type="button" class="rounded-lg border border-border px-3 py-1" @click="duplicateBlock(index)">Дублювати</button>
+                                <button type="button" class="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-1 text-destructive" @click="removeBlock(index)">Видалити</button>
+                            </div>
+                        </div>
+
+                        <input type="hidden" :name="`blocks[${index}][id]`" x-model="block.id">
+
+                        <div class="grid gap-4 md:grid-cols-2">
+                            <label class="space-y-1 text-sm">
+                                <span class="font-medium">Мова</span>
+                                <input type="text" maxlength="8" :name="`blocks[${index}][locale]`" class="w-full rounded-xl border border-input bg-background px-3 py-2" x-model="block.locale">
+                            </label>
+                            <label class="space-y-1 text-sm">
+                                <span class="font-medium">Тип</span>
+                                <input type="text" maxlength="32" :name="`blocks[${index}][type]`" class="w-full rounded-xl border border-input bg-background px-3 py-2" x-model="block.type">
+                            </label>
+                            <label class="space-y-1 text-sm">
+                                <span class="font-medium">Колонка</span>
+                                <select :name="`blocks[${index}][column]`" class="w-full rounded-xl border border-input bg-background px-3 py-2" x-model="block.column">
+                                    <option value="">—</option>
+                                    <option value="left">Ліва</option>
+                                    <option value="right">Права</option>
+                                </select>
+                            </label>
+                            <label class="space-y-1 text-sm">
+                                <span class="font-medium">Сортування</span>
+                                <input type="number" min="0" :name="`blocks[${index}][sort_order]`" class="w-full rounded-xl border border-input bg-background px-3 py-2" x-model.number="block.sort_order">
+                            </label>
+                            <label class="space-y-1 text-sm md:col-span-2">
+                                <span class="font-medium">CSS клас</span>
+                                <input type="text" :name="`blocks[${index}][css_class]`" class="w-full rounded-xl border border-input bg-background px-3 py-2" x-model="block.css_class">
+                            </label>
+                            <label class="space-y-1 text-sm md:col-span-2" x-show="block.type !== 'subtitle'">
+                                <span class="font-medium">Заголовок</span>
+                                <input type="text" :name="`blocks[${index}][heading]`" class="w-full rounded-xl border border-input bg-background px-3 py-2" x-model="block.heading">
+                            </label>
+                            <label class="space-y-1 text-sm md:col-span-2">
+                                <span class="font-medium">Контент</span>
+                                <textarea rows="6" :name="`blocks[${index}][body]`" class="w-full rounded-xl border border-input bg-background px-3 py-2" x-model="block.body"></textarea>
+                            </label>
+                        </div>
+                    </div>
+                </template>
+            </div>
+        </section>
+
+        <div class="flex items-center justify-end gap-3">
+            <a href="{{ route('pages-v2.manage.index') }}" class="rounded-xl border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground">Скасувати</a>
+            <button type="submit" class="rounded-xl bg-primary px-6 py-2 text-sm font-semibold text-primary-foreground">
+                {{ $submitLabel }}
+            </button>
+        </div>
+    </form>
+</div>
+
+@once
+    <script>
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('pageEditor', (config) => ({
+                defaultLocale: config.defaultLocale || 'uk',
+                blocks: (config.initialBlocks || []).map((block, index) => ({
+                    ...block,
+                    uid: block.uid || `block-${block.id || index}-${Date.now()}`,
+                })),
+                nextUid: Date.now(),
+                addBlock(type = 'box') {
+                    this.blocks.push({
+                        id: null,
+                        uid: `new-${this.nextUid++}`,
+                        locale: this.defaultLocale,
+                        type: type,
+                        column: type === 'subtitle' ? '' : 'left',
+                        heading: '',
+                        css_class: type === 'subtitle' ? 'gw-subtitle' : '',
+                        sort_order: (this.blocks.length + 1) * 10,
+                        body: '',
+                    });
+                },
+                removeBlock(index) {
+                    this.blocks.splice(index, 1);
+                },
+                duplicateBlock(index) {
+                    const original = this.blocks[index];
+                    const clone = JSON.parse(JSON.stringify(original));
+                    clone.id = null;
+                    clone.uid = `copy-${this.nextUid++}`;
+                    clone.sort_order = (this.blocks.length + 1) * 10;
+                    this.blocks.splice(index + 1, 0, clone);
+                },
+            }));
+        });
+    </script>
+@endonce

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\GrammarTestController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\PageController;
 use App\Http\Controllers\PageV2Controller;
+use App\Http\Controllers\PageV2ManageController;
 use App\Http\Controllers\QuestionAnswerController;
 use App\Http\Controllers\QuestionController;
 use App\Http\Controllers\QuestionHelpController;
@@ -58,6 +59,16 @@ Route::middleware('auth.admin')->group(function () {
     Route::get('/pages', [PageController::class, 'index'])->name('pages.index');
     Route::get('/pages/{slug}', [PageController::class, 'show'])->name('pages.show');
     Route::get('/pages-v2', [PageV2Controller::class, 'index'])->name('pages-v2.index');
+
+    Route::prefix('/pages-v2/manage')->name('pages-v2.manage.')->group(function () {
+        Route::get('/', [PageV2ManageController::class, 'index'])->name('index');
+        Route::get('/create', [PageV2ManageController::class, 'create'])->name('create');
+        Route::post('/', [PageV2ManageController::class, 'store'])->name('store');
+        Route::get('/{page}/edit', [PageV2ManageController::class, 'edit'])->name('edit');
+        Route::put('/{page}', [PageV2ManageController::class, 'update'])->name('update');
+        Route::delete('/{page}', [PageV2ManageController::class, 'destroy'])->name('destroy');
+    });
+
     Route::get('/pages-v2/{slug}', [PageV2Controller::class, 'show'])->name('pages-v2.show');
     
     Route::get('/words/test', [WordsTestController::class, 'index'])->name('words.test');


### PR DESCRIPTION
## Summary
- add a dedicated PageV2ManageController that validates and syncs page blocks
- expose admin routes for listing, creating, updating, and deleting v2 pages
- build Tailwind/Alpine-based views for managing pages and their structured blocks

## Testing
- php artisan test *(fails: vendor/autoload.php missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e419df54b0832a8f193c279791461a