### PR TITLE
Add V2 conditional worksheet seeders

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,8 @@ use Database\Seeders\V2\FutureTensesPracticeV2Seeder;
 use Database\Seeders\V2\FirstConditionalPracticeV2Seeder;
 use Database\Seeders\V2\FirstConditionalChooseABCV2Seeder;
 use Database\Seeders\V2\SecondConditionalTestV2Seeder;
+use Database\Seeders\V2\ConditionalsType1And2WorksheetV2Seeder;
+use Database\Seeders\V2\ConditionalsZeroToSecondWorksheetV2Seeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -103,6 +105,8 @@ class DatabaseSeeder extends Seeder
             PastPerfectVsPastSimpleTestSeeder::class,
             PastPerfectSimpleVsContinuousCTestSeeder::class,
             PastTimeClausesMixedTestSeeder::class,
+            ConditionalsType1And2WorksheetV2Seeder::class,
+            ConditionalsZeroToSecondWorksheetV2Seeder::class,
             FutureTensesPracticeV2Seeder::class,
             FirstConditionalPracticeV2Seeder::class,
             FirstConditionalChooseABCV2Seeder::class,

--- a/database/seeders/V2/ConditionalsType1And2WorksheetV2Seeder.php
+++ b/database/seeders/V2/ConditionalsType1And2WorksheetV2Seeder.php
@@ -1,0 +1,621 @@
+<?php
+
+namespace Database\Seeders\V2;
+
+use App\Models\Category;
+use App\Models\Source;
+use App\Models\Tag;
+use Database\Seeders\QuestionSeeder;
+
+class ConditionalsType1And2WorksheetV2Seeder extends QuestionSeeder
+{
+    private array $levelDifficulty = [
+        'A1' => 1,
+        'A2' => 2,
+        'B1' => 3,
+        'B2' => 4,
+        'C1' => 5,
+        'C2' => 5,
+    ];
+
+    private array $hintTemplates = [
+        'if_present_simple' => "Час: First Conditional.\nФормула: **if + Present Simple**.\nПояснення: Умовна частина типу 1 описує реальну можливість, тому використовуємо Present Simple (наприклад, форма від «%verb%» для %subject%).\nПриклад: *%example%*",
+        'if_past_simple' => "Час: Second Conditional.\nФормула: **if + Past Simple**.\nПояснення: Уявну ситуацію у другому умовному передаємо Past Simple від дієслова «%verb%».\nПриклад: *%example%*",
+        'result_will_simple' => "Час: First Conditional.\nФормула: **will + V1** (наприклад, «will %verb%»).\nПояснення: Результат у типі 1 виражаємо через will + базове дієслово.\nПриклад: *%example%*",
+        'result_will_negative' => "Час: First Conditional.\nФормула: **will not / won't + V1**.\nПояснення: Для заперечення в головному реченні типу 1 вживаємо won't + базове дієслово «%verb%».\nПриклад: *%example%*",
+        'result_would_simple' => "Час: Second Conditional.\nФормула: **would + V1** (наприклад, «would %verb%»).\nПояснення: У результаті другого умовного використовуємо would + базове дієслово.\nПриклад: *%example%*",
+        'result_would_negative' => "Час: Second Conditional.\nФормула: **would not / wouldn't + V1**.\nПояснення: Заперечення у другому умовному будуємо через wouldn't + базове дієслово «%verb%».\nПриклад: *%example%*",
+        'result_modal_must_not' => "Час: First Conditional з модальним дієсловом must.\nФормула: **must not + V1** (наприклад, «must not %verb%»).\nПояснення: Заборону в результаті типу 1 передаємо через must not + базове дієслово.\nПриклад: *%example%*",
+    ];
+
+    private array $explanationTemplates = [
+        'if_present_simple' => [
+            'correct' => "✅ «%option%» — правильна форма Present Simple у підрядному реченні для %subject%.\nПриклад: *%example%*",
+            'future' => "❌ «%option%» містить will, але в if-клауза типу 1 ми не використовуємо will.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; для реальної умови потрібен Present Simple.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» належить до другого умовного з would, а не до першого.\nПриклад: *%example%*",
+            'continuous' => "❌ «%option%» — тривала форма, але if-клауза типу 1 потребує Present Simple.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'if_past_simple' => [
+            'correct' => "✅ «%option%» — правильна форма Past Simple у підрядному реченні другого умовного для %subject%.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple, але друга умова потребує Past Simple.\nПриклад: *%example%*",
+            'future' => "❌ «%option%» містить will, що притаманно першому умовному. Тут потрібен Past Simple.\nПриклад: *%example%*",
+            'perfect' => "❌ «%option%» — форма Third Conditional (had + V3). У другому умовному вона не використовується.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» — результат з would, а не частина з if.\nПриклад: *%example%*",
+            'was' => "❌ «%option%» — форма was; у другому умовному для будь-якого підмета вживаємо were.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_will_simple' => [
+            'correct' => "✅ «%option%» — правильна модель will + V1 для результату першого умовного.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» використовує would, а це друга умова. У типі 1 потрібен will.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple; результат має містити will.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple, а нам потрібен will + базове дієслово.\nПриклад: *%example%*",
+            'continuous' => "❌ «%option%» — тривала форма; завдання перевіряє просту конструкцію will + V1.\nПриклад: *%example%*",
+            'extra_will' => "❌ «%option%» повторює will, хоча допоміжне слово вже є у реченні. Дивись приклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_will_negative' => [
+            'correct' => "✅ «%option%» — правильне заперечення won't + V1 для результату типу 1.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» має would, що властиво другому умовному. Тут потрібно won't.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple без will; у першому умовному результат формуємо через won't.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; правильне заперечення — won't + V1.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_would_simple' => [
+            'correct' => "✅ «%option%» — правильна конструкція would + V1 для результату другого умовного.\nПриклад: *%example%*",
+            'will' => "❌ «%option%» з will належить до першого умовного, а тут потрібен would.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple; у другому умовному результат описуємо через would.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; потрібно would + V1.\nПриклад: *%example%*",
+            'continuous' => "❌ «%option%» — тривала форма; ми тренуємо просту модель would + V1.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_would_negative' => [
+            'correct' => "✅ «%option%» — правильне заперечення wouldn't + V1 у другому умовному.\nПриклад: *%example%*",
+            'will' => "❌ «%option%» з won't відповідає першому умовному, а в другому треба wouldn't.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple; уявний результат вимагає wouldn't + V1.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; у другому умовному потрібна форма wouldn't + V1.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_modal_must_not' => [
+            'correct' => "✅ «%option%» — правильна модальна форма must not + V1 для результату першого умовного.\nПриклад: *%example%*",
+            'will' => "❌ «%option%» містить will, але тут потрібна заборона must not.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple без модального дієслова must.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» належить до другого умовного з would. Тут вживаємо must not.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+    ];
+
+    public function run(): void
+    {
+        $categoryId = Category::firstOrCreate(['name' => 'Conditionals'])->id;
+        $sourceId = Source::firstOrCreate(['name' => 'Worksheet: Conditionals Type 1 & 2 (V2)'])->id;
+
+        $themeTagId = Tag::firstOrCreate(
+            ['name' => 'Mixed Conditionals Practice (Type 1 & 2)'],
+            ['category' => 'English Grammar Theme']
+        )->id;
+
+        $detailTagId = Tag::firstOrCreate(
+            ['name' => 'Conditional Sentence Gap Fill'],
+            ['category' => 'English Grammar Detail']
+        )->id;
+
+        $structureTagId = Tag::firstOrCreate(
+            ['name' => 'Conditional Sentences (Type 1 & 2)'],
+            ['category' => 'English Grammar Structure']
+        )->id;
+
+        $tenseTags = [
+            'First Conditional' => Tag::firstOrCreate(['name' => 'First Conditional'], ['category' => 'English Grammar Tense'])->id,
+            'Second Conditional' => Tag::firstOrCreate(['name' => 'Second Conditional'], ['category' => 'English Grammar Tense'])->id,
+        ];
+
+        $entries = $this->questionEntries();
+
+        $items = [];
+        $meta = [];
+
+        foreach ($entries as $index => $entry) {
+            $answersMap = [];
+            $verbHints = [];
+            $optionSets = [];
+            $optionMarkerMap = [];
+            $optionReasons = [];
+
+            foreach ($entry['markers'] as $marker => $markerData) {
+                $answersMap[$marker] = $this->normalizeValue($markerData['answer']);
+                $verbHints[$marker] = $markerData['verb_hint'] ?? ($markerData['verb'] ?? null);
+
+                $options = [];
+                foreach ($markerData['options'] as $option) {
+                    $value = $this->normalizeValue($option['value']);
+                    $options[] = $value;
+                    $optionMarkerMap[$value] = $marker;
+                    $optionReasons[$marker][$value] = $option['reason'] ?? 'default';
+                }
+
+                $optionSets[$marker] = array_values(array_unique($options));
+            }
+
+            $example = $this->formatExample($entry['question'], $answersMap);
+
+            $explanations = [];
+            foreach ($optionMarkerMap as $value => $marker) {
+                $context = $entry['markers'][$marker] ?? [];
+                $reason = $optionReasons[$marker][$value] ?? 'default';
+                $explanations[$value] = $this->buildExplanation(
+                    $context['type'] ?? '',
+                    $reason,
+                    $value,
+                    $context,
+                    $example
+                );
+            }
+
+            $hints = [];
+            foreach ($entry['markers'] as $marker => $markerData) {
+                $hints[$marker] = $this->buildHint($markerData['type'], $markerData, $example);
+            }
+
+            $answers = [];
+            foreach ($answersMap as $marker => $answer) {
+                $answers[] = [
+                    'marker' => $marker,
+                    'answer' => $answer,
+                    'verb_hint' => $this->normalizeHint($verbHints[$marker] ?? null),
+                ];
+            }
+
+            $flatOptions = [];
+            foreach ($optionSets as $options) {
+                foreach ($options as $value) {
+                    $flatOptions[] = $value;
+                }
+            }
+            $flatOptions = array_values(array_unique($flatOptions));
+
+            $tagIds = [$themeTagId, $detailTagId, $structureTagId];
+            foreach ($entry['tenses'] as $tense) {
+                if (isset($tenseTags[$tense])) {
+                    $tagIds[] = $tenseTags[$tense];
+                }
+            }
+
+            $uuid = $this->generateQuestionUuid($index + 1, $entry['question']);
+
+            $items[] = [
+                'uuid' => $uuid,
+                'question' => $entry['question'],
+                'category_id' => $categoryId,
+                'difficulty' => $this->levelDifficulty[$entry['level']] ?? 3,
+                'source_id' => $sourceId,
+                'flag' => 0,
+                'level' => $entry['level'],
+                'tag_ids' => array_values(array_unique($tagIds)),
+                'answers' => $answers,
+                'options' => $flatOptions,
+                'variants' => [$entry['question']],
+            ];
+
+            $meta[] = [
+                'uuid' => $uuid,
+                'answers' => $answersMap,
+                'option_markers' => $optionMarkerMap,
+                'hints' => $hints,
+                'explanations' => $explanations,
+            ];
+        }
+
+        $this->seedQuestionData($items, $meta);
+    }
+
+    private function questionEntries(): array
+    {
+        return [
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If John gave me the money, I {a1} it on clothes.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'result_would_simple',
+                        'subject' => 'I',
+                        'verb' => 'spend',
+                        'verb_hint' => 'spend',
+                        'answer' => 'would spend',
+                        'options' => [
+                            ['value' => 'would spend', 'reason' => 'correct'],
+                            ['value' => 'will spend', 'reason' => 'will'],
+                            ['value' => 'spend', 'reason' => 'present'],
+                            ['value' => 'spent', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'Cathy will be upset if she {a1} Michael at the party.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_present_simple',
+                        'subject' => 'she',
+                        'verb' => 'see',
+                        'verb_hint' => 'see',
+                        'answer' => 'sees',
+                        'options' => [
+                            ['value' => 'sees', 'reason' => 'correct'],
+                            ['value' => 'will see', 'reason' => 'future'],
+                            ['value' => 'saw', 'reason' => 'past'],
+                            ['value' => 'would see', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'Rosemary would buy the house if she {a1} the money.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_past_simple',
+                        'subject' => 'she',
+                        'verb' => 'have',
+                        'verb_hint' => 'have',
+                        'answer' => 'had',
+                        'options' => [
+                            ['value' => 'had', 'reason' => 'correct'],
+                            ['value' => 'has', 'reason' => 'present'],
+                            ['value' => 'would have', 'reason' => 'would'],
+                            ['value' => 'have had', 'reason' => 'perfect'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'I won\'t call him if I {a1} to.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_present_simple',
+                        'subject' => 'I',
+                        'verb' => 'not want',
+                        'verb_hint' => 'not want',
+                        'answer' => "don't want",
+                        'options' => [
+                            ['value' => "don't want", 'reason' => 'correct'],
+                            ['value' => "won't want", 'reason' => 'future'],
+                            ['value' => "didn't want", 'reason' => 'past'],
+                            ['value' => "wouldn't want", 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'If you have the treasure map, you {a1} it to us.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'result_modal_must_not',
+                        'subject' => 'you',
+                        'verb' => 'show',
+                        'verb_hint' => 'not show',
+                        'answer' => 'must not show',
+                        'options' => [
+                            ['value' => 'must not show', 'reason' => 'correct'],
+                            ['value' => 'will not show', 'reason' => 'will'],
+                            ['value' => 'do not show', 'reason' => 'present'],
+                            ['value' => 'would not show', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If you {a1} the lottery, what would you buy?',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_past_simple',
+                        'subject' => 'you',
+                        'verb' => 'win',
+                        'verb_hint' => 'win',
+                        'answer' => 'won',
+                        'options' => [
+                            ['value' => 'won', 'reason' => 'correct'],
+                            ['value' => 'win', 'reason' => 'present'],
+                            ['value' => 'will win', 'reason' => 'future'],
+                            ['value' => 'would win', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If I {a1} you, I {a2} the same in your place.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_past_simple',
+                        'subject' => 'I',
+                        'verb' => 'be',
+                        'verb_hint' => 'be',
+                        'answer' => 'were',
+                        'options' => [
+                            ['value' => 'were', 'reason' => 'correct'],
+                            ['value' => 'was', 'reason' => 'was'],
+                            ['value' => 'am', 'reason' => 'present'],
+                            ['value' => 'would be', 'reason' => 'would'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_would_simple',
+                        'subject' => 'I',
+                        'verb' => 'do',
+                        'verb_hint' => 'do',
+                        'answer' => 'would do',
+                        'options' => [
+                            ['value' => 'would do', 'reason' => 'correct'],
+                            ['value' => 'will do', 'reason' => 'will'],
+                            ['value' => 'did', 'reason' => 'past'],
+                            ['value' => 'do', 'reason' => 'present'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If I {a1} to the cinema, I would be extremely sad.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_past_simple',
+                        'subject' => 'I',
+                        'verb' => 'not go',
+                        'verb_hint' => 'not go',
+                        'answer' => "didn't go",
+                        'options' => [
+                            ['value' => "didn't go", 'reason' => 'correct'],
+                            ['value' => "don't go", 'reason' => 'present'],
+                            ['value' => "won't go", 'reason' => 'future'],
+                            ['value' => "hadn't gone", 'reason' => 'perfect'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If I {a1} too tired, I {a2} her to go to the cinema with me.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_past_simple',
+                        'subject' => 'I',
+                        'verb' => 'be',
+                        'verb_hint' => 'be',
+                        'answer' => 'were',
+                        'options' => [
+                            ['value' => 'were', 'reason' => 'correct'],
+                            ['value' => 'was', 'reason' => 'was'],
+                            ['value' => 'am', 'reason' => 'present'],
+                            ['value' => 'would be', 'reason' => 'would'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_would_simple',
+                        'subject' => 'I',
+                        'verb' => 'ask',
+                        'verb_hint' => 'ask',
+                        'answer' => 'would ask',
+                        'options' => [
+                            ['value' => 'would ask', 'reason' => 'correct'],
+                            ['value' => 'will ask', 'reason' => 'will'],
+                            ['value' => 'ask', 'reason' => 'present'],
+                            ['value' => 'asked', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'If my train isn\'t late, I {a1} in school on time.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'result_will_simple',
+                        'subject' => 'I',
+                        'verb' => 'be',
+                        'verb_hint' => 'be',
+                        'answer' => 'will be',
+                        'options' => [
+                            ['value' => 'will be', 'reason' => 'correct'],
+                            ['value' => 'would be', 'reason' => 'would'],
+                            ['value' => 'am', 'reason' => 'present'],
+                            ['value' => 'was', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['Second Conditional'],
+                'question' => 'You {a1} so unfit if you {a2} more exercise.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'result_would_negative',
+                        'subject' => 'you',
+                        'verb' => 'not be',
+                        'verb_hint' => 'not be',
+                        'answer' => "wouldn't be",
+                        'options' => [
+                            ['value' => "wouldn't be", 'reason' => 'correct'],
+                            ['value' => "won't be", 'reason' => 'will'],
+                            ['value' => "aren't", 'reason' => 'present'],
+                            ['value' => "weren't", 'reason' => 'past'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'if_past_simple',
+                        'subject' => 'you',
+                        'verb' => 'take',
+                        'verb_hint' => 'take',
+                        'answer' => 'took',
+                        'options' => [
+                            ['value' => 'took', 'reason' => 'correct'],
+                            ['value' => 'take', 'reason' => 'present'],
+                            ['value' => 'will take', 'reason' => 'future'],
+                            ['value' => 'taken', 'reason' => 'perfect'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['First Conditional'],
+                'question' => 'If he doesn\'t work harder, he {a1} his job.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'result_will_negative',
+                        'subject' => 'he',
+                        'verb' => 'keep',
+                        'verb_hint' => 'not keep',
+                        'answer' => "won't keep",
+                        'options' => [
+                            ['value' => "won't keep", 'reason' => 'correct'],
+                            ['value' => "wouldn't keep", 'reason' => 'would'],
+                            ['value' => 'keeps', 'reason' => 'present'],
+                            ['value' => 'kept', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['First Conditional'],
+                'question' => 'If he doesn\'t pass the exam, will you {a1} him?',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'result_will_simple',
+                        'subject' => 'you',
+                        'verb' => 'help',
+                        'verb_hint' => 'help',
+                        'answer' => 'help',
+                        'options' => [
+                            ['value' => 'help', 'reason' => 'correct'],
+                            ['value' => 'will help', 'reason' => 'extra_will'],
+                            ['value' => 'helped', 'reason' => 'past'],
+                            ['value' => 'would help', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If he {a1} his scholarship, his friends would visit him more often.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_past_simple',
+                        'subject' => 'he',
+                        'verb' => 'not lose',
+                        'verb_hint' => 'not lose',
+                        'answer' => "didn't lose",
+                        'options' => [
+                            ['value' => "didn't lose", 'reason' => 'correct'],
+                            ['value' => "doesn't lose", 'reason' => 'present'],
+                            ['value' => "wouldn't lose", 'reason' => 'would'],
+                            ['value' => 'had not lost', 'reason' => 'perfect'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If he {a1} so far, his friends would visit him every weekend.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_past_simple',
+                        'subject' => 'he',
+                        'verb' => 'not live',
+                        'verb_hint' => 'not live',
+                        'answer' => "didn't live",
+                        'options' => [
+                            ['value' => "didn't live", 'reason' => 'correct'],
+                            ['value' => "doesn't live", 'reason' => 'present'],
+                            ['value' => 'lived', 'reason' => 'past'],
+                            ['value' => "wouldn't live", 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function buildHint(string $type, array $context, string $example): string
+    {
+        $template = $this->hintTemplates[$type] ?? "Час: Conditionals.\nПояснення: Оберіть форму, що відповідає правилу.\nПриклад: *%example%*";
+
+        return $this->renderTemplate($template, [
+            'subject' => $context['subject'] ?? '',
+            'verb' => $context['verb'] ?? '',
+            'example' => $example,
+        ]);
+    }
+
+    private function buildExplanation(string $type, string $reason, string $option, array $context, string $example): string
+    {
+        $templates = $this->explanationTemplates[$type] ?? [];
+        $template = $templates[$reason] ?? ($templates['default'] ?? "❌ Неправильний варіант.\nПриклад: *%example%*");
+
+        return $this->renderTemplate($template, [
+            'option' => $option,
+            'subject' => $context['subject'] ?? '',
+            'verb' => $context['verb'] ?? '',
+            'example' => $example,
+        ]);
+    }
+
+    private function renderTemplate(string $template, array $context): string
+    {
+        $replacements = [
+            '%option%' => $context['option'] ?? '',
+            '%verb%' => $context['verb'] ?? '',
+            '%example%' => $context['example'] ?? '',
+            '%subject%' => $this->subjectPhrase($context['subject'] ?? ''),
+        ];
+
+        return trim(strtr($template, $replacements));
+    }
+
+    private function subjectPhrase(?string $subject): string
+    {
+        $subject = trim((string) $subject);
+
+        if ($subject === '') {
+            return 'цього підмета';
+        }
+
+        return match (mb_strtolower($subject, 'UTF-8')) {
+            'i' => 'займенника «I»',
+            'you' => 'займенника «you»',
+            'he' => 'займенника «he»',
+            'she' => 'займенника «she»',
+            'it' => 'займенника «it»',
+            'we' => 'займенника «we»',
+            'they' => 'займенника «they»',
+            default => 'підмета «' . $subject . '»',
+        };
+    }
+
+    private function normalizeValue(string $value): string
+    {
+        $value = str_replace(['’', '‘', '‛', 'ʻ'], "'", $value);
+        $value = preg_replace('/\s+/', ' ', $value);
+
+        return trim($value);
+    }
+}

--- a/database/seeders/V2/ConditionalsZeroToSecondWorksheetV2Seeder.php
+++ b/database/seeders/V2/ConditionalsZeroToSecondWorksheetV2Seeder.php
@@ -1,0 +1,991 @@
+<?php
+
+namespace Database\Seeders\V2;
+
+use App\Models\Category;
+use App\Models\Source;
+use App\Models\Tag;
+use Database\Seeders\QuestionSeeder;
+
+class ConditionalsZeroToSecondWorksheetV2Seeder extends QuestionSeeder
+{
+    private array $levelDifficulty = [
+        'A1' => 1,
+        'A2' => 2,
+        'B1' => 3,
+        'B2' => 4,
+        'C1' => 5,
+        'C2' => 5,
+    ];
+
+    private array $hintTemplates = [
+        'if_zero_present' => "Час: Zero Conditional.\nФормула: **if + Present Simple** (наприклад, «if + %verb%»).\nПояснення: Для загальних фактів в обох частинах вживаємо Present Simple.\nПриклад: *%example%*",
+        'result_zero_present' => "Час: Zero Conditional.\nФормула: **Present Simple** (наприклад, «%subject% %verb%»).\nПояснення: Результат загального правила також стоїть у Present Simple.\nПриклад: *%example%*",
+        'result_zero_negative' => "Час: Zero Conditional.\nФормула: **do/does not + V1** (наприклад, «do not %verb%»).\nПояснення: Заперечення у нульовому умовному будуємо через do/does not.\nПриклад: *%example%*",
+        'if_first_present' => "Час: First Conditional.\nФормула: **if + Present Simple** (наприклад, «if + %verb%»).\nПояснення: Умовну частину про реальне майбутнє пишемо в Present Simple.\nПриклад: *%example%*",
+        'result_first_will' => "Час: First Conditional.\nФормула: **will + V1** (наприклад, «will %verb%»).\nПояснення: Результат реальної умови виражаємо через will + базове дієслово.\nПриклад: *%example%*",
+        'result_first_have_to' => "Час: First Conditional.\nФормула: **will have to + V1**.\nПояснення: Для необхідності в майбутньому використовуємо will have to + базове дієслово.\nПриклад: *%example%*",
+        'if_second_past' => "Час: Second Conditional.\nФормула: **if + Past Simple**.\nПояснення: Уявні ситуації в умовній частині виражаємо Past Simple.\nПриклад: *%example%*",
+        'result_second_would' => "Час: Second Conditional.\nФормула: **would + V1**.\nПояснення: Результат уявної ситуації будуємо через would + базове дієслово.\nПриклад: *%example%*",
+        'result_second_negative' => "Час: Second Conditional.\nФормула: **would not / wouldn't + V1**.\nПояснення: Заперечення у результаті другого умовного створюємо через wouldn't + V1.\nПриклад: *%example%*",
+    ];
+
+    private array $explanationTemplates = [
+        'if_zero_present' => [
+            'correct' => "✅ «%option%» — Present Simple у нульовому умовному для %subject%.\nПриклад: *%example%*",
+            'future' => "❌ «%option%» має will, але Zero Conditional використовує Present Simple.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» належить до другого умовного з would.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; для загальної істини потрібен Present Simple.\nПриклад: *%example%*",
+            'continuous' => "❌ «%option%» — тривала форма; в Zero Conditional потрібна проста форма.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_zero_present' => [
+            'correct' => "✅ «%option%» — Present Simple показує результат загального правила.\nПриклад: *%example%*",
+            'future' => "❌ «%option%» містить will, але у нульовому умовному результат теж у Present Simple.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» належить до Second Conditional; тут потрібен Present Simple.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; лишаємо Present Simple.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» не має потрібного закінчення/форми Present Simple для %subject%.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_zero_negative' => [
+            'correct' => "✅ «%option%» — правильне заперечення do/does not + V1 у Zero Conditional.\nПриклад: *%example%*",
+            'future' => "❌ «%option%» має will, але нульовий умовний не використовує will.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» належить до другого умовного.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — ствердна форма; потрібне заперечення з do/does not.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'if_first_present' => [
+            'correct' => "✅ «%option%» — Present Simple у підрядній частині першого умовного.\nПриклад: *%example%*",
+            'future' => "❌ «%option%» містить will, але в if-клауза типу 1 використовуємо Present Simple.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; для реальної умови потрібен Present Simple.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» належить до другого умовного.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_first_will' => [
+            'correct' => "✅ «%option%» — правильна форма will + V1 у першому умовному.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple; потрібне will + V1.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; результат має містити will.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» належить до другого умовного.\nПриклад: *%example%*",
+            'continuous' => "❌ «%option%» — тривала форма; вправа тренує will + V1.\nПриклад: *%example%*",
+            'extra_will' => "❌ «%option%» дублює will, хоча допоміжне слово вже є у реченні.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_first_have_to' => [
+            'correct' => "✅ «%option%» — правильна конструкція will have to + V1.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» належить до другого умовного; потрібно will have to.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple; виражай необхідність як will have to.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; тут говоримо про майбутнє.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'if_second_past' => [
+            'correct' => "✅ «%option%» — Past Simple у підрядній частині другого умовного.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple; у другому умовному потрібен Past Simple.\nПриклад: *%example%*",
+            'future' => "❌ «%option%» містить will; друга умова використовує Past Simple.\nПриклад: *%example%*",
+            'perfect' => "❌ «%option%» — Past Perfect; це вже третій умовний.\nПриклад: *%example%*",
+            'would' => "❌ «%option%» належить до результату з would.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_second_would' => [
+            'correct' => "✅ «%option%» — правильна модель would + V1 для результату другого умовного.\nПриклад: *%example%*",
+            'will' => "❌ «%option%» з will утворює перший умовний.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple; для уявних результатів потрібне would + V1.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; потрібен would + V1.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+        'result_second_negative' => [
+            'correct' => "✅ «%option%» — правильне заперечення wouldn't + V1 у другому умовному.\nПриклад: *%example%*",
+            'will' => "❌ «%option%» з won't — перший умовний.\nПриклад: *%example%*",
+            'present' => "❌ «%option%» — Present Simple; потрібно wouldn't + V1.\nПриклад: *%example%*",
+            'past' => "❌ «%option%» — Past Simple; потрібна форма wouldn't + V1.\nПриклад: *%example%*",
+            'default' => "❌ Неправильний варіант.\nПриклад: *%example%*",
+        ],
+    ];
+
+    public function run(): void
+    {
+        $categoryId = Category::firstOrCreate(['name' => 'Conditionals'])->id;
+        $sourceId = Source::firstOrCreate(['name' => 'Worksheet: Conditionals 0-1-2 (V2)'])->id;
+
+        $themeTagId = Tag::firstOrCreate(
+            ['name' => 'Conditionals Type 0-1-2 Practice'],
+            ['category' => 'English Grammar Theme']
+        )->id;
+
+        $detailTagId = Tag::firstOrCreate(
+            ['name' => 'Mixed Conditional Forms Worksheet'],
+            ['category' => 'English Grammar Detail']
+        )->id;
+
+        $structureTagId = Tag::firstOrCreate(
+            ['name' => 'Conditional Sentences (Zero to Second)'],
+            ['category' => 'English Grammar Structure']
+        )->id;
+
+        $tenseTags = [
+            'Zero Conditional' => Tag::firstOrCreate(['name' => 'Zero Conditional'], ['category' => 'English Grammar Tense'])->id,
+            'First Conditional' => Tag::firstOrCreate(['name' => 'First Conditional'], ['category' => 'English Grammar Tense'])->id,
+            'Second Conditional' => Tag::firstOrCreate(['name' => 'Second Conditional'], ['category' => 'English Grammar Tense'])->id,
+        ];
+
+        $entries = $this->questionEntries();
+
+        $items = [];
+        $meta = [];
+
+        foreach ($entries as $index => $entry) {
+            $answersMap = [];
+            $verbHints = [];
+            $optionSets = [];
+            $optionMarkerMap = [];
+            $optionReasons = [];
+
+            foreach ($entry['markers'] as $marker => $markerData) {
+                $answersMap[$marker] = $this->normalizeValue($markerData['answer']);
+                $verbHints[$marker] = $markerData['verb_hint'] ?? ($markerData['verb'] ?? null);
+
+                $options = [];
+                foreach ($markerData['options'] as $option) {
+                    $value = $this->normalizeValue($option['value']);
+                    $options[] = $value;
+                    $optionMarkerMap[$value] = $marker;
+                    $optionReasons[$marker][$value] = $option['reason'] ?? 'default';
+                }
+
+                $optionSets[$marker] = array_values(array_unique($options));
+            }
+
+            $example = $this->formatExample($entry['question'], $answersMap);
+
+            $explanations = [];
+            foreach ($optionMarkerMap as $value => $marker) {
+                $context = $entry['markers'][$marker] ?? [];
+                $reason = $optionReasons[$marker][$value] ?? 'default';
+                $explanations[$value] = $this->buildExplanation(
+                    $context['type'] ?? '',
+                    $reason,
+                    $value,
+                    $context,
+                    $example
+                );
+            }
+
+            $hints = [];
+            foreach ($entry['markers'] as $marker => $markerData) {
+                $hints[$marker] = $this->buildHint($markerData['type'], $markerData, $example);
+            }
+
+            $answers = [];
+            foreach ($answersMap as $marker => $answer) {
+                $answers[] = [
+                    'marker' => $marker,
+                    'answer' => $answer,
+                    'verb_hint' => $this->normalizeHint($verbHints[$marker] ?? null),
+                ];
+            }
+
+            $flatOptions = [];
+            foreach ($optionSets as $options) {
+                foreach ($options as $value) {
+                    $flatOptions[] = $value;
+                }
+            }
+            $flatOptions = array_values(array_unique($flatOptions));
+
+            $tagIds = [$themeTagId, $detailTagId, $structureTagId];
+            foreach ($entry['tenses'] as $tense) {
+                if (isset($tenseTags[$tense])) {
+                    $tagIds[] = $tenseTags[$tense];
+                }
+            }
+
+            $uuid = $this->generateQuestionUuid($index + 1, $entry['question']);
+
+            $items[] = [
+                'uuid' => $uuid,
+                'question' => $entry['question'],
+                'category_id' => $categoryId,
+                'difficulty' => $this->levelDifficulty[$entry['level']] ?? 3,
+                'source_id' => $sourceId,
+                'flag' => 0,
+                'level' => $entry['level'],
+                'tag_ids' => array_values(array_unique($tagIds)),
+                'answers' => $answers,
+                'options' => $flatOptions,
+                'variants' => [$entry['question']],
+            ];
+
+            $meta[] = [
+                'uuid' => $uuid,
+                'answers' => $answersMap,
+                'option_markers' => $optionMarkerMap,
+                'hints' => $hints,
+                'explanations' => $explanations,
+            ];
+        }
+
+        $this->seedQuestionData($items, $meta);
+    }
+
+    private function questionEntries(): array
+    {
+        return [
+            [
+                'level' => 'A2',
+                'tenses' => ['Zero Conditional'],
+                'question' => 'If the sun {a1} high, it {a2} hot.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_zero_present',
+                        'subject' => 'the sun',
+                        'verb' => 'rise',
+                        'verb_hint' => 'rise',
+                        'answer' => 'rises',
+                        'options' => [
+                            ['value' => 'rises', 'reason' => 'correct'],
+                            ['value' => 'will rise', 'reason' => 'future'],
+                            ['value' => 'rose', 'reason' => 'past'],
+                            ['value' => 'would rise', 'reason' => 'would'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_zero_present',
+                        'subject' => 'it',
+                        'verb' => 'turn',
+                        'verb_hint' => 'turn',
+                        'answer' => 'turns',
+                        'options' => [
+                            ['value' => 'turns', 'reason' => 'correct'],
+                            ['value' => 'will turn', 'reason' => 'future'],
+                            ['value' => 'turned', 'reason' => 'past'],
+                            ['value' => 'would turn', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['Zero Conditional'],
+                'question' => 'Plants {a1} water, or they {a2}.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'result_zero_present',
+                        'subject' => 'plants',
+                        'verb' => 'need',
+                        'verb_hint' => 'need',
+                        'answer' => 'need',
+                        'options' => [
+                            ['value' => 'need', 'reason' => 'correct'],
+                            ['value' => 'needs', 'reason' => 'present'],
+                            ['value' => 'needed', 'reason' => 'past'],
+                            ['value' => 'will need', 'reason' => 'future'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_zero_negative',
+                        'subject' => 'they',
+                        'verb' => 'grow',
+                        'verb_hint' => 'not grow',
+                        'answer' => "do not grow",
+                        'options' => [
+                            ['value' => "do not grow", 'reason' => 'correct'],
+                            ['value' => "won't grow", 'reason' => 'future'],
+                            ['value' => "wouldn't grow", 'reason' => 'would'],
+                            ['value' => 'grow', 'reason' => 'present'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['Zero Conditional'],
+                'question' => 'If it {a1}, people {a2} umbrellas.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_zero_present',
+                        'subject' => 'it',
+                        'verb' => 'rain',
+                        'verb_hint' => 'rain',
+                        'answer' => 'rains',
+                        'options' => [
+                            ['value' => 'rains', 'reason' => 'correct'],
+                            ['value' => 'will rain', 'reason' => 'future'],
+                            ['value' => 'rained', 'reason' => 'past'],
+                            ['value' => 'would rain', 'reason' => 'would'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_zero_present',
+                        'subject' => 'people',
+                        'verb' => 'use',
+                        'verb_hint' => 'use',
+                        'answer' => 'use',
+                        'options' => [
+                            ['value' => 'use', 'reason' => 'correct'],
+                            ['value' => 'uses', 'reason' => 'present'],
+                            ['value' => 'will use', 'reason' => 'future'],
+                            ['value' => 'used', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['Zero Conditional'],
+                'question' => 'If Priya {a1} sports, he or she always {a2} fit.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_zero_present',
+                        'subject' => 'Priya',
+                        'verb' => 'practise',
+                        'verb_hint' => 'practise',
+                        'answer' => 'practises',
+                        'options' => [
+                            ['value' => 'practises', 'reason' => 'correct'],
+                            ['value' => 'practise', 'reason' => 'present'],
+                            ['value' => 'will practise', 'reason' => 'future'],
+                            ['value' => 'practised', 'reason' => 'past'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_zero_present',
+                        'subject' => 'he or she',
+                        'verb' => 'feel',
+                        'verb_hint' => 'feel',
+                        'answer' => 'feels',
+                        'options' => [
+                            ['value' => 'feels', 'reason' => 'correct'],
+                            ['value' => 'feel', 'reason' => 'present'],
+                            ['value' => 'will feel', 'reason' => 'future'],
+                            ['value' => 'felt', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'If you {a1} the supper, I {a2} the dishes.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_first_present',
+                        'subject' => 'you',
+                        'verb' => 'cook',
+                        'verb_hint' => 'cook',
+                        'answer' => 'cook',
+                        'options' => [
+                            ['value' => 'cook', 'reason' => 'correct'],
+                            ['value' => 'cooks', 'reason' => 'present'],
+                            ['value' => 'cooked', 'reason' => 'past'],
+                            ['value' => 'will cook', 'reason' => 'future'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_first_will',
+                        'subject' => 'I',
+                        'verb' => 'wash',
+                        'verb_hint' => 'wash',
+                        'answer' => 'will wash',
+                        'options' => [
+                            ['value' => 'will wash', 'reason' => 'correct'],
+                            ['value' => 'wash', 'reason' => 'present'],
+                            ['value' => 'washed', 'reason' => 'past'],
+                            ['value' => 'would wash', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'If I {a1} a million dollars, I {a2} a big house.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_first_present',
+                        'subject' => 'I',
+                        'verb' => 'have',
+                        'verb_hint' => 'have',
+                        'answer' => 'have',
+                        'options' => [
+                            ['value' => 'have', 'reason' => 'correct'],
+                            ['value' => 'has', 'reason' => 'present'],
+                            ['value' => 'had', 'reason' => 'past'],
+                            ['value' => 'will have', 'reason' => 'future'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_first_will',
+                        'subject' => 'I',
+                        'verb' => 'buy',
+                        'verb_hint' => 'buy',
+                        'answer' => 'will buy',
+                        'options' => [
+                            ['value' => 'will buy', 'reason' => 'correct'],
+                            ['value' => 'buy', 'reason' => 'present'],
+                            ['value' => 'bought', 'reason' => 'past'],
+                            ['value' => 'would buy', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'If Juan {a1} his friend, he {a2} to the park.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_first_present',
+                        'subject' => 'Juan',
+                        'verb' => 'see',
+                        'verb_hint' => 'see',
+                        'answer' => 'sees',
+                        'options' => [
+                            ['value' => 'sees', 'reason' => 'correct'],
+                            ['value' => 'see', 'reason' => 'present'],
+                            ['value' => 'saw', 'reason' => 'past'],
+                            ['value' => 'will see', 'reason' => 'future'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_first_will',
+                        'subject' => 'he',
+                        'verb' => 'go',
+                        'verb_hint' => 'go',
+                        'answer' => 'will go',
+                        'options' => [
+                            ['value' => 'will go', 'reason' => 'correct'],
+                            ['value' => 'goes', 'reason' => 'present'],
+                            ['value' => 'went', 'reason' => 'past'],
+                            ['value' => 'would go', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'Paula {a1} sad if Juan {a2} away.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'result_first_will',
+                        'subject' => 'Paula',
+                        'verb' => 'be',
+                        'verb_hint' => 'be',
+                        'answer' => 'will be',
+                        'options' => [
+                            ['value' => 'will be', 'reason' => 'correct'],
+                            ['value' => 'is', 'reason' => 'present'],
+                            ['value' => 'was', 'reason' => 'past'],
+                            ['value' => 'would be', 'reason' => 'would'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'if_first_present',
+                        'subject' => 'Juan',
+                        'verb' => 'move',
+                        'verb_hint' => 'move',
+                        'answer' => 'moves',
+                        'options' => [
+                            ['value' => 'moves', 'reason' => 'correct'],
+                            ['value' => 'move', 'reason' => 'present'],
+                            ['value' => 'will move', 'reason' => 'future'],
+                            ['value' => 'moved', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If I {a1} a million dollars, I {a2} a big house.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_second_past',
+                        'subject' => 'I',
+                        'verb' => 'have',
+                        'verb_hint' => 'have',
+                        'answer' => 'had',
+                        'options' => [
+                            ['value' => 'had', 'reason' => 'correct'],
+                            ['value' => 'have', 'reason' => 'present'],
+                            ['value' => 'would have', 'reason' => 'would'],
+                            ['value' => 'had had', 'reason' => 'perfect'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_second_would',
+                        'subject' => 'I',
+                        'verb' => 'buy',
+                        'verb_hint' => 'buy',
+                        'answer' => 'would buy',
+                        'options' => [
+                            ['value' => 'would buy', 'reason' => 'correct'],
+                            ['value' => 'will buy', 'reason' => 'will'],
+                            ['value' => 'buy', 'reason' => 'present'],
+                            ['value' => 'bought', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If he {a1} a bird, he {a2} to you.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_second_past',
+                        'subject' => 'he',
+                        'verb' => 'be',
+                        'verb_hint' => 'be',
+                        'answer' => 'were',
+                        'options' => [
+                            ['value' => 'were', 'reason' => 'correct'],
+                            ['value' => 'was', 'reason' => 'present'],
+                            ['value' => 'is', 'reason' => 'present'],
+                            ['value' => 'would be', 'reason' => 'would'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_second_would',
+                        'subject' => 'he',
+                        'verb' => 'fly',
+                        'verb_hint' => 'fly',
+                        'answer' => 'would fly',
+                        'options' => [
+                            ['value' => 'would fly', 'reason' => 'correct'],
+                            ['value' => 'will fly', 'reason' => 'will'],
+                            ['value' => 'flies', 'reason' => 'present'],
+                            ['value' => 'flew', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If I {a1} the answer, I {a2} it to you.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_second_past',
+                        'subject' => 'I',
+                        'verb' => 'know',
+                        'verb_hint' => 'know',
+                        'answer' => 'knew',
+                        'options' => [
+                            ['value' => 'knew', 'reason' => 'correct'],
+                            ['value' => 'know', 'reason' => 'present'],
+                            ['value' => 'will know', 'reason' => 'future'],
+                            ['value' => 'had known', 'reason' => 'perfect'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_second_would',
+                        'subject' => 'I',
+                        'verb' => 'show',
+                        'verb_hint' => 'show',
+                        'answer' => 'would show',
+                        'options' => [
+                            ['value' => 'would show', 'reason' => 'correct'],
+                            ['value' => 'will show', 'reason' => 'will'],
+                            ['value' => 'show', 'reason' => 'present'],
+                            ['value' => 'showed', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If we {a1} on the same street, I {a2} you every day.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_second_past',
+                        'subject' => 'we',
+                        'verb' => 'live',
+                        'verb_hint' => 'live',
+                        'answer' => 'lived',
+                        'options' => [
+                            ['value' => 'lived', 'reason' => 'correct'],
+                            ['value' => 'live', 'reason' => 'present'],
+                            ['value' => 'will live', 'reason' => 'future'],
+                            ['value' => 'had lived', 'reason' => 'perfect'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_second_would',
+                        'subject' => 'I',
+                        'verb' => 'visit',
+                        'verb_hint' => 'visit',
+                        'answer' => 'would visit',
+                        'options' => [
+                            ['value' => 'would visit', 'reason' => 'correct'],
+                            ['value' => 'will visit', 'reason' => 'will'],
+                            ['value' => 'visit', 'reason' => 'present'],
+                            ['value' => 'visited', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['Zero Conditional'],
+                'question' => 'If you {a1} water, it {a2} to steam.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_zero_present',
+                        'subject' => 'you',
+                        'verb' => 'boil',
+                        'verb_hint' => 'boil',
+                        'answer' => 'boil',
+                        'options' => [
+                            ['value' => 'boil', 'reason' => 'correct'],
+                            ['value' => 'boils', 'reason' => 'present'],
+                            ['value' => 'will boil', 'reason' => 'future'],
+                            ['value' => 'boiled', 'reason' => 'past'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_zero_present',
+                        'subject' => 'it',
+                        'verb' => 'turn',
+                        'verb_hint' => 'turn',
+                        'answer' => 'turns',
+                        'options' => [
+                            ['value' => 'turns', 'reason' => 'correct'],
+                            ['value' => 'turn', 'reason' => 'present'],
+                            ['value' => 'will turn', 'reason' => 'future'],
+                            ['value' => 'turned', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'If I {a1} some fresh vegetables tomorrow, I {a2} a salad for you.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_first_present',
+                        'subject' => 'I',
+                        'verb' => 'get',
+                        'verb_hint' => 'get',
+                        'answer' => 'get',
+                        'options' => [
+                            ['value' => 'get', 'reason' => 'correct'],
+                            ['value' => 'gets', 'reason' => 'present'],
+                            ['value' => 'will get', 'reason' => 'future'],
+                            ['value' => 'got', 'reason' => 'past'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_first_will',
+                        'subject' => 'I',
+                        'verb' => 'make',
+                        'verb_hint' => 'make',
+                        'answer' => 'will make',
+                        'options' => [
+                            ['value' => 'will make', 'reason' => 'correct'],
+                            ['value' => 'make', 'reason' => 'present'],
+                            ['value' => 'made', 'reason' => 'past'],
+                            ['value' => 'would make', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'If he {a1} around this evening, I {a2} him to the movies.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_first_present',
+                        'subject' => 'he',
+                        'verb' => 'come',
+                        'verb_hint' => 'come',
+                        'answer' => 'comes',
+                        'options' => [
+                            ['value' => 'comes', 'reason' => 'correct'],
+                            ['value' => 'come', 'reason' => 'present'],
+                            ['value' => 'came', 'reason' => 'past'],
+                            ['value' => 'will come', 'reason' => 'future'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_first_will',
+                        'subject' => 'I',
+                        'verb' => 'take',
+                        'verb_hint' => 'take',
+                        'answer' => 'will take',
+                        'options' => [
+                            ['value' => 'will take', 'reason' => 'correct'],
+                            ['value' => 'take', 'reason' => 'present'],
+                            ['value' => 'took', 'reason' => 'past'],
+                            ['value' => 'would take', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'If the weather {a1} sunny at the weekend, we {a2} to the mountains.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_first_present',
+                        'subject' => 'the weather',
+                        'verb' => 'be',
+                        'verb_hint' => 'be',
+                        'answer' => 'is',
+                        'options' => [
+                            ['value' => 'is', 'reason' => 'correct'],
+                            ['value' => 'will be', 'reason' => 'future'],
+                            ['value' => 'was', 'reason' => 'past'],
+                            ['value' => 'are', 'reason' => 'present'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_first_will',
+                        'subject' => 'we',
+                        'verb' => 'go',
+                        'verb_hint' => 'go',
+                        'answer' => 'will go',
+                        'options' => [
+                            ['value' => 'will go', 'reason' => 'correct'],
+                            ['value' => 'go', 'reason' => 'present'],
+                            ['value' => 'went', 'reason' => 'past'],
+                            ['value' => 'would go', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'If we {a1} hard, we {a2} the exam.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_first_present',
+                        'subject' => 'we',
+                        'verb' => 'study',
+                        'verb_hint' => 'study',
+                        'answer' => 'study',
+                        'options' => [
+                            ['value' => 'study', 'reason' => 'correct'],
+                            ['value' => 'studies', 'reason' => 'present'],
+                            ['value' => 'studied', 'reason' => 'past'],
+                            ['value' => 'will study', 'reason' => 'future'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_first_will',
+                        'subject' => 'we',
+                        'verb' => 'pass',
+                        'verb_hint' => 'pass',
+                        'answer' => 'will pass',
+                        'options' => [
+                            ['value' => 'will pass', 'reason' => 'correct'],
+                            ['value' => 'pass', 'reason' => 'present'],
+                            ['value' => 'passed', 'reason' => 'past'],
+                            ['value' => 'would pass', 'reason' => 'would'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If we {a1} harder, we {a2} the exam.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_second_past',
+                        'subject' => 'we',
+                        'verb' => 'study',
+                        'verb_hint' => 'study',
+                        'answer' => 'studied',
+                        'options' => [
+                            ['value' => 'studied', 'reason' => 'correct'],
+                            ['value' => 'study', 'reason' => 'present'],
+                            ['value' => 'will study', 'reason' => 'future'],
+                            ['value' => 'had studied', 'reason' => 'perfect'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_second_would',
+                        'subject' => 'we',
+                        'verb' => 'pass',
+                        'verb_hint' => 'pass',
+                        'answer' => 'would pass',
+                        'options' => [
+                            ['value' => 'would pass', 'reason' => 'correct'],
+                            ['value' => 'will pass', 'reason' => 'will'],
+                            ['value' => 'pass', 'reason' => 'present'],
+                            ['value' => 'passed', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'B1',
+                'tenses' => ['Second Conditional'],
+                'question' => 'If I {a1} more, I {a2} better grades.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_second_past',
+                        'subject' => 'I',
+                        'verb' => 'study',
+                        'verb_hint' => 'study',
+                        'answer' => 'studied',
+                        'options' => [
+                            ['value' => 'studied', 'reason' => 'correct'],
+                            ['value' => 'study', 'reason' => 'present'],
+                            ['value' => 'will study', 'reason' => 'future'],
+                            ['value' => 'had studied', 'reason' => 'perfect'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_second_would',
+                        'subject' => 'I',
+                        'verb' => 'get',
+                        'verb_hint' => 'get',
+                        'answer' => 'would get',
+                        'options' => [
+                            ['value' => 'would get', 'reason' => 'correct'],
+                            ['value' => 'will get', 'reason' => 'will'],
+                            ['value' => 'get', 'reason' => 'present'],
+                            ['value' => 'got', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['Zero Conditional'],
+                'question' => 'If she {a1} to bed early, she {a2} up on time.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_zero_present',
+                        'subject' => 'she',
+                        'verb' => 'go',
+                        'verb_hint' => 'go',
+                        'answer' => 'goes',
+                        'options' => [
+                            ['value' => 'goes', 'reason' => 'correct'],
+                            ['value' => 'go', 'reason' => 'present'],
+                            ['value' => 'will go', 'reason' => 'future'],
+                            ['value' => 'went', 'reason' => 'past'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_zero_present',
+                        'subject' => 'she',
+                        'verb' => 'wake',
+                        'verb_hint' => 'wake',
+                        'answer' => 'wakes',
+                        'options' => [
+                            ['value' => 'wakes', 'reason' => 'correct'],
+                            ['value' => 'wake', 'reason' => 'present'],
+                            ['value' => 'will wake', 'reason' => 'future'],
+                            ['value' => 'woke', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'level' => 'A2',
+                'tenses' => ['First Conditional'],
+                'question' => 'If the snow {a1} any worse, we {a2} go to the doctor\'s.',
+                'markers' => [
+                    'a1' => [
+                        'type' => 'if_first_present',
+                        'subject' => 'the snow',
+                        'verb' => 'get',
+                        'verb_hint' => 'get',
+                        'answer' => 'gets',
+                        'options' => [
+                            ['value' => 'gets', 'reason' => 'correct'],
+                            ['value' => 'get', 'reason' => 'present'],
+                            ['value' => 'will get', 'reason' => 'future'],
+                            ['value' => 'got', 'reason' => 'past'],
+                        ],
+                    ],
+                    'a2' => [
+                        'type' => 'result_first_have_to',
+                        'subject' => 'we',
+                        'verb' => 'go',
+                        'verb_hint' => 'have to',
+                        'answer' => 'will have to',
+                        'options' => [
+                            ['value' => 'will have to', 'reason' => 'correct'],
+                            ['value' => 'have to', 'reason' => 'present'],
+                            ['value' => 'would have to', 'reason' => 'would'],
+                            ['value' => 'had to', 'reason' => 'past'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function buildHint(string $type, array $context, string $example): string
+    {
+        $template = $this->hintTemplates[$type] ?? "Час: Conditionals.\nПояснення: Оберіть форму, що відповідає правилу.\nПриклад: *%example%*";
+
+        return $this->renderTemplate($template, [
+            'subject' => $context['subject'] ?? '',
+            'verb' => $context['verb'] ?? '',
+            'example' => $example,
+        ]);
+    }
+
+    private function buildExplanation(string $type, string $reason, string $option, array $context, string $example): string
+    {
+        $templates = $this->explanationTemplates[$type] ?? [];
+        $template = $templates[$reason] ?? ($templates['default'] ?? "❌ Неправильний варіант.\nПриклад: *%example%*");
+
+        return $this->renderTemplate($template, [
+            'option' => $option,
+            'subject' => $context['subject'] ?? '',
+            'verb' => $context['verb'] ?? '',
+            'example' => $example,
+        ]);
+    }
+
+    private function renderTemplate(string $template, array $context): string
+    {
+        $replacements = [
+            '%option%' => $context['option'] ?? '',
+            '%verb%' => $context['verb'] ?? '',
+            '%example%' => $context['example'] ?? '',
+            '%subject%' => $this->subjectPhrase($context['subject'] ?? ''),
+        ];
+
+        return trim(strtr($template, $replacements));
+    }
+
+    private function subjectPhrase(?string $subject): string
+    {
+        $subject = trim((string) $subject);
+
+        if ($subject === '') {
+            return 'цього підмета';
+        }
+
+        return match (mb_strtolower($subject, 'UTF-8')) {
+            'i' => 'займенника «I»',
+            'you' => 'займенника «you»',
+            'he' => 'займенника «he»',
+            'she' => 'займенника «she»',
+            'it' => 'займенника «it»',
+            'we' => 'займенника «we»',
+            'they' => 'займенника «they»',
+            default => 'підмета «' . $subject . '»',
+        };
+    }
+
+    private function normalizeValue(string $value): string
+    {
+        $value = str_replace(['’', '‘', '‛', 'ʻ'], "'", $value);
+        $value = preg_replace('/\s+/', ' ', $value);
+
+        return trim($value);
+    }
+}


### PR DESCRIPTION
## Summary
- add ConditionalsType1And2WorksheetV2Seeder with pattern-driven hints, explanations, and question data from the worksheet
- add ConditionalsZeroToSecondWorksheetV2Seeder to cover zero, first, and second conditional practice with templated feedback
- register the new worksheet seeders in DatabaseSeeder so they run with the rest of the seeding suite

## Testing
- php -l database/seeders/V2/ConditionalsType1And2WorksheetV2Seeder.php
- php -l database/seeders/V2/ConditionalsZeroToSecondWorksheetV2Seeder.php
- php -l database/seeders/DatabaseSeeder.php

------
https://chatgpt.com/codex/tasks/task_e_68e56aea1904832a8822e036cd3dee9b