### PR TITLE
Add conditional text column migration for pages table

### DIFF
--- a/database/migrations/2025_10_09_000002_add_text_column_to_pages_table.php
+++ b/database/migrations/2025_10_09_000002_add_text_column_to_pages_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('pages', 'text')) {
+            Schema::table('pages', function (Blueprint $table) {
+                $table->text('text')->nullable();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('pages', 'text')) {
+            Schema::table('pages', function (Blueprint $table) {
+                $table->dropColumn('text');
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration that restores the `text` column on the `pages` table when it is missing
- ensure the migration removes the column on rollback only when it exists

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e612aea8a0832a9e2fcae0fba63e88